### PR TITLE
fix: approvals disappearing on Tx complete

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -1,6 +1,6 @@
 import { Card, CardBody, CardHeader, Heading, useDisclosure, usePrevious } from '@chakra-ui/react'
 import { isArbitrumBridgeTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ArbitrumBridgeSwapper/getTradeQuote/getTradeQuote'
-import { memo, useCallback, useEffect, useMemo, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
@@ -38,6 +38,8 @@ export const MultiHopTradeConfirm = memo(() => {
   const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
   const activeQuote = useAppSelector(selectActiveQuote)
   const { isModeratePriceImpact, priceImpactPercentage } = usePriceImpact(activeQuote)
+
+  const initialActiveTradeIdRef = useRef(activeQuote?.id ?? '')
 
   const { isLoading } = useIsApprovalInitiallyNeeded()
 
@@ -144,12 +146,17 @@ export const MultiHopTradeConfirm = memo(() => {
               isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.withdrawComplete' : undefined
             }
           >
-            <Hops isFirstHopOpen isSecondHopOpen />
+            <Hops
+              initialActiveTradeId={initialActiveTradeIdRef.current}
+              isFirstHopOpen
+              isSecondHopOpen
+            />
           </TradeSuccess>
         ) : (
           <>
             <CardBody py={0} px={0}>
               <Hops
+                initialActiveTradeId={initialActiveTradeIdRef.current}
                 isFirstHopOpen={isFirstHopOpen}
                 isSecondHopOpen={isSecondHopOpen}
                 onToggleFirstHop={onToggleFirstHop}

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -62,6 +62,7 @@ export const Hop = ({
   slippageTolerancePercentageDecimal,
   onToggleIsOpen,
   activeTradeId,
+  initialActiveTradeId,
 }: {
   swapperName: SwapperName
   tradeQuoteStep: TradeQuoteStep
@@ -70,9 +71,8 @@ export const Hop = ({
   slippageTolerancePercentageDecimal: string | undefined
   onToggleIsOpen?: () => void
   activeTradeId: TradeQuote['id']
+  initialActiveTradeId: TradeQuote['id']
 }) => {
-  // Keep track of the original activeTradeId. Else, when we switch from rate to quote, we will miss the allowance info.
-  const initialTradeIdRef = useRef(activeTradeId)
   const {
     number: { toCrypto },
   } = useLocaleFormatter()
@@ -105,10 +105,10 @@ export const Hop = ({
   }, [activeTradeId, hopIndex])
   const rateHopExecutionMetadataFilter = useMemo(
     () => ({
-      tradeId: initialTradeIdRef.current,
+      tradeId: initialActiveTradeId,
       hopIndex,
     }),
-    [hopIndex],
+    [hopIndex, initialActiveTradeId],
   )
 
   const {

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -19,7 +19,7 @@ import type {
 } from '@shapeshiftoss/swapper'
 import { isArbitrumBridgeTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ArbitrumBridgeSwapper/getTradeQuote/getTradeQuote'
 import prettyMilliseconds from 'pretty-ms'
-import { useCallback, useMemo, useRef } from 'react'
+import { useCallback, useMemo } from 'react'
 import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hops.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hops.tsx
@@ -12,6 +12,7 @@ import { useAppSelector } from 'state/store'
 import { Hop } from './Hop'
 
 export type HopsProps = {
+  initialActiveTradeId: string
   isFirstHopOpen: boolean
   isSecondHopOpen: boolean
   onToggleFirstHop?: () => void
@@ -19,7 +20,13 @@ export type HopsProps = {
 }
 
 export const Hops = memo((props: HopsProps) => {
-  const { isFirstHopOpen, isSecondHopOpen, onToggleFirstHop, onToggleSecondHop } = props
+  const {
+    initialActiveTradeId,
+    isFirstHopOpen,
+    isSecondHopOpen,
+    onToggleFirstHop,
+    onToggleSecondHop,
+  } = props
   const swapperName = useAppSelector(selectActiveSwapperName)
   const firstHop = useAppSelector(selectFirstHop)
   const lastHop = useAppSelector(selectLastHop)
@@ -45,6 +52,7 @@ export const Hops = memo((props: HopsProps) => {
         onToggleIsOpen={onToggleFirstHop}
         slippageTolerancePercentageDecimal={activeQuote.slippageTolerancePercentageDecimal}
         activeTradeId={activeTradeId}
+        initialActiveTradeId={initialActiveTradeId}
       />
       {isMultiHopTrade && lastHop && (
         <Hop
@@ -55,6 +63,7 @@ export const Hops = memo((props: HopsProps) => {
           onToggleIsOpen={onToggleSecondHop}
           slippageTolerancePercentageDecimal={activeQuote.slippageTolerancePercentageDecimal}
           activeTradeId={activeTradeId}
+          initialActiveTradeId={initialActiveTradeId}
         />
       )}
     </Stack>


### PR DESCRIPTION
## Description

This PR fixes two things:

1. The approval step disappearing at preview/execution time when a final quote is refetched
2. The approval step disappearing from trade complete step

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8191

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Note: If testing Portals Txs with small amounts, ensure you bump slippage up (e.g 10% Portals max) or things will fail at quote time, not introduced by this PR

- Get rates for a swapper which gets a final quote after approvals e.g Portals
- Ensure that after you have granted the approval and a final quote is fetched (i.e rate changed modal), the approval row is still present
- Ensure that after Tx completion, the approval row is present at the Swap Complete summary step

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Note: Dev unchained endpoint tend to be slow and/or timing out, you may have to try the whole flow a few times before you get to completion e2e, this is the same in develop currently
- ☝🏽 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- develop

https://jam.dev/c/11f0d16b-94cd-496c-9339-871571381251

- this diff

https://jam.dev/c/0b3f0cc9-f9ac-41e9-a34a-3c504feed712

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
