### PR TITLE
fix: keepkey menu margin

### DIFF
--- a/src/components/Layout/Header/NavBar/SubmenuHeader.tsx
+++ b/src/components/Layout/Header/NavBar/SubmenuHeader.tsx
@@ -38,7 +38,7 @@ export const SubmenuHeader = ({
         </Center>
       </Flex>
       {description && (
-        <Text fontSize='sm' px={1} color={descriptionTextColor}>
+        <Text fontSize='sm' px={1} color={descriptionTextColor} mb={4}>
           {description}
         </Text>
       )}


### PR DESCRIPTION
## Description

Small fix to KeepKey's menu margins.

Before:

<img width="268" alt="Screenshot 2024-12-02 at 09 01 48" src="https://github.com/user-attachments/assets/7c2ed578-d7b7-4e3f-bf77-9b0d17a73c14">

<img width="258" alt="Screenshot 2024-12-02 at 09 31 50" src="https://github.com/user-attachments/assets/f4547cf1-a10e-4eaf-af7b-8736d9e72d6b">

After:

<img width="261" alt="Screenshot 2024-12-02 at 09 07 12" src="https://github.com/user-attachments/assets/cd80351b-832d-4272-87ca-a34e51a53561">

<img width="272" alt="Screenshot 2024-12-02 at 09 35 57" src="https://github.com/user-attachments/assets/fb60f90d-53a5-4a72-bb72-504e37d4cddb">

## Issue (if applicable)

None, noticed whilst testing KeepKey PRs.

## Risk

Tiny

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure KeepKey sub-menu's look sane.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See description.