### PR TITLE
fix: mobile app login flow

### DIFF
--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -11,12 +11,13 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
   const { keyring, modal, modalType } = state
 
   useEffect(() => {
-    if (isMobile) return
     const handleEvent = (e: [deviceId: string, message: Event]) => {
       const deviceId = e[0]
       switch (e[1].message_type) {
         case NativeEvents.MNEMONIC_REQUIRED:
           if (!deviceId) break
+          // If we're on mobile, we don't need to handle the MNEMONIC_REQUIRED event as we use the device's native authentication instead
+          if (isMobile) break
           dispatch({ type: WalletActions.NATIVE_PASSWORD_OPEN, payload: { modal: true, deviceId } })
 
           break

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -5,7 +5,7 @@ import { useEffect } from 'react'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
 import type { InitialState } from 'context/WalletProvider/WalletProvider'
-import { isMobile } from 'lib/globals'
+import { isMobile as isMobileApp } from 'lib/globals'
 
 export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<ActionTypes>) => {
   const { keyring, modal, modalType } = state
@@ -18,7 +18,7 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
           if (!deviceId) break
           // If we're on the native mobile app we don't need to handle the MNEMONIC_REQUIRED event as we use the device's native authentication instead
           // Reacting to this event will incorrectly open the native password modal after authentication completes when on the mobile app
-          if (isMobile) break
+          if (isMobileApp) break
           dispatch({ type: WalletActions.NATIVE_PASSWORD_OPEN, payload: { modal: true, deviceId } })
 
           break

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -5,11 +5,13 @@ import { useEffect } from 'react'
 import type { ActionTypes } from 'context/WalletProvider/actions'
 import { WalletActions } from 'context/WalletProvider/actions'
 import type { InitialState } from 'context/WalletProvider/WalletProvider'
+import { isMobile } from 'lib/globals'
 
 export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<ActionTypes>) => {
   const { keyring, modal, modalType } = state
 
   useEffect(() => {
+    if (isMobile) return
     const handleEvent = (e: [deviceId: string, message: Event]) => {
       const deviceId = e[0]
       switch (e[1].message_type) {

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -16,7 +16,8 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
       switch (e[1].message_type) {
         case NativeEvents.MNEMONIC_REQUIRED:
           if (!deviceId) break
-          // If we're on mobile, we don't need to handle the MNEMONIC_REQUIRED event as we use the device's native authentication instead
+          // If we're on the native mobile app we don't need to handle the MNEMONIC_REQUIRED event as we use the device's native authentication instead
+          // Reacting to this event will incorrectly open the native password modal after authentication completes when on the mobile app
           if (isMobile) break
           dispatch({ type: WalletActions.NATIVE_PASSWORD_OPEN, payload: { modal: true, deviceId } })
 


### PR DESCRIPTION
## Description

Ensures we do not fire the `WalletActions.NATIVE_PASSWORD_OPEN` action when on the native mobile app when the `NativeEvents.MNEMONIC_REQUIRED` event is observed.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8257

## Risk

> High Risk PRs Require 2 approvals

Medium - small code change, but ignoring this event when we shouldn't could cause problems!

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- Mobile wallet connection
- Native wallet connection

## Testing

Point the mobile app at `juice` to test this PR.

On the mobile app, once you've authenticated using the device's native auth (e.g. FaceID), ensure the native password entry modal does not display.

Also confirm the following works as expected

- creating a wallet on mobile
- switching between saved wallets

Test this on both iOS and Android. Note, I was only able to test iOS.

Also ensure that connecting via native wallets on non-mobile app platforms still works as expected.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A