### PR TITLE
fix: runepool withdraws status detection

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -505,8 +505,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const canWithdraw = useMemo(() => {
     const amountCryptoBaseUnit = toBaseUnit(state?.withdraw.cryptoAmount, asset.precision)
 
-    // @TODO: RUNEPool withdraws are not going through for now because of the 90 days lock, we don't know yet if there are any protocol fees
-    // we might want to adjust it later if we confirm that it involve some protocol fees
+    // RUNEPool withdraws occur no explicit protocol fees, see https://viewblock.io/thorchain/tx/8C8DA9D44AAE7C042F38393B8E42AEF6DB9BAFF09D3A702991C35CBA215AD576 /
     return bnOrZero(amountCryptoBaseUnit).gte(isRunePool ? 0 : protocolFeeCryptoBaseUnit)
   }, [state?.withdraw.cryptoAmount, asset.precision, protocolFeeCryptoBaseUnit, isRunePool])
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -505,7 +505,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
   const canWithdraw = useMemo(() => {
     const amountCryptoBaseUnit = toBaseUnit(state?.withdraw.cryptoAmount, asset.precision)
 
-    // RUNEPool withdraws occur no explicit protocol fees, see https://viewblock.io/thorchain/tx/8C8DA9D44AAE7C042F38393B8E42AEF6DB9BAFF09D3A702991C35CBA215AD576 /
+    // RUNEPool withdraws occur no explicit protocol fees, see https://viewblock.io/thorchain/tx/8C8DA9D44AAE7C042F38393B8E42AEF6DB9BAFF09D3A702991C35CBA215AD576
     return bnOrZero(amountCryptoBaseUnit).gte(isRunePool ? 0 : protocolFeeCryptoBaseUnit)
   }, [state?.withdraw.cryptoAmount, asset.precision, protocolFeeCryptoBaseUnit, isRunePool])
 

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -105,7 +105,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
         })
       }
     })()
-  }, [accountId, appDispatch, contextDispatch, getOpportunitiesUserData, state?.txid])
+  }, [accountId, appDispatch, contextDispatch, getOpportunitiesUserData, isRunePool, state?.txid])
 
   const handleViewPosition = useCallback(() => {
     browserHistory.push('/earn')

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -77,7 +77,8 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
       // Note, the transaction we wait for here is a Thorchain transaction, *not* the inbound Tx
       const thorchainTxStatus = await waitForThorchainUpdate({
         txId: state.txid!,
-        skipOutbound: false,
+        // RUNEPool has no outbound Tx so we skipOutbound, else this will spin to infinity
+        skipOutbound: isRunePool,
       }).promise
 
       if ([TxStatusType.Confirmed, TxStatusType.Failed].includes(thorchainTxStatus)) {


### PR DESCRIPTION
## Description

Ensures RUNEPool withdraws do not spin for eternity.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8181

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- RUNEPool withdraws correctly go to complete state.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

![image](https://github.com/user-attachments/assets/322fd5cb-3779-4a82-af8d-165406b6d161)


- this diff

<img width="535" alt="Screenshot 2024-11-25 at 19 19 30" src="https://github.com/user-attachments/assets/9ed3efcf-401d-4dc4-ae14-67b5bce8d6fd">

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
