### PR TITLE
fix: dont refetch accounts that were disabled

### DIFF
--- a/src/context/AppProvider/hooks/useAccountsFetchQuery.tsx
+++ b/src/context/AppProvider/hooks/useAccountsFetchQuery.tsx
@@ -26,8 +26,12 @@ export const useAccountsFetchQuery = () => {
   const { deviceId, wallet } = useWallet().state
 
   const hasManagedAccounts = useMemo(() => {
-    // MM without snap doesn't allow account management - if the user just installed the snap, we know they don't have managed accounts
-    if (!previousIsSnapInstalled && isSnapInstalled) return false
+    // MM without snap doesn't allow account management - if the user just installed the snap, we
+    // know they don't have managed accounts. NOTE - the values we're comparing here are
+    // `boolean | null`, so explicit comparison is needed!
+    if (previousIsSnapInstalled === false && isSnapInstalled === true) {
+      return false
+    }
     // We know snap wasn't just installed in this render - so if there are any requestedAccountIds, we assume the user has managed accounts
     return enabledWalletAccountIds.length > 0
   }, [isSnapInstalled, previousIsSnapInstalled, enabledWalletAccountIds.length])
@@ -37,12 +41,12 @@ export const useAccountsFetchQuery = () => {
   useEffect(() => {
     const { getAllTxHistory } = txHistoryApi.endpoints
 
-    // Note no force refetch here - only fetch Tx history once per acccount
+    // Note no force refetch here - only fetch Tx history once per account
     enabledWalletAccountIds.forEach(accountId => {
       dispatch(portfolioApi.endpoints.getAccount.initiate({ accountId, upsertOnFetch: true }))
     })
 
-    // Note no force refetch here - only fetch Tx history once per acccount
+    // Note no force refetch here - only fetch Tx history once per account
     enabledWalletAccountIds.map(requestedAccountId =>
       dispatch(getAllTxHistory.initiate(requestedAccountId)),
     )


### PR DESCRIPTION
## Description

Fixes issue where accounts that were disabled by a user were being automagically re-enabled when entering the trade page. Root cause was falsey comparison of `boolean | null`.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8105 

## Risk

> High Risk PRs Require 2 approvals

Low risk.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

1. open app with metamask with snap enabled
2. go to "my wallet" page
3. disable ethereum in account management
4. go to "trade" page
5. wait a few seconds - the account was being re-added, now it remains disabled

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Disabled account is still disabled 🎉

<img src="https://github.com/user-attachments/assets/24bad5f0-ec62-4989-9b8f-9edb578ce36b" width="200">

