### PR TITLE
feat: limit orders list button

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1073,6 +1073,7 @@
       "expired": "Expired"
     },
     "orders": "Orders",
+    "viewOrders": "View Orders",
     "loadingOrderList": "Loading your limit orders..."
   },
   "modals": {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -62,6 +62,7 @@ import { SharedSlippagePopover } from '../../SharedTradeInput/SharedSlippagePopo
 import { SharedTradeInput } from '../../SharedTradeInput/SharedTradeInput'
 import { SharedTradeInputBody } from '../../SharedTradeInput/SharedTradeInputBody'
 import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter'
+import { useSharedHeight } from '../../TradeInput/hooks/useSharedHeight'
 import { getCowSwapErrorTranslation, isCowSwapError } from '../helpers'
 import { useLimitOrderRecipientAddress } from '../hooks/useLimitOrderRecipientAddress'
 import { LimitOrderRoutePaths } from '../types'
@@ -88,6 +89,7 @@ export const LimitOrderInput = ({
   const history = useHistory()
   const { handleSubmit } = useFormContext()
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
+  const totalHeight = useSharedHeight(tradeInputRef)
 
   const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
@@ -510,6 +512,18 @@ export const LimitOrderInput = ({
     quoteStatusTranslation,
   ])
 
+  const sideContent = useMemo(() => {
+    return (
+      <CollapsibleLimitOrderList
+        isOpen={!isCompact && !isSmallerThanXl}
+        isLoading={isLoading}
+        width={tradeInputRef.current?.offsetWidth ?? 'full'}
+        height={totalHeight ?? 'full'}
+        ml={4}
+      />
+    )
+  }, [isCompact, isLoading, isSmallerThanXl, totalHeight, tradeInputRef])
+
   return (
     <>
       <WarningAcknowledgement
@@ -521,11 +535,9 @@ export const LimitOrderInput = ({
       <SharedTradeInput
         bodyContent={bodyContent}
         footerContent={footerContent}
-        shouldOpenSideComponent={true}
         headerRightContent={headerRightContent}
         isCompact={isCompact}
-        isLoading={isLoading}
-        sideComponent={CollapsibleLimitOrderList}
+        sideContent={sideContent}
         tradeInputRef={tradeInputRef}
         tradeInputTab={TradeInputTab.LimitOrder}
         onSubmit={handleTradeQuoteConfirm}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -1,4 +1,4 @@
-import { Divider, Stack } from '@chakra-ui/react'
+import { Button, Divider, HStack, Stack, useMediaQuery } from '@chakra-ui/react'
 import { skipToken } from '@reduxjs/toolkit/query'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
@@ -17,6 +17,7 @@ import { useHistory } from 'react-router'
 import type { Address } from 'viem'
 import { WarningAcknowledgement } from 'components/Acknowledgement/Acknowledgement'
 import { TradeInputTab } from 'components/MultiHopTrade/types'
+import { Text } from 'components/Text'
 import { useAccountsFetchQuery } from 'context/AppProvider/hooks/useAccountsFetchQuery'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useActions } from 'hooks/useActions'
@@ -55,6 +56,7 @@ import {
   selectShouldShowTradeQuoteOrAwaitInput,
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
+import { breakpoints } from 'theme/theme'
 
 import { SharedSlippagePopover } from '../../SharedTradeInput/SharedSlippagePopover'
 import { SharedTradeInput } from '../../SharedTradeInput/SharedTradeInput'
@@ -85,6 +87,7 @@ export const LimitOrderInput = ({
 
   const history = useHistory()
   const { handleSubmit } = useFormContext()
+  const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
 
   const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
@@ -299,6 +302,10 @@ export const LimitOrderInput = ({
     [handleFormSubmit],
   )
 
+  const handleShowLimitOrdersList = useCallback(() => {
+    history.push(LimitOrderRoutePaths.Orders)
+  }, [history])
+
   const isLoading = useMemo(() => {
     return (
       isLimitOrderQuoteFetching ||
@@ -320,14 +327,28 @@ export const LimitOrderInput = ({
 
   const headerRightContent = useMemo(() => {
     return (
-      <SharedSlippagePopover
-        defaultSlippagePercentage={defaultSlippagePercentage}
-        quoteSlippagePercentage={undefined} // No slippage returned by CoW
-        userSlippagePercentage={userSlippagePercentage}
-        setUserSlippagePercentage={setSlippagePreferencePercentage}
-      />
+      <HStack>
+        {Boolean(isCompact || isSmallerThanXl) && (
+          <Button size='xs' borderRadius='full' onClick={handleShowLimitOrdersList}>
+            <Text translation='limitOrder.viewOrders' />
+          </Button>
+        )}
+        <SharedSlippagePopover
+          defaultSlippagePercentage={defaultSlippagePercentage}
+          quoteSlippagePercentage={undefined} // No slippage returned by CoW
+          userSlippagePercentage={userSlippagePercentage}
+          setUserSlippagePercentage={setSlippagePreferencePercentage}
+        />
+      </HStack>
     )
-  }, [defaultSlippagePercentage, setSlippagePreferencePercentage, userSlippagePercentage])
+  }, [
+    isCompact,
+    isSmallerThanXl,
+    defaultSlippagePercentage,
+    setSlippagePreferencePercentage,
+    handleShowLimitOrdersList,
+    userSlippagePercentage,
+  ])
 
   const bodyContent = useMemo(() => {
     return (

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -62,7 +62,6 @@ import { SharedSlippagePopover } from '../../SharedTradeInput/SharedSlippagePopo
 import { SharedTradeInput } from '../../SharedTradeInput/SharedTradeInput'
 import { SharedTradeInputBody } from '../../SharedTradeInput/SharedTradeInputBody'
 import { SharedTradeInputFooter } from '../../SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter'
-import { useSharedHeight } from '../../TradeInput/hooks/useSharedHeight'
 import { getCowSwapErrorTranslation, isCowSwapError } from '../helpers'
 import { useLimitOrderRecipientAddress } from '../hooks/useLimitOrderRecipientAddress'
 import { LimitOrderRoutePaths } from '../types'
@@ -89,7 +88,6 @@ export const LimitOrderInput = ({
   const history = useHistory()
   const { handleSubmit } = useFormContext()
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
-  const totalHeight = useSharedHeight(tradeInputRef)
 
   const userSlippagePercentageDecimal = useAppSelector(selectUserSlippagePercentageDecimal)
   const userSlippagePercentage = useAppSelector(selectUserSlippagePercentage)
@@ -512,18 +510,6 @@ export const LimitOrderInput = ({
     quoteStatusTranslation,
   ])
 
-  const sideContent = useMemo(() => {
-    return (
-      <CollapsibleLimitOrderList
-        isOpen={!isCompact && !isSmallerThanXl}
-        isLoading={isLoading}
-        width={tradeInputRef.current?.offsetWidth ?? 'full'}
-        height={totalHeight ?? 'full'}
-        ml={4}
-      />
-    )
-  }, [isCompact, isLoading, isSmallerThanXl, totalHeight, tradeInputRef])
-
   return (
     <>
       <WarningAcknowledgement
@@ -537,7 +523,9 @@ export const LimitOrderInput = ({
         footerContent={footerContent}
         headerRightContent={headerRightContent}
         isCompact={isCompact}
-        sideContent={sideContent}
+        isLoading={isLoading}
+        SideComponent={CollapsibleLimitOrderList}
+        shouldOpenSideComponent
         tradeInputRef={tradeInputRef}
         tradeInputTab={TradeInputTab.LimitOrder}
         onSubmit={handleTradeQuoteConfirm}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -30,6 +30,10 @@ import { useGetLimitOrdersQuery } from '../hooks/useGetLimitOrdersForAccountQuer
 import { CancelLimitOrder } from './CancelLimtOrder'
 import { LimitOrderCard } from './LimitOrderCard'
 
+const textSelectedProps = {
+  color: 'text.base',
+}
+
 type LimitOrderListProps = {
   isLoading: boolean
   cardProps?: CardProps
@@ -37,18 +41,6 @@ type LimitOrderListProps = {
 }
 
 export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) => {
-  const textColorBaseProps = useMemo(() => {
-    return {
-      color: 'text.base',
-      ...(onBack && {
-        bg: 'blue.500',
-        px: 4,
-        py: 2,
-        borderRadius: 'full',
-      }),
-    }
-  }, [onBack])
-
   const { setOrderToCancel } = useActions(limitOrderSlice.actions)
   const { data: ordersResponse, isLoading } = useGetLimitOrdersQuery()
 
@@ -102,8 +94,8 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
             p={0}
             fontSize='md'
             fontWeight='bold'
-            color={onBack ? 'text.base' : 'text.subtle'}
-            _selected={textColorBaseProps}
+            color='text.subtle'
+            _selected={textSelectedProps}
           >
             <Text translation='limitOrder.openOrders' />
           </Tab>
@@ -111,8 +103,8 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
             p={0}
             fontSize='md'
             fontWeight='bold'
-            color={onBack ? 'text.base' : 'text.subtle'}
-            _selected={textColorBaseProps}
+            color='text.subtle'
+            _selected={textSelectedProps}
           >
             <Text translation='limitOrder.orderHistory' />
           </Tab>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -5,17 +5,13 @@ import { ThorFreeFeeBanner } from 'components/ThorFreeFeeBanner/ThorFreeFeeBanne
 import { breakpoints } from 'theme/theme'
 
 import { SharedTradeInputHeader } from '../SharedTradeInput/SharedTradeInputHeader'
-import { WithLazyMount } from '../TradeInput/components/WithLazyMount'
-import { useSharedHeight } from '../TradeInput/hooks/useSharedHeight'
 
 type SharedTradeInputProps = {
   bodyContent: JSX.Element
   footerContent: JSX.Element
-  shouldOpenSideComponent: boolean
   headerRightContent: JSX.Element
   isCompact: boolean | undefined
-  isLoading: boolean
-  sideComponent: React.ComponentType<any>
+  sideContent: JSX.Element
   tradeInputRef: React.RefObject<HTMLDivElement>
   tradeInputTab: TradeInputTab
   onChangeTab: (newTab: TradeInputTab) => void
@@ -24,18 +20,15 @@ type SharedTradeInputProps = {
 
 export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   bodyContent,
-  shouldOpenSideComponent,
   headerRightContent,
   isCompact,
-  isLoading,
-  sideComponent,
+  sideContent,
   tradeInputTab,
   tradeInputRef,
   footerContent,
   onChangeTab,
   onSubmit,
 }) => {
-  const totalHeight = useSharedHeight(tradeInputRef)
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
 
   return (
@@ -65,15 +58,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
             {footerContent}
           </Card>
         </Box>
-        <WithLazyMount
-          shouldUse={!isCompact && !isSmallerThanXl}
-          component={sideComponent}
-          isOpen={!isCompact && !isSmallerThanXl && shouldOpenSideComponent}
-          isLoading={isLoading}
-          width={tradeInputRef.current?.offsetWidth ?? 'full'}
-          height={totalHeight ?? 'full'}
-          ml={4}
-        />
+        {sideContent}
       </Center>
     </Flex>
   )

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -1,3 +1,4 @@
+import type { CardProps } from '@chakra-ui/react'
 import { Box, Card, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import type { FormEvent } from 'react'
 import type { TradeInputTab } from 'components/MultiHopTrade/types'
@@ -5,13 +6,24 @@ import { ThorFreeFeeBanner } from 'components/ThorFreeFeeBanner/ThorFreeFeeBanne
 import { breakpoints } from 'theme/theme'
 
 import { SharedTradeInputHeader } from '../SharedTradeInput/SharedTradeInputHeader'
+import { useSharedHeight } from '../TradeInput/hooks/useSharedHeight'
+
+export type SideComponentProps = {
+  isOpen: boolean
+  width: string | number
+  height: string | number
+  isLoading: boolean
+  ml: CardProps['ml']
+}
 
 type SharedTradeInputProps = {
   bodyContent: JSX.Element
   footerContent: JSX.Element
   headerRightContent: JSX.Element
   isCompact: boolean | undefined
-  sideContent: JSX.Element
+  isLoading: boolean
+  SideComponent: React.ComponentType<SideComponentProps>
+  shouldOpenSideComponent: boolean
   tradeInputRef: React.RefObject<HTMLDivElement>
   tradeInputTab: TradeInputTab
   onChangeTab: (newTab: TradeInputTab) => void
@@ -22,7 +34,9 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   bodyContent,
   headerRightContent,
   isCompact,
-  sideContent,
+  isLoading,
+  SideComponent,
+  shouldOpenSideComponent,
   tradeInputTab,
   tradeInputRef,
   footerContent,
@@ -30,6 +44,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   onSubmit,
 }) => {
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
+  const totalHeight = useSharedHeight(tradeInputRef)
 
   return (
     <Flex
@@ -58,7 +73,13 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
             {footerContent}
           </Card>
         </Box>
-        {sideContent}
+        <SideComponent
+          isOpen={!isCompact && !isSmallerThanXl && shouldOpenSideComponent}
+          isLoading={isLoading}
+          width={tradeInputRef.current?.offsetWidth ?? 'full'}
+          height={totalHeight ?? 'full'}
+          ml={4}
+        />
       </Center>
     </Flex>
   )

--- a/src/components/MultiHopTrade/components/SlideTransitionRoute.tsx
+++ b/src/components/MultiHopTrade/components/SlideTransitionRoute.tsx
@@ -1,10 +1,11 @@
 import type { CardProps } from '@chakra-ui/react'
-import { Center, Flex, useMediaQuery } from '@chakra-ui/react'
+import { Box, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import type { FC } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
 import { TradeSlideTransition } from 'components/MultiHopTrade/TradeSlideTransition'
 import type { TradeRoutePaths } from 'components/MultiHopTrade/types'
+import { ThorFreeFeeBanner } from 'components/ThorFreeFeeBanner/ThorFreeFeeBanner'
 import { breakpoints } from 'theme/theme'
 
 import type { LimitOrderRoutePaths } from './LimitOrder/types'
@@ -46,12 +47,21 @@ export const SlideTransitionRoute = ({
   )
 
   return (
-    <TradeSlideTransition>
-      <Flex width='full' justifyContent='center' maxWidth={isSmallerThanXl ? '500px' : undefined}>
-        <Center width='inherit'>
-          <Component onBack={handleBack} isLoading={false} cardProps={cardProps} />
-        </Center>
-      </Flex>
-    </TradeSlideTransition>
+    <Center width='inherit' alignItems='flex-end'>
+      <Box width='full' maxWidth='500px'>
+        <ThorFreeFeeBanner />
+        <TradeSlideTransition>
+          <Flex
+            width='full'
+            justifyContent='center'
+            maxWidth={isSmallerThanXl ? '500px' : undefined}
+          >
+            <Center width='inherit'>
+              <Component onBack={handleBack} isLoading={false} cardProps={cardProps} />
+            </Center>
+          </Flex>
+        </TradeSlideTransition>
+      </Box>
+    </Center>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -1,4 +1,3 @@
-import { useMediaQuery } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { isArbitrumBridgeTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ArbitrumBridgeSwapper/getTradeQuote/getTradeQuote'
@@ -53,7 +52,6 @@ import {
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { store, useAppDispatch, useAppSelector } from 'state/store'
-import { breakpoints } from 'theme/theme'
 
 import { useAccountIds } from '../../hooks/useAccountIds'
 import { SharedTradeInput } from '../SharedTradeInput/SharedTradeInput'
@@ -62,7 +60,6 @@ import { TradeAssetInput } from '../TradeAssetInput'
 import { CollapsibleQuoteList } from './components/CollapsibleQuoteList'
 import { ConfirmSummary } from './components/ConfirmSummary'
 import { TradeSettingsMenu } from './components/TradeSettingsMenu'
-import { useSharedHeight } from './hooks/useSharedHeight'
 import { useTradeReceiveAddress } from './hooks/useTradeReceiveAddress'
 
 const emptyPercentOptions: number[] = []
@@ -85,8 +82,6 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     dispatch: walletDispatch,
     state: { isConnected, isDemoWallet, wallet },
   } = useWallet()
-  const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
-  const totalHeight = useSharedHeight(tradeInputRef)
 
   const { handleSubmit } = useFormContext()
   const dispatch = useAppDispatch()
@@ -429,18 +424,6 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     )
   }, [isCompact, isLoading, manualReceiveAddress, walletReceiveAddress])
 
-  const sideContent = useMemo(() => {
-    return (
-      <CollapsibleQuoteList
-        isOpen={!isCompact && !isSmallerThanXl && hasUserEnteredAmount}
-        isLoading={isLoading}
-        width={tradeInputRef.current?.offsetWidth ?? 'full'}
-        height={totalHeight ?? 'full'}
-        ml={4}
-      />
-    )
-  }, [hasUserEnteredAmount, isCompact, isLoading, isSmallerThanXl, totalHeight, tradeInputRef])
-
   // TODO: Its possible for multiple Acknowledgements to appear at once. Based on the logical paths,
   // if the WarningAcknowledgement shows, it can then show either StreamingAcknowledgement or
   // ArbitrumBridgeAcknowledgement, but never both. While the current implementation works, its by
@@ -472,7 +455,9 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
         footerContent={footerContent}
         headerRightContent={headerRightContent}
         isCompact={isCompact}
-        sideContent={sideContent}
+        isLoading={isLoading}
+        SideComponent={CollapsibleQuoteList}
+        shouldOpenSideComponent={hasUserEnteredAmount}
         tradeInputRef={tradeInputRef}
         tradeInputTab={TradeInputTab.Trade}
         onSubmit={handleTradeQuoteConfirm}


### PR DESCRIPTION
## Description

Adds a button users can click to show the limit orders list, when on compact or mobile view.

Includes some fixes to layout handling so the UI doesn't flash and go nuts when toggling between "trade" and "limit" tabs ("claim" tab still awful though).

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8215

## Risk

> High Risk PRs Require 2 approvals

Low risk, mostly relates to view layout.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Spot trade input, quote list, and limit orders input all affected.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo of viewing limit orders list in compact layout:

https://github.com/user-attachments/assets/d466523a-9a56-48a8-9356-8df55f08bf9b

Demo of the layout flashing jankiness before this PR:

https://github.com/user-attachments/assets/dc871ee7-6406-4539-93aa-e7f1b8ae1182

Demo of layout improvements when switching between "trade" and "limit" tabs:

https://github.com/user-attachments/assets/73ffb50d-367f-418a-9097-335e16b00a1c





