### PR TITLE
feat: only show one of two tooltips for unknown gas

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -310,15 +310,19 @@ export const Hop = ({
       <CardFooter fontSize='sm' pl={8}>
         <HStack width='full' justifyContent='space-between'>
           {/* Hovering over this should render a popover with details */}
-          <Tooltip label={translate('trade.tooltip.gasFee')}>
+          <Tooltip
+            label={translate(
+              networkFeeFiatUserCurrency
+                ? 'trade.tooltip.gasFee'
+                : 'trade.tooltip.continueSwapping',
+            )}
+          >
             <Flex alignItems='center' gap={2}>
               <Flex color='text.subtle'>
                 <FaGasPump />
               </Flex>
               {!networkFeeFiatUserCurrency ? (
-                <Tooltip label={translate('trade.tooltip.continueSwapping')}>
-                  <Text translation={'trade.unknownGas'} fontSize='sm' />
-                </Tooltip>
+                <Text translation={'trade.unknownGas'} fontSize='sm' />
               ) : (
                 <Amount.Fiat value={networkFeeFiatUserCurrency} display='inline' />
               )}


### PR DESCRIPTION
## Description

Ensures "This is the estimated gas fee to complete this trade." does not get overlayed by "Continue swapping for final details"
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8250

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Preview a Portals rate
- Ensure that when hovering over the gas icon / "(unknown)", the "This is the estimated gas fee to complete this trade." tooltip doesn't appear, only the former.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="302" alt="Screenshot 2024-12-05 at 12 52 27" src="https://github.com/user-attachments/assets/c6764ae4-ef9f-43e2-a075-f9a16bd961e5">


- this diff

<img width="404" alt="Screenshot 2024-12-05 at 12 53 12" src="https://github.com/user-attachments/assets/a7e4b54b-f3bc-45e9-a659-280cc126a206">


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
