### PR TITLE
fix: remove price history data that is out of bounds of a given timeframe

### DIFF
--- a/packages/utils/src/historyTimeframe.ts
+++ b/packages/utils/src/historyTimeframe.ts
@@ -3,8 +3,10 @@ import dayjs from 'dayjs'
 
 import { assertUnreachable } from './assertUnreachable'
 
-export const getHistoryTimeframeBounds = (timeframe: HistoryTimeframe) => {
-  const end = dayjs().endOf('day')
+export const getHistoryTimeframeBounds = (
+  timeframe: HistoryTimeframe,
+  end = dayjs().endOf('day'),
+) => {
   let start = end // Shut up typescript.
   switch (timeframe) {
     case HistoryTimeframe.HOUR:

--- a/packages/utils/src/historyTimeframe.ts
+++ b/packages/utils/src/historyTimeframe.ts
@@ -6,7 +6,6 @@ export const getHistoryTimeframeBounds = (timeframe: HistoryTimeframe) => {
   let start
   switch (timeframe) {
     case HistoryTimeframe.HOUR:
-      // minimum granularity on upstream API is 1 day
       start = end.subtract(1, 'day')
       break
     case HistoryTimeframe.DAY:

--- a/packages/utils/src/historyTimeframe.ts
+++ b/packages/utils/src/historyTimeframe.ts
@@ -5,7 +5,7 @@ import { assertUnreachable } from './assertUnreachable'
 
 export const getHistoryTimeframeBounds = (timeframe: HistoryTimeframe) => {
   const end = dayjs().endOf('day')
-  let start
+  let start = end // Shut up typescript.
   switch (timeframe) {
     case HistoryTimeframe.HOUR:
       start = end.subtract(1, 'day')

--- a/packages/utils/src/historyTimeframe.ts
+++ b/packages/utils/src/historyTimeframe.ts
@@ -1,0 +1,32 @@
+import { HistoryTimeframe } from '@shapeshiftoss/types'
+import dayjs from 'dayjs'
+
+export const getHistoryTimeframeBounds = (timeframe: HistoryTimeframe) => {
+  const end = dayjs().endOf('day')
+  let start
+  switch (timeframe) {
+    case HistoryTimeframe.HOUR:
+      // minimum granularity on upstream API is 1 day
+      start = end.subtract(1, 'day')
+      break
+    case HistoryTimeframe.DAY:
+      start = end.subtract(1, 'day')
+      break
+    case HistoryTimeframe.WEEK:
+      start = end.subtract(1, 'week')
+      break
+    case HistoryTimeframe.MONTH:
+      start = end.subtract(1, 'month')
+      break
+    case HistoryTimeframe.YEAR:
+      start = end.subtract(1, 'year')
+      break
+    case HistoryTimeframe.ALL:
+      start = end.subtract(5, 'years')
+      break
+    default:
+      start = end
+  }
+
+  return { start, end }
+}

--- a/packages/utils/src/historyTimeframe.ts
+++ b/packages/utils/src/historyTimeframe.ts
@@ -1,6 +1,8 @@
 import { HistoryTimeframe } from '@shapeshiftoss/types'
 import dayjs from 'dayjs'
 
+import { assertUnreachable } from './assertUnreachable'
+
 export const getHistoryTimeframeBounds = (timeframe: HistoryTimeframe) => {
   const end = dayjs().endOf('day')
   let start
@@ -24,7 +26,7 @@ export const getHistoryTimeframeBounds = (timeframe: HistoryTimeframe) => {
       start = end.subtract(5, 'years')
       break
     default:
-      start = end
+      assertUnreachable(timeframe)
   }
 
   return { start, end }

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -14,6 +14,7 @@ export * from './treasury'
 export * from './timeout'
 export * from './createThrottle'
 export * from './evmChainIds'
+export * from './historyTimeframe'
 
 export const isSome = <T>(option: T | null | undefined): option is T =>
   !isUndefined(option) && !isNull(option)

--- a/src/components/TransactionHistoryRows/utils.ts
+++ b/src/components/TransactionHistoryRows/utils.ts
@@ -1,3 +1,4 @@
+import type { AssetId } from '@shapeshiftoss/caip'
 import type { TransferType, TxMetadata } from '@shapeshiftoss/chain-adapters'
 import type { Asset, MarketData } from '@shapeshiftoss/types'
 import { memoize } from 'lodash'
@@ -29,7 +30,7 @@ type GetTradeFeesInput = {
   buy: Transfer
   sell: Transfer
   blockTime: number
-  cryptoPriceHistoryData?: PriceHistoryData
+  cryptoPriceHistoryData?: PriceHistoryData<AssetId>
 }
 
 export type TradeFees = {

--- a/src/hooks/useBalanceChartData/useBalanceChartData.test.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.test.ts
@@ -97,7 +97,7 @@ describe('calculateBucketPrices', () => {
 
     const txs = [FOXSend]
 
-    const cryptoPriceHistoryData: PriceHistoryData = {
+    const cryptoPriceHistoryData: PriceHistoryData<AssetId> = {
       [foxAssetId]: [{ price: 0, date: Number() }],
     }
     const fiatPriceHistoryData: HistoryData[] = [{ price: 0, date: Number() }]
@@ -130,7 +130,7 @@ describe('calculateBucketPrices', () => {
     }
     const assetIds = [ethAssetId]
     const timeframe = HistoryTimeframe.YEAR
-    const cryptoPriceHistoryData: PriceHistoryData = {
+    const cryptoPriceHistoryData: PriceHistoryData<AssetId> = {
       [ethAssetId]: [{ price: 0, date: Number() }],
     }
     const fiatPriceHistoryData: HistoryData[] = [{ price: 0, date: Number() }]

--- a/src/hooks/useBalanceChartData/useBalanceChartData.ts
+++ b/src/hooks/useBalanceChartData/useBalanceChartData.ts
@@ -154,7 +154,7 @@ export const bucketEvents = (txs: Tx[], bucketsAndMeta: MakeBucketsReturn): Buck
 type FiatBalanceAtBucketArgs = {
   bucket: Bucket
   assets: AssetsByIdPartial
-  cryptoPriceHistoryData: PriceHistoryData
+  cryptoPriceHistoryData: PriceHistoryData<AssetId>
   fiatPriceHistoryData: HistoryData[]
   selectedCurrency: SupportedFiatCurrencies
 }
@@ -194,7 +194,7 @@ type CalculateBucketPricesArgs = {
   assetIds: AssetId[]
   buckets: Bucket[]
   assets: AssetsByIdPartial
-  cryptoPriceHistoryData: PriceHistoryData
+  cryptoPriceHistoryData: PriceHistoryData<AssetId>
   fiatPriceHistoryData: HistoryData[]
   selectedCurrency: SupportedFiatCurrencies
 }

--- a/src/lib/market-service/exchange-rates-host/exchange-rates-host.ts
+++ b/src/lib/market-service/exchange-rates-host/exchange-rates-host.ts
@@ -1,5 +1,5 @@
 import type { HistoryData, MarketData } from '@shapeshiftoss/types'
-import { HistoryTimeframe } from '@shapeshiftoss/types'
+import { getHistoryTimeframeBounds } from '@shapeshiftoss/utils'
 import Axios from 'axios'
 import { setupCache } from 'axios-cache-interceptor'
 import { getConfig } from 'config'
@@ -70,31 +70,7 @@ export class ExchangeRateHostService implements FiatMarketService {
     symbol,
     timeframe,
   }: FiatPriceHistoryArgs): Promise<HistoryData[]> => {
-    const end = dayjs().endOf('day')
-    let start
-    switch (timeframe) {
-      case HistoryTimeframe.HOUR:
-        // minimum granularity on upstream API is 1 day
-        start = end.subtract(1, 'day')
-        break
-      case HistoryTimeframe.DAY:
-        start = end.subtract(1, 'day')
-        break
-      case HistoryTimeframe.WEEK:
-        start = end.subtract(1, 'week')
-        break
-      case HistoryTimeframe.MONTH:
-        start = end.subtract(1, 'month')
-        break
-      case HistoryTimeframe.YEAR:
-        start = end.subtract(1, 'year')
-        break
-      case HistoryTimeframe.ALL:
-        start = end.subtract(5, 'years')
-        break
-      default:
-        start = end
-    }
+    const { start, end } = getHistoryTimeframeBounds(timeframe)
 
     try {
       const urls: string[] = makeExchangeRateRequestUrls(

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -19,6 +19,7 @@ import type {
 } from 'state/slices/marketDataSlice/types'
 
 import type { MarketDataById } from './types'
+import { trimOutOfBoundsMarketData } from './utils'
 
 export const initialState: MarketDataState = {
   crypto: {
@@ -94,6 +95,14 @@ export const marketData = createSlice({
     setCryptoPriceHistory: {
       reducer: (state, { payload }: { payload: CryptoPriceHistoryPayload }) => {
         const { timeframe, historyDataByAssetId } = payload
+
+        // Trim market data out of the bounds of the current timeframe
+        trimOutOfBoundsMarketData(
+          state.fiat.priceHistory,
+          timeframe,
+          Object.keys(historyDataByAssetId),
+        )
+
         const incoming = {
           crypto: {
             priceHistory: {
@@ -123,6 +132,10 @@ export const marketData = createSlice({
     ) => {
       const { args, data } = payload
       const { symbol, timeframe } = args
+
+      // Trim market data out of the bounds of the current timeframe
+      trimOutOfBoundsMarketData(state.fiat.priceHistory, timeframe, [symbol])
+
       const incoming = {
         fiat: {
           priceHistory: {

--- a/src/state/slices/marketDataSlice/types.ts
+++ b/src/state/slices/marketDataSlice/types.ts
@@ -2,14 +2,23 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import type { HistoryData, HistoryTimeframe, MarketData, PartialRecord } from '@shapeshiftoss/types'
 import type { SupportedFiatCurrencies } from 'lib/market-service'
 
-export type PriceHistoryData = PartialRecord<AssetId, HistoryData[]>
-export type PriceHistoryByTimeframe = PartialRecord<HistoryTimeframe, PriceHistoryData>
+export type PriceHistoryData<T extends SupportedFiatCurrencies | AssetId> = PartialRecord<
+  T,
+  HistoryData[]
+>
+export type PriceHistoryByTimeframe<T extends SupportedFiatCurrencies | AssetId> = PartialRecord<
+  HistoryTimeframe,
+  PriceHistoryData<T>
+>
 
-export type MarketDataById<T extends string> = PartialRecord<T, MarketData>
+export type MarketDataById<T extends SupportedFiatCurrencies | AssetId> = PartialRecord<
+  T,
+  MarketData
+>
 
-export type MarketDataStateVariant<T extends string> = {
+export type MarketDataStateVariant<T extends SupportedFiatCurrencies | AssetId> = {
   byId: MarketDataById<T>
-  priceHistory: PriceHistoryByTimeframe
+  priceHistory: PriceHistoryByTimeframe<T>
   ids: T[]
 }
 

--- a/src/state/slices/marketDataSlice/utils.ts
+++ b/src/state/slices/marketDataSlice/utils.ts
@@ -2,7 +2,7 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import type { HistoryData, HistoryTimeframe, PartialRecord } from '@shapeshiftoss/types'
 import { getHistoryTimeframeBounds } from '@shapeshiftoss/utils'
 import dayjs from 'dayjs'
-import { merge } from 'lodash'
+import { merge, orderBy } from 'lodash'
 import type { SupportedFiatCurrencies } from 'lib/market-service'
 
 import type { PriceHistoryByTimeframe } from './types'
@@ -25,9 +25,13 @@ export const getTrimmedOutOfBoundsMarketData = <T extends SupportedFiatCurrencie
   for (const id of ids) {
     const idHistory = timeFrameData[id]
     if (!idHistory) continue
-    results[id] = idHistory.filter(
+
+    const filteredResults = idHistory.filter(
       ({ date }) => date >= startTimeStampMillis && date <= endTimeStampMillis,
     )
+
+    // Sort the historical entries.
+    results[id] = orderBy(filteredResults, 'date', 'asc')
   }
 
   return results

--- a/src/state/slices/marketDataSlice/utils.ts
+++ b/src/state/slices/marketDataSlice/utils.ts
@@ -1,0 +1,45 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import type { HistoryData, HistoryTimeframe, PartialRecord } from '@shapeshiftoss/types'
+import { getHistoryTimeframeBounds } from '@shapeshiftoss/utils'
+import { merge } from 'lodash'
+import type { SupportedFiatCurrencies } from 'lib/market-service'
+
+import type { PriceHistoryByTimeframe } from './types'
+
+export const getTrimmedOutOfBoundsMarketData = <T extends SupportedFiatCurrencies | AssetId>(
+  priceHistory: PriceHistoryByTimeframe<T>,
+  timeframe: HistoryTimeframe,
+  ids: T[],
+) => {
+  const timeFrameData = priceHistory[timeframe]
+  if (!timeFrameData) return
+
+  const { start, end } = getHistoryTimeframeBounds(timeframe)
+
+  const startTimeStampMillis = start.valueOf()
+  const endTimeStampMillis = end.valueOf()
+
+  const results: PartialRecord<T, HistoryData[]> = {}
+
+  for (const id of ids) {
+    const idHistory = timeFrameData[id]
+    if (!idHistory) continue
+    results[id] = idHistory.filter(
+      ({ date }) => date >= startTimeStampMillis && date <= endTimeStampMillis,
+    )
+  }
+
+  return results
+}
+
+export const trimOutOfBoundsMarketData = <T extends SupportedFiatCurrencies | AssetId>(
+  priceHistory: PriceHistoryByTimeframe<T>,
+  timeframe: HistoryTimeframe,
+  ids: T[],
+) => {
+  const trimmedTimeframeMarketData = getTrimmedOutOfBoundsMarketData(priceHistory, timeframe, ids)
+
+  if (!trimmedTimeframeMarketData) return priceHistory
+
+  return merge(priceHistory[timeframe], trimmedTimeframeMarketData)
+}

--- a/src/state/slices/marketDataSlice/utils.ts
+++ b/src/state/slices/marketDataSlice/utils.ts
@@ -1,6 +1,7 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import type { HistoryData, HistoryTimeframe, PartialRecord } from '@shapeshiftoss/types'
 import { getHistoryTimeframeBounds } from '@shapeshiftoss/utils'
+import dayjs from 'dayjs'
 import { merge } from 'lodash'
 import type { SupportedFiatCurrencies } from 'lib/market-service'
 
@@ -14,7 +15,7 @@ export const getTrimmedOutOfBoundsMarketData = <T extends SupportedFiatCurrencie
   const timeFrameData = priceHistory[timeframe]
   if (!timeFrameData) return
 
-  const { start, end } = getHistoryTimeframeBounds(timeframe)
+  const { start, end } = getHistoryTimeframeBounds(timeframe, dayjs())
 
   const startTimeStampMillis = start.valueOf()
   const endTimeStampMillis = end.valueOf()


### PR DESCRIPTION
## Description

Fixes corrupted price charts caused by price samples spanning times outside of the selected timeframe. For example for the 24 hour time period, data prior to 24 hours ago was being displayed, resulting in corrupted charts in the UI. The solution was to trim price history data when it's upserted in redux, and also when it's read from redux.

NOTE: It's possible there is still chart corruption occurring due to incorrectly sorted price history samples. If this is the case, let me know and I'll add sorting to the selector. However if this is not the case we'd be best off avoiding the additional compute.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8093

## Risk

> High Risk PRs Require 2 approvals

Low risk, this affects display of price charts only, which is already broken.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Before:
<img src="https://github.com/user-attachments/assets/99140bff-6aff-48d5-b23f-f4df0b15ef38" width="200">

After:
<img src="https://github.com/user-attachments/assets/e163c8ab-9937-44f5-b8c6-7f927946c4b7" width="200">
