### PR TITLE
fix: portals protocol fee

### DIFF
--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -134,7 +134,7 @@ export async function getPortalsTradeQuote(
       tx,
     } = portalsTradeOrderResponse
 
-    const feeAsset = feeToken === inputToken ? sellAsset : buyAsset
+    const protocolFeeAsset = feeToken === inputToken ? sellAsset : buyAsset
 
     if (!tx) throw new Error('Portals Tx simulation failed upstream')
 
@@ -181,9 +181,9 @@ export async function getPortalsTradeQuote(
           feeData: {
             networkFeeCryptoBaseUnit,
             protocolFees: {
-              [feeAsset.assetId]: {
+              [protocolFeeAsset.assetId]: {
                 amountCryptoBaseUnit: feeAmount,
-                asset: feeAsset,
+                asset: protocolFeeAsset,
                 requiresBalance: false,
               },
             },

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -129,9 +129,12 @@ export async function getPortalsTradeQuote(
         target: allowanceContract,
         feeAmount,
         gasLimit,
+        feeToken,
       },
       tx,
     } = portalsTradeOrderResponse
+
+    const feeAsset = feeToken === inputToken ? sellAsset : buyAsset
 
     if (!tx) throw new Error('Portals Tx simulation failed upstream')
 
@@ -177,11 +180,10 @@ export async function getPortalsTradeQuote(
             input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
           feeData: {
             networkFeeCryptoBaseUnit,
-            // Protocol fees are always denominated in sell asset here
             protocolFees: {
-              [sellAsset.assetId]: {
+              [feeAsset.assetId]: {
                 amountCryptoBaseUnit: feeAmount,
-                asset: sellAsset,
+                asset: feeAsset,
                 requiresBalance: false,
               },
             },


### PR DESCRIPTION
## Description

Portals protocol fees can be in either the buy asset or the sell asset.

This diff accounts for that and makes portals protocol fees great again.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8266

## Risk

> High Risk PRs Require 2 approvals

Small - UI only.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Portals trade quotes.

## Testing

Ensure the protocol fee on Portals trade quotes looks accurate.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

Production

<img width="377" alt="Screenshot 2024-12-05 at 12 08 10" src="https://github.com/user-attachments/assets/cc03fa32-c744-4beb-9ef6-19ec8c5da1b7">

This PR

<img width="398" alt="Screenshot 2024-12-05 at 12 07 40" src="https://github.com/user-attachments/assets/898136ca-2976-41c9-b7e4-d527ef277607">