### PR TITLE
feat: unchained-client runepool Txs parsing

### DIFF
--- a/packages/unchained-client/src/cosmossdk/thorchain/parser/__tests__/mockData/thorchainRunePoolDeposit.ts
+++ b/packages/unchained-client/src/cosmossdk/thorchain/parser/__tests__/mockData/thorchainRunePoolDeposit.ts
@@ -1,0 +1,61 @@
+import type { Tx } from '../../../index'
+
+const tx: Tx = {
+  txid: '59D7472B6E9B30AEB3B99D2C0F95CC86EC680AE61F20E1E60D79839A7181989B',
+  blockHash: 'FC8D01330732672D63355141DD4E8D83808DAEBE757B400FA9C65D14BDD73029',
+  blockHeight: 18731307,
+  timestamp: 1732547788,
+  confirmations: 1672,
+  fee: {
+    amount: '2000000',
+    denom: 'rune',
+  },
+  gasUsed: '472720',
+  gasWanted: '0',
+  index: 33,
+  memo: 'POOL+',
+  value: '',
+  messages: [
+    {
+      index: '0',
+      origin: 'thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
+      from: 'thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
+      to: 'thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt',
+      type: 'deposit',
+      value: {
+        amount: '10000000',
+        denom: 'rune',
+      },
+    },
+  ],
+  events: {
+    '0': {
+      coin_received: {
+        amount: '10000000rune',
+        receiver: 'thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt',
+      },
+      coin_spent: {
+        amount: '10000000rune',
+        spender: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+      },
+      message: {
+        action: 'deposit',
+        memo: 'POOL+',
+        sender: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+      },
+      rune_pool_deposit: {
+        rune_address: 'thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
+        rune_amount: '10000000',
+        tx_id: '59D7472B6E9B30AEB3B99D2C0F95CC86EC680AE61F20E1E60D79839A7181989B',
+        units: '9290329',
+      },
+      transfer: {
+        amount: '10000000rune',
+        recipient: 'thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt',
+        sender: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+      },
+    },
+  },
+}
+
+export default { tx }

--- a/packages/unchained-client/src/cosmossdk/thorchain/parser/__tests__/mockData/thorchainRunePoolWithdraw.ts
+++ b/packages/unchained-client/src/cosmossdk/thorchain/parser/__tests__/mockData/thorchainRunePoolWithdraw.ts
@@ -1,0 +1,65 @@
+import type { Tx } from '../../../index'
+
+const tx: Tx = {
+  txid: '97B284C589F026818905BDB1591BFAC55754575CFBDD2456B26D8D3D4B1487DC',
+  blockHash: '37A12F1FE039914927334B293B2B2F8628F45741B61E14E60B5E89AF9D7BBD99',
+  blockHeight: 18730527,
+  timestamp: 1732543019,
+  confirmations: 2462,
+  fee: {
+    amount: '2000000',
+    denom: 'rune',
+  },
+  gasUsed: '490937',
+  gasWanted: '0',
+  index: 149,
+  memo: 'POOL-:10000:t:200',
+  value: '',
+  messages: [
+    {
+      index: '0',
+      origin: 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4',
+      from: 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4',
+      to: 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4',
+      type: 'deposit',
+      value: {
+        amount: '0',
+        denom: 'rune',
+      },
+    },
+  ],
+  events: {
+    '0': {
+      coin_received: {
+        amount: '2669457604rune',
+        receiver: 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4',
+      },
+      coin_spent: {
+        amount: '2669457604rune',
+        spender: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+      },
+      message: {
+        action: 'deposit',
+        memo: 'POOL-:10000:t:200',
+        sender: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+      },
+      rune_pool_withdraw: {
+        affiliate_address: 'thor1xnkml34dfmhtmx3hfxte4jxrxn2j3604mtx5h0',
+        affiliate_amount: '3458318',
+        affiliate_basis_points: '200',
+        basis_points: '10000',
+        rune_address: 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4',
+        rune_amount: '2672915922',
+        tx_id: '97B284C589F026818905BDB1591BFAC55754575CFBDD2456B26D8D3D4B1487DC',
+        units: '2491645482',
+      },
+      transfer: {
+        amount: '2669457604rune',
+        recipient: 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4',
+        sender: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+      },
+    },
+  },
+}
+
+export default { tx }

