### PR TITLE
fix: portals tooltip overlay

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -309,24 +309,32 @@ export const Hop = ({
       <Divider width='auto' ml={6} borderColor='border.base' opacity={1} />
       <CardFooter fontSize='sm' pl={8}>
         <HStack width='full' justifyContent='space-between'>
-          {/* Hovering over this should render a popover with details */}
-          <Tooltip label={translate('trade.tooltip.gasFee')}>
+          <Tooltip
+            label={
+              networkFeeFiatUserCurrency
+                ? translate('trade.tooltip.gasFee')
+                : translate('trade.tooltip.continueSwapping')
+            }
+          >
             <Flex alignItems='center' gap={2}>
               <Flex color='text.subtle'>
                 <FaGasPump />
               </Flex>
               {!networkFeeFiatUserCurrency ? (
-                <Tooltip label={translate('trade.tooltip.continueSwapping')}>
-                  <Text translation={'trade.unknownGas'} fontSize='sm' />
-                </Tooltip>
+                <Text translation={'trade.unknownGas'} fontSize='sm' />
               ) : (
                 <Amount.Fiat value={networkFeeFiatUserCurrency} display='inline' />
               )}
             </Flex>
           </Tooltip>
 
-          {/* Hovering over this should render a popover with details */}
-          <Tooltip label={translate('trade.tooltip.protocolFee')}>
+          <Tooltip
+            label={
+              protocolFeeFiatPrecision
+                ? translate('trade.tooltip.protocolFee')
+                : translate('trade.tooltip.continueSwapping')
+            }
+          >
             <Flex alignItems='center' gap={2}>
               <Flex color='text.subtle'>
                 <ProtocolIcon />

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/Hop.tsx
@@ -310,11 +310,11 @@ export const Hop = ({
       <CardFooter fontSize='sm' pl={8}>
         <HStack width='full' justifyContent='space-between'>
           <Tooltip
-            label={
+            label={translate(
               networkFeeFiatUserCurrency
-                ? translate('trade.tooltip.gasFee')
-                : translate('trade.tooltip.continueSwapping')
-            }
+                ? 'trade.tooltip.gasFee'
+                : 'trade.tooltip.continueSwapping',
+            )}
           >
             <Flex alignItems='center' gap={2}>
               <Flex color='text.subtle'>
@@ -329,11 +329,11 @@ export const Hop = ({
           </Tooltip>
 
           <Tooltip
-            label={
+            label={translate(
               protocolFeeFiatPrecision
-                ? translate('trade.tooltip.protocolFee')
-                : translate('trade.tooltip.continueSwapping')
-            }
+                ? 'trade.tooltip.protocolFee'
+                : 'trade.tooltip.continueSwapping',
+            )}
           >
             <Flex alignItems='center' gap={2}>
               <Flex color='text.subtle'>


### PR DESCRIPTION
## Description

Fixes the duplicate tooltip issue by only showing one.

If we have no gas or protocol fee, show the "continue swapping" tooltip, else show the explanation tooltip.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8250

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Portals quote UI.

## Testing

Get a Portals quote. Observe that no gas value is available before clicking "Confirm and Trade", and that only one tooltip shows: the "continue swapping" one.

### Engineering

☝️

Anticipates change coming in https://github.com/shapeshift/web/pull/8287 and preemptively adds a tooltip for the `undefined` case there.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="451" alt="Screenshot 2024-12-05 at 16 06 29" src="https://github.com/user-attachments/assets/95e7b1de-4382-4f92-9bd5-5e1d8b01de6c">
