### PR TITLE
fix: remove pointless button from limit order confirm

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
@@ -7,7 +7,6 @@ import {
   CardHeader,
   Heading,
   HStack,
-  Link,
   Stack,
 } from '@chakra-ui/react'
 import { SwapperName } from '@shapeshiftoss/swapper'
@@ -46,9 +45,6 @@ import { WithBackButton } from '../../WithBackButton'
 import { LimitOrderRoutePaths } from '../types'
 
 const cardBorderRadius = { base: '2xl' }
-
-// TODO: Populate this!
-const learnMoreUrl = ''
 
 export const LimitOrderConfirm = () => {
   const history = useHistory()
@@ -193,9 +189,8 @@ export const LimitOrderConfirm = () => {
             <Card bg='background.surface.raised.pressed' borderRadius={6} p={4}>
               <HStack>
                 <InfoIcon boxSize='1.3em' color='text.info' />
-                <RawText>
-                  {translate('limitOrder.confirmInfo')}{' '}
-                  <Button
+                <RawText>{translate('limitOrder.confirmInfo')}</RawText>
+                {/* <Button
                     as={Link}
                     href={learnMoreUrl}
                     variant='link'
@@ -207,8 +202,7 @@ export const LimitOrderConfirm = () => {
                     verticalAlign='baseline'
                   >
                     <Text as='span' translation='limitOrder.learnMore' />
-                  </Button>
-                </RawText>
+                  </Button> */}
               </HStack>
             </Card>
             <Button


### PR DESCRIPTION
## Description

Removes a pointless "learn more" button from limit order confirm. It didn't do anything so we're commenting it out until we have a URL to point at.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes NA

## Risk

> High Risk PRs Require 2 approvals

Virtually no risk, though I won't ever discount the possibility of everything breaking.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Preview a limit order and confirm the "learn more" button is now gone.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Prod:
<img src="https://github.com/user-attachments/assets/0217a323-f1dd-4ba0-93e1-cbfdc87e6582" width="200">

This PR:
<img src="https://github.com/user-attachments/assets/3499f2b5-f3e0-4735-8ed1-1b1eed07db20" width="200">