--- a/packages/unchained-client/src/cosmossdk/thorchain/parser/__tests__/thorchain.test.ts
+++ b/packages/unchained-client/src/cosmossdk/thorchain/parser/__tests__/thorchain.test.ts
@@ -14,6 +14,8 @@ import thorchainLpRefund from './mockData/thorchainLpRefund'
 import thorchainLpWithdraw from './mockData/thorchainLpWithdraw'
 import thorchainRefund from './mockData/thorchainRefund'
 import thorchainRfoxReward from './mockData/thorchainRfoxReward'
+import thorchainRunePoolDeposit from './mockData/thorchainRunePoolDeposit'
+import thorchainRunePoolWithdraw from './mockData/thorchainRunePoolWithdraw'
 import thorchainStreamingSwap from './mockData/thorchainStreamingSwap'
 import thorchainStreamingSwapOutbound from './mockData/thorchainStreamingSwapOutbound'
 import thorchainStreamingSwapRefund from './mockData/thorchainStreamingSwapRefund'
@@ -637,6 +639,98 @@ describe('parseTx', () => {
         epoch: 0,
         ipfsHash: 'QmYUiUq9UWK5NPF1h2BGdatw95psNtW8seGQpXZYoQYK1s',
         stakingAddress: '0x32DBc9Cf9E8FbCebE1e0a2ecF05Ed86Ca3096Cb6',
+      },
+    }
+
+    const actual = await txParser.parse(tx, address)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should be able to parse a runepool deposit', async () => {
+    const { tx } = thorchainRunePoolDeposit
+    const address = 'thor125dwsa39yeylqc7pn59l079dur502nsleyrgup'
+
+    const expected: ParsedTx = {
+      txid: tx.txid,
+      blockHash: tx.blockHash,
+      blockHeight: tx.blockHeight,
+      blockTime: tx.timestamp,
+      confirmations: tx.confirmations,
+      status: TxStatus.Confirmed,
+      address,
+      chainId: thorchainChainId,
+      fee: {
+        assetId: thorchainAssetId,
+        value: '2000000',
+      },
+      transfers: [
+        {
+          type: TransferType.Send,
+          from: address,
+          to: 'thor1dheycdevq39qlkxs2a6wuuzyn4aqxhve4qxtxt',
+          assetId: thorchainAssetId,
+          totalValue: '10000000',
+          components: [{ value: '10000000' }],
+        },
+      ],
+      data: {
+        parser: 'thorchain',
+        method: 'deposit',
+        memo: 'POOL+',
+        liquidity: {
+          type: 'RUNEPool',
+        },
+      },
+    }
+
+    const actual = await txParser.parse(tx, address)
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('should be able to parse a runepool withdraw', async () => {
+    const { tx } = thorchainRunePoolWithdraw
+    const address = 'thor1cwxrd57zs697k68njqvklsash74revw82mslx4'
+
+    const expected: ParsedTx = {
+      txid: tx.txid,
+      blockHash: tx.blockHash,
+      blockHeight: tx.blockHeight,
+      blockTime: tx.timestamp,
+      confirmations: tx.confirmations,
+      status: TxStatus.Confirmed,
+      address,
+      chainId: thorchainChainId,
+      fee: {
+        assetId: thorchainAssetId,
+        value: '2000000',
+      },
+      transfers: [
+        {
+          type: TransferType.Send,
+          from: address,
+          to: address,
+          assetId: thorchainAssetId,
+          totalValue: '0',
+          components: [{ value: '0' }],
+        },
+        {
+          type: TransferType.Receive,
+          from: 'thor1rzqfv62dzu585607s5awqtgnvvwz5rzhdtv772',
+          to: address,
+          assetId: thorchainAssetId,
+          totalValue: '2669457604',
+          components: [{ value: '2669457604' }],
+        },
+      ],
+      data: {
+        parser: 'thorchain',
+        method: 'withdrawNative',
+        memo: 'POOL-:10000:t:200',
+        liquidity: {
+          type: 'RUNEPool',
+        },
       },
     }
 

--- a/packages/unchained-client/src/parser/thorchain.ts
+++ b/packages/unchained-client/src/parser/thorchain.ts
@@ -157,7 +157,9 @@ export class Parser {
       }
       case 'pool-': {
         const type = 'RUNEPool'
-        return { data: { parser: 'thorchain', method: 'withdraw', memo, liquidity: { type } } }
+        return {
+          data: { parser: 'thorchain', method: 'withdrawNative', memo, liquidity: { type } },
+        }
       }
       case '$+':
       case 'loan+':

--- a/packages/unchained-client/src/parser/thorchain.ts
+++ b/packages/unchained-client/src/parser/thorchain.ts
@@ -4,7 +4,7 @@ import axios from 'axios'
 import type { BaseTxMetadata, StandardTx } from '../types'
 import { Dex, TradeType } from '../types'
 
-export type LiquidityType = 'Savers' | 'LP'
+export type LiquidityType = 'Savers' | 'LP' | 'RUNEPool'
 export type SwapType = 'Standard' | 'Streaming'
 
 interface Liquidity {
@@ -144,11 +144,19 @@ export class Parser {
         const type = getLiquidityType(pool)
         return { data: { parser: 'thorchain', method: 'deposit', memo, liquidity: { type } } }
       }
+      case 'pool+': {
+        const type = 'RUNEPool'
+        return { data: { parser: 'thorchain', method: 'deposit', memo, liquidity: { type } } }
+      }
       case 'withdraw':
       case '-':
       case 'wd': {
         const [, pool] = memo.split(':')
         const type = getLiquidityType(pool)
+        return { data: { parser: 'thorchain', method: 'withdraw', memo, liquidity: { type } } }
+      }
+      case 'pool-': {
+        const type = 'RUNEPool'
         return { data: { parser: 'thorchain', method: 'withdraw', memo, liquidity: { type } } }
       }
       case '$+':


### PR DESCRIPTION
## Description

Does what it says on the box - ensures RUNEPool Txs are parsed as such.

Note the amount being off for withdraws is not a concern of this PR, this isn't necessarily the "amount being deposited/withdrawn" but the "Tx value" (in tokens or native asset) which is not a concern of this PR and happens holistically across Txs e.g savers withdraws for tokens:

<img width="408" alt="Screenshot 2024-11-25 at 22 15 24" src="https://github.com/user-attachments/assets/720018ad-3f00-4439-b050-afac4a718917">


## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8182

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure RUNEPool deposits and withdraws are tagged as "RUNEPool" and displayed as "Deposit" and "Withdraw Requested"

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="397" alt="Screenshot 2024-11-25 at 22 26 22" src="https://github.com/user-attachments/assets/bb9150c7-ab3e-450f-a756-7c91dec35009">
<img width="396" alt="Screenshot 2024-11-25 at 22 17 09" src="https://github.com/user-attachments/assets/6a475c1e-aa8b-439e-b241-1d60b20b5454">


- This diff

<img width="407" alt="Screenshot 2024-11-25 at 22 15 38" src="https://github.com/user-attachments/assets/c2c4e190-f4c1-489a-b9e2-f134c07ab5a1">
<img width="399" alt="image" src="https://github.com/user-attachments/assets/1ebf8969-26ce-4bcf-a4d6-b7d897436d27">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
