### PR TITLE
fix: clear tradeQuoteSlice state on trade input mount

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -7,7 +7,6 @@ import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
-import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
 import { LimitOrder } from './components/LimitOrder/LimitOrder'
@@ -98,17 +97,6 @@ type TradeRoutesProps = {
 const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
   const history = useHistory()
   const location = useLocation()
-  const dispatch = useAppDispatch()
-
-  useEffect(() => {
-    return () => {
-      // Reset the trade slices to initial state on unmount
-      // Don't move me to one of the trade route components, this needs to be at router-level
-      // We only want to clear swapper state when trade components are fully unmounted, not when trade routes change
-      dispatch(tradeInput.actions.clear())
-      dispatch(tradeQuoteSlice.actions.clear())
-    }
-  }, [dispatch])
 
   const tradeInputRef = useRef<HTMLDivElement | null>(null)
 

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -5,6 +5,7 @@ import type { ThorTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/Thorch
 import type { Asset } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { positiveOrZero } from '@shapeshiftoss/utils'
+import type { Location } from 'history'
 import type { FormEvent } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext } from 'react-hook-form'
@@ -155,6 +156,18 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
       isWalletReceiveAddressLoading,
     ],
   )
+
+  // Reset the trade quote slice to initial state on mount
+  useEffect(() => {
+    // history.entries isn't officially documented but it exists
+    const entries = (history as any).entries as Location[]
+    const previousHistoryIndex = entries.length - 2
+    // Do not clear tradeQuoteSlice when navigating back from trade quotes list, or selecting a quote other than the default will reset the slice and break swapper until user changes input
+    if (entries.length > 1 && entries[previousHistoryIndex].pathname === TradeRoutePaths.QuoteList)
+      return
+
+    dispatch(tradeQuoteSlice.actions.clearTradeQuotes())
+  }, [dispatch, history])
 
   useEffect(() => {
     // Reset the trade warning if the active quote has changed, i.e. a better quote has come in and the

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -23,6 +23,11 @@ export const tradeQuoteSlice = createSlice({
       ...initialState,
       tradeExecution: state.tradeExecution, // Leave the trade execution state alone
     }),
+    clearTradeQuotes: state => ({
+      ...initialState,
+      tradeExecution: state.tradeExecution, // Leave the trade execution state alone
+      activeQuoteMeta: state.activeQuoteMeta, // And the activeQuoteMeta too, or we'll lose the active quote when backing out from preview
+    }),
     setIsTradeQuoteRequestAborted: (state, action: PayloadAction<boolean>) => {
       state.isTradeQuoteRequestAborted = action.payload
     },


### PR DESCRIPTION
## Description

This PR ensures that we never have stale final trade quotes when going back from an unfinalized quote back to swapper.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8291

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium, theoretically low, but reset could be wrong and come back biting us, see testing steps

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure going back and forth to an uncompleted Portals trade where final quote was fetched back to input, then going for a Portals trade with the same input doesn't keep the previous final quote as stale.
  This can be confirmed by `(unknown)` being back, vs. the previous behaviour being the previous final quote still being present, which can be seen with the presence of a network fee.
- Going to trade confirm (whichever stage you go to, either preview or all the way to final quote), then back to input should keep the selected quote if you've selected a manual one
- Selecting a quote other than the best should still be happy and not make the swapper in a perma-loading state until the input is changed. **Note**: test this on small viewports too, where the quote selection is a proper screen/route vs. a sidebar with larger viewports
- When selecting a rate other than the default for a swapper, paranoia check on explorer that it is still executed for said swapper


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/7133a1f7-8d4f-4d80-befe-a201c28e1cc5

- this diff

https://jam.dev/c/754cc93f-0323-4dff-932a-ee165b752b34

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
