### PR TITLE
Fix sed Compatibility Issue for Extended Regular Expressions

### DIFF
--- a/scripts/sha256sums.sh
+++ b/scripts/sha256sums.sh
@@ -2,5 +2,5 @@
 
 rm -f ./build/SHA256SUMS
 TEMP=$(mktemp)
-find -L ./build -type f | xargs shasum -a 256 | sed -r 's/^([0-9a-f]{64}\s+)\.\/build\//\1/' | LC_ALL=C sort -k 2 | tee "$TEMP"
+find -L ./build -type f | xargs shasum -a 256 | sed -E 's/^([0-9a-f]{64}\s+)\.\/build\//\1/' | LC_ALL=C sort -k 2 | tee "$TEMP"
 mv "$TEMP" ./build/SHA256SUMS


### PR DESCRIPTION
## Description

Here is a proposed change for the script to fix a compatibility issue. The original script uses the `-r` flag for extended regular expressions with `sed`, which might not be supported on some systems (like macOS). The flag should be replaced with `-E` for better compatibility across different environments.

### The issue:
- **Command `sed -r`**: On some systems, such as macOS, the `-r` flag for extended regular expressions is not supported. This causes the script to fail in those environments.

### The solution:
- **Replace `-r` with `-E`**: The `-E` flag is widely supported and works as a replacement for `-r` for extended regular expressions in `sed`.

Here is the updated script:

```sh
#!/bin/sh -e

rm -f ./build/SHA256SUMS
TEMP=$(mktemp)
find -L ./build -type f | xargs shasum -a 256 | sed -E 's/^([0-9a-f]{64}\s+)\.\/build\//\1/' | LC_ALL=C sort -k 2 | tee "$TEMP"
mv "$TEMP" ./build/SHA256SUMS
```

### Why this is important:
This change ensures the script works on a wider range of systems, making it more portable and preventing errors that arise due to the lack of `-r` support on some platforms like macOS. It improves the overall compatibility of the script without altering its functionality.
