### PR TITLE
fix: keepkey label ui

### DIFF
--- a/src/components/Layout/Header/NavBar/KeepKey/ChangeLabel.tsx
+++ b/src/components/Layout/Header/NavBar/KeepKey/ChangeLabel.tsx
@@ -24,7 +24,7 @@ export const ChangeLabel = () => {
       deviceState: { awaitingDeviceInteraction },
     },
   } = useWallet()
-  const [keepKeyLabel, setKeepKeyLabel] = useState(walletInfo?.name)
+  const [keepKeyLabel, setKeepKeyLabel] = useState(walletInfo?.meta?.label ?? walletInfo?.name)
 
   const handleChangeLabelInitializeEvent = useCallback(async () => {
     await keepKeyWallet?.applySettings({ label: keepKeyLabel }).catch(e => {

--- a/src/components/Layout/Header/NavBar/KeepKey/KeepKeyMenu.tsx
+++ b/src/components/Layout/Header/NavBar/KeepKey/KeepKeyMenu.tsx
@@ -149,7 +149,7 @@ export const KeepKeyMenu = () => {
           <ExpandedMenuItem
             onClick={navigateToKeepKeyLabel}
             label='walletProvider.keepKey.settings.menuLabels.label'
-            value={walletInfo?.name}
+            value={walletInfo?.meta?.label ?? walletInfo?.name}
             hasSubmenu={true}
           />
           <ExpandedMenuItem


### PR DESCRIPTION
## Description

Fixes the KeepKey label UI in the submenu - it currently shows `walletinfo.name`, which is incorrect (always "KeepKey'). The label path is `walletInfo.meta.label`.

## Issue (if applicable)

None, noticed whilst testing Neo's KeepKey PR.

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Connect a KeepKey with a label (or set one). The current label should show in the UI.

<img width="273" alt="Screenshot 2024-12-02 at 08 55 23" src="https://github.com/user-attachments/assets/393ff7bf-6c0d-4d57-bccb-4f42cfe42a77">

<img width="269" alt="Screenshot 2024-12-02 at 08 55 30" src="https://github.com/user-attachments/assets/acf0b03c-d6a5-4330-a450-e0b5776e1818">

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.