### PR TITLE
fix: limit order custom limit price state lost

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -13,7 +13,7 @@ import {
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { bn, bnOrZero } from '@shapeshiftoss/utils'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import type { NumberFormatValues } from 'react-number-format'
 import NumberFormat from 'react-number-format'
 import { StyledAssetMenuButton } from 'components/AssetSelection/components/AssetMenuButton'
@@ -22,26 +22,23 @@ import { Text } from 'components/Text'
 import { useActions } from 'hooks/useActions'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { assertUnreachable } from 'lib/utils'
-import { ExpiryOption, PriceDirection } from 'state/slices/limitOrderInputSlice/constants'
+import {
+  ExpiryOption,
+  PresetLimit,
+  PriceDirection,
+} from 'state/slices/limitOrderInputSlice/constants'
 import { limitOrderInput } from 'state/slices/limitOrderInputSlice/limitOrderInputSlice'
 import {
   selectExpiry,
   selectLimitPriceDirection,
   selectLimitPriceForSelectedPriceDirection,
   selectLimitPriceOppositeDirection,
+  selectPresetLimitPrice,
 } from 'state/slices/limitOrderInputSlice/selectors'
 import { allowedDecimalSeparators } from 'state/slices/preferencesSlice/preferencesSlice'
 import { useAppSelector } from 'state/store'
 
 import { AmountInput } from '../../TradeAmountInput'
-
-enum PresetLimit {
-  Market = 'market',
-  OnePercent = 'onePercent',
-  TwoPercent = 'twoPercent',
-  FivePercent = 'fivePercent',
-  TenPercent = 'tenPercent',
-}
 
 const EXPIRY_OPTIONS = [
   ExpiryOption.OneHour,
@@ -91,16 +88,17 @@ export const LimitOrderConfig = ({
 }: LimitOrderConfigProps) => {
   const priceAmountRef = useRef<string | null>(null)
 
-  const [presetLimit, setPresetLimit] = useState<PresetLimit | undefined>(PresetLimit.Market)
-
   const limitPriceForSelectedPriceDirection = useAppSelector(
     selectLimitPriceForSelectedPriceDirection,
   )
   const priceDirection = useAppSelector(selectLimitPriceDirection)
   const oppositePriceDirection = useAppSelector(selectLimitPriceOppositeDirection)
   const expiry = useAppSelector(selectExpiry)
+  const presetLimitPrice = useAppSelector(selectPresetLimitPrice)
 
-  const { setLimitPriceDirection, setExpiry, setLimitPrice } = useActions(limitOrderInput.actions)
+  const { setLimitPriceDirection, setExpiry, setLimitPrice, setPresetLimit } = useActions(
+    limitOrderInput.actions,
+  )
 
   // Reset the user config when the assets change
   useEffect(
@@ -177,7 +175,7 @@ export const LimitOrderConfig = ({
         [PriceDirection.SellAssetDenomination]: bn(1).div(adjustedLimitPriceBuyAsset).toFixed(),
       })
     },
-    [marketPriceBuyAsset, setLimitPrice],
+    [marketPriceBuyAsset, setLimitPrice, setPresetLimit],
   )
 
   const handleSetMarketLimit = useCallback(() => {
@@ -223,7 +221,7 @@ export const LimitOrderConfig = ({
 
     // Unset the preset limit, as this is a custom value
     setPresetLimit(undefined)
-  }, [oppositePriceDirection, priceDirection, setLimitPrice])
+  }, [oppositePriceDirection, priceDirection, setLimitPrice, setPresetLimit])
 
   const handleValueChange = useCallback(
     (values: NumberFormatValues) => {
@@ -296,7 +294,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimit === PresetLimit.Market}
+          isActive={presetLimitPrice === PresetLimit.Market}
           onClick={handleSetMarketLimit}
           isDisabled={isLoading}
         >
@@ -305,7 +303,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimit === PresetLimit.OnePercent}
+          isActive={presetLimitPrice === PresetLimit.OnePercent}
           onClick={handleSetOnePercentLimit}
           isDisabled={isLoading}
         >
@@ -314,7 +312,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimit === PresetLimit.TwoPercent}
+          isActive={presetLimitPrice === PresetLimit.TwoPercent}
           onClick={handleSetTwoPercentLimit}
           isDisabled={isLoading}
         >
@@ -323,7 +321,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimit === PresetLimit.FivePercent}
+          isActive={presetLimitPrice === PresetLimit.FivePercent}
           onClick={handleSetFivePercentLimit}
           isDisabled={isLoading}
         >
@@ -332,7 +330,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimit === PresetLimit.TenPercent}
+          isActive={presetLimitPrice === PresetLimit.TenPercent}
           onClick={handleSetTenPercentLimit}
           isDisabled={isLoading}
         >

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -13,7 +13,7 @@ import {
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { bn, bnOrZero } from '@shapeshiftoss/utils'
-import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { useCallback, useMemo, useRef } from 'react'
 import type { NumberFormatValues } from 'react-number-format'
 import NumberFormat from 'react-number-format'
 import { StyledAssetMenuButton } from 'components/AssetSelection/components/AssetMenuButton'
@@ -98,23 +98,6 @@ export const LimitOrderConfig = ({
 
   const { setLimitPriceDirection, setExpiry, setLimitPrice, setPresetLimit } = useActions(
     limitOrderInput.actions,
-  )
-
-  // Reset the user config when the assets change
-  useEffect(
-    () => {
-      setLimitPriceDirection(PriceDirection.BuyAssetDenomination)
-      setPresetLimit(PresetLimit.Market)
-      setExpiry(ExpiryOption.SevenDays)
-      setLimitPrice({
-        [PriceDirection.BuyAssetDenomination]: marketPriceBuyAsset,
-        [PriceDirection.SellAssetDenomination]: bn(1).div(marketPriceBuyAsset).toFixed(),
-      })
-    },
-    // NOTE: we DO NOT want to react to `marketPriceBuyAsset` here, because polling will reset it
-    // every time!
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [sellAsset, buyAsset, setLimitPrice],
   )
 
   const {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -24,7 +24,7 @@ import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { assertUnreachable } from 'lib/utils'
 import {
   ExpiryOption,
-  PresetLimit,
+  LimitPriceMode,
   PriceDirection,
 } from 'state/slices/limitOrderInputSlice/constants'
 import { limitOrderInput } from 'state/slices/limitOrderInputSlice/limitOrderInputSlice'
@@ -134,19 +134,19 @@ export const LimitOrderConfig = ({
   }, [priceDirection])
 
   const handleSetPresetLimit = useCallback(
-    (presetLimit: PresetLimit) => {
+    (presetLimit: LimitPriceMode) => {
       setPresetLimit(presetLimit)
       const multiplier = (() => {
         switch (presetLimit) {
-          case PresetLimit.Market:
+          case LimitPriceMode.Market:
             return '1.00'
-          case PresetLimit.OnePercent:
+          case LimitPriceMode.OnePercent:
             return '1.01'
-          case PresetLimit.TwoPercent:
+          case LimitPriceMode.TwoPercent:
             return '1.02'
-          case PresetLimit.FivePercent:
+          case LimitPriceMode.FivePercent:
             return '1.05'
-          case PresetLimit.TenPercent:
+          case LimitPriceMode.TenPercent:
             return '1.10'
           default:
             assertUnreachable(presetLimit)
@@ -162,23 +162,23 @@ export const LimitOrderConfig = ({
   )
 
   const handleSetMarketLimit = useCallback(() => {
-    handleSetPresetLimit(PresetLimit.Market)
+    handleSetPresetLimit(LimitPriceMode.Market)
   }, [handleSetPresetLimit])
 
   const handleSetOnePercentLimit = useCallback(() => {
-    handleSetPresetLimit(PresetLimit.OnePercent)
+    handleSetPresetLimit(LimitPriceMode.OnePercent)
   }, [handleSetPresetLimit])
 
   const handleSetTwoPercentLimit = useCallback(() => {
-    handleSetPresetLimit(PresetLimit.TwoPercent)
+    handleSetPresetLimit(LimitPriceMode.TwoPercent)
   }, [handleSetPresetLimit])
 
   const handleSetFivePercentLimit = useCallback(() => {
-    handleSetPresetLimit(PresetLimit.FivePercent)
+    handleSetPresetLimit(LimitPriceMode.FivePercent)
   }, [handleSetPresetLimit])
 
   const handleSetTenPercentLimit = useCallback(() => {
-    handleSetPresetLimit(PresetLimit.TenPercent)
+    handleSetPresetLimit(LimitPriceMode.TenPercent)
   }, [handleSetPresetLimit])
 
   const handleTogglePriceDirection = useCallback(() => {
@@ -277,7 +277,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimitPrice === PresetLimit.Market}
+          isActive={presetLimitPrice === LimitPriceMode.Market}
           onClick={handleSetMarketLimit}
           isDisabled={isLoading}
         >
@@ -286,7 +286,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimitPrice === PresetLimit.OnePercent}
+          isActive={presetLimitPrice === LimitPriceMode.OnePercent}
           onClick={handleSetOnePercentLimit}
           isDisabled={isLoading}
         >
@@ -295,7 +295,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimitPrice === PresetLimit.TwoPercent}
+          isActive={presetLimitPrice === LimitPriceMode.TwoPercent}
           onClick={handleSetTwoPercentLimit}
           isDisabled={isLoading}
         >
@@ -304,7 +304,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimitPrice === PresetLimit.FivePercent}
+          isActive={presetLimitPrice === LimitPriceMode.FivePercent}
           onClick={handleSetFivePercentLimit}
           isDisabled={isLoading}
         >
@@ -313,7 +313,7 @@ export const LimitOrderConfig = ({
         <Button
           variant='ghost'
           size='sm'
-          isActive={presetLimitPrice === PresetLimit.TenPercent}
+          isActive={presetLimitPrice === LimitPriceMode.TenPercent}
           onClick={handleSetTenPercentLimit}
           isDisabled={isLoading}
         >

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
@@ -132,7 +132,7 @@ export const LimitOrderConfirm = () => {
         borderColor='border.base'
         bg='background.surface.raised.base'
       >
-        <CardHeader px={6} pt={4} borderWidth={0}>
+        <CardHeader px={6} pt={4} borderBottomWidth={0}>
           <WithBackButton onBack={handleBack}>
             <Heading textAlign='center' fontSize='lg'>
               <Text translation='limitOrder.confirm' />

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -241,6 +241,7 @@ export const LimitOrderInput = ({
   // TODO: If we introduce polling of quotes, we will need to add logic inside `LimitOrderConfig` to
   // not reset the user's config unless the asset pair changes.
   useEffect(() => {
+    console.log('resetting')
     setLimitPrice({
       [PriceDirection.BuyAssetDenomination]: marketPriceBuyAsset,
       [PriceDirection.SellAssetDenomination]: bn(1).div(marketPriceBuyAsset).toFixed(),

--- a/src/state/slices/common/tradeInputBase/createTradeInputBaseSlice.ts
+++ b/src/state/slices/common/tradeInputBase/createTradeInputBaseSlice.ts
@@ -1,4 +1,4 @@
-import type { Draft, PayloadAction, SliceCaseReducers } from '@reduxjs/toolkit'
+import type { Draft, PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
@@ -109,9 +109,17 @@ export type BaseReducers<T extends TradeInputBaseState> = ReturnType<typeof getB
  * @returns A configured Redux slice with all the base trade input reducers
  */
 export function createTradeInputBaseSlice<
+  S extends Record<string, any>,
   T extends TradeInputBaseState,
-  S extends (baseReducers: BaseReducers<T>) => SliceCaseReducers<T>,
->({ name, initialState, extraReducers }: { name: string; initialState: T; extraReducers: S }) {
+>({
+  name,
+  initialState,
+  extraReducers,
+}: {
+  name: string
+  initialState: T
+  extraReducers: (baseReducers: BaseReducers<T>) => S
+}) {
   const baseReducers = getBaseReducers(initialState)
   return createSlice({
     name,

--- a/src/state/slices/common/tradeInputBase/createTradeInputBaseSlice.ts
+++ b/src/state/slices/common/tradeInputBase/createTradeInputBaseSlice.ts
@@ -1,4 +1,4 @@
-import type { PayloadAction } from '@reduxjs/toolkit'
+import type { Draft, PayloadAction, SliceCaseReducers } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
 import type { AccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
@@ -18,6 +18,84 @@ export interface TradeInputBaseState {
   slippagePreferencePercentage: string | undefined
 }
 
+const getBaseReducers = <T extends TradeInputBaseState>(initialState: T) => ({
+  clear: () => initialState,
+  setBuyAsset: (state: Draft<T>, action: PayloadAction<Asset>) => {
+    const asset = action.payload
+    if (asset.assetId === state.buyAsset.assetId) return
+
+    if (asset.assetId === state.sellAsset.assetId) {
+      state.sellAsset = state.buyAsset
+      state.sellAmountCryptoPrecision = '0'
+    }
+
+    if (asset.chainId !== state.buyAsset.chainId) {
+      state.buyAccountId = undefined
+    }
+
+    state.manualReceiveAddress = undefined
+    state.buyAsset = asset
+  },
+  setSellAsset: (state: Draft<T>, action: PayloadAction<Asset>) => {
+    const asset = action.payload
+    if (asset.assetId === state.sellAsset.assetId) return
+
+    if (asset.assetId === state.buyAsset.assetId) {
+      state.buyAsset = state.sellAsset
+    }
+
+    state.sellAmountCryptoPrecision = '0'
+
+    if (asset.chainId !== state.sellAsset.chainId) {
+      state.sellAccountId = undefined
+    }
+
+    state.manualReceiveAddress = undefined
+    state.sellAsset = action.payload
+  },
+  setSellAccountId: (state: Draft<T>, action: PayloadAction<AccountId | undefined>) => {
+    state.sellAccountId = action.payload
+  },
+  setBuyAccountId: (state: Draft<T>, action: PayloadAction<AccountId | undefined>) => {
+    state.buyAccountId = action.payload
+  },
+  setSellAmountCryptoPrecision: (state: Draft<T>, action: PayloadAction<string>) => {
+    state.sellAmountCryptoPrecision = bnOrZero(action.payload).toString()
+  },
+  switchAssets: (state: Draft<T>) => {
+    const buyAsset = state.sellAsset
+    state.sellAsset = state.buyAsset
+    state.buyAsset = buyAsset
+    state.sellAmountCryptoPrecision = '0'
+
+    const sellAssetAccountId = state.sellAccountId
+    state.sellAccountId = state.buyAccountId
+    state.buyAccountId = sellAssetAccountId
+
+    state.manualReceiveAddress = undefined
+  },
+  setManualReceiveAddress: (state: Draft<T>, action: PayloadAction<string | undefined>) => {
+    state.manualReceiveAddress = action.payload
+  },
+  setIsManualReceiveAddressValidating: (state: Draft<T>, action: PayloadAction<boolean>) => {
+    state.isManualReceiveAddressValidating = action.payload
+  },
+  setIsManualReceiveAddressEditing: (state: Draft<T>, action: PayloadAction<boolean>) => {
+    state.isManualReceiveAddressEditing = action.payload
+  },
+  setIsManualReceiveAddressValid: (state: Draft<T>, action: PayloadAction<boolean | undefined>) => {
+    state.isManualReceiveAddressValid = action.payload
+  },
+  setIsInputtingFiatSellAmount: (state: Draft<T>, action: PayloadAction<boolean>) => {
+    state.isInputtingFiatSellAmount = action.payload
+  },
+  setSlippagePreferencePercentage: (state: Draft<T>, action: PayloadAction<string | undefined>) => {
+    state.slippagePreferencePercentage = action.payload
+  },
+})
+
+export type BaseReducers<T extends TradeInputBaseState> = ReturnType<typeof getBaseReducers<T>>
+
 /**
  * Creates a reusable Redux slice for trade input functionality. This is a higher-order slice
  * factory that generates a slice with common trade-related reducers. It provides base functionality
@@ -31,98 +109,14 @@ export interface TradeInputBaseState {
  * @returns A configured Redux slice with all the base trade input reducers
  */
 export function createTradeInputBaseSlice<
-  S extends Record<string, any>,
   T extends TradeInputBaseState,
->({
-  name,
-  initialState,
-  extraReducers = {} as S,
-}: {
-  name: string
-  initialState: T
-  extraReducers?: S
-}) {
+  S extends (baseReducers: BaseReducers<T>) => SliceCaseReducers<T>,
+>({ name, initialState, extraReducers }: { name: string; initialState: T; extraReducers: S }) {
+  const baseReducers = getBaseReducers(initialState)
   return createSlice({
     name,
     initialState,
-    reducers: {
-      clear: () => initialState,
-      setBuyAsset: (state, action: PayloadAction<Asset>) => {
-        const asset = action.payload
-        if (asset.assetId === state.buyAsset.assetId) return
-
-        if (asset.assetId === state.sellAsset.assetId) {
-          state.sellAsset = state.buyAsset
-          state.sellAmountCryptoPrecision = '0'
-        }
-
-        if (asset.chainId !== state.buyAsset.chainId) {
-          state.buyAccountId = undefined
-        }
-
-        state.manualReceiveAddress = undefined
-        state.buyAsset = asset
-      },
-      setSellAsset: (state, action: PayloadAction<Asset>) => {
-        const asset = action.payload
-        if (asset.assetId === state.sellAsset.assetId) return
-
-        if (asset.assetId === state.buyAsset.assetId) {
-          state.buyAsset = state.sellAsset
-        }
-
-        state.sellAmountCryptoPrecision = '0'
-
-        if (asset.chainId !== state.sellAsset.chainId) {
-          state.sellAccountId = undefined
-        }
-
-        state.manualReceiveAddress = undefined
-        state.sellAsset = action.payload
-      },
-      setSellAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
-        state.sellAccountId = action.payload
-      },
-      setBuyAccountId: (state, action: PayloadAction<AccountId | undefined>) => {
-        state.buyAccountId = action.payload
-      },
-      setSellAmountCryptoPrecision: (state, action: PayloadAction<string>) => {
-        state.sellAmountCryptoPrecision = bnOrZero(action.payload).toString()
-      },
-      switchAssets: state => {
-        const buyAsset = state.sellAsset
-        state.sellAsset = state.buyAsset
-        state.buyAsset = buyAsset
-        state.sellAmountCryptoPrecision = '0'
-
-        const sellAssetAccountId = state.sellAccountId
-        state.sellAccountId = state.buyAccountId
-        state.buyAccountId = sellAssetAccountId
-
-        state.manualReceiveAddress = undefined
-      },
-      setManualReceiveAddress: (state, action: PayloadAction<string | undefined>) => {
-        state.manualReceiveAddress = action.payload
-      },
-      setIsManualReceiveAddressValidating: (state, action: PayloadAction<boolean>) => {
-        state.isManualReceiveAddressValidating = action.payload
-      },
-      setIsManualReceiveAddressEditing: (state, action: PayloadAction<boolean>) => {
-        state.isManualReceiveAddressEditing = action.payload
-      },
-      setIsManualReceiveAddressValid: (state, action: PayloadAction<boolean | undefined>) => {
-        state.isManualReceiveAddressValid = action.payload
-      },
-      setIsInputtingFiatSellAmount: (state, action: PayloadAction<boolean>) => {
-        state.isInputtingFiatSellAmount = action.payload
-      },
-      setSlippagePreferencePercentage: (
-        state: TradeInputBaseState,
-        action: PayloadAction<string | undefined>,
-      ) => {
-        state.slippagePreferencePercentage = action.payload
-      },
-      ...extraReducers,
-    },
+    // Note: extraReducers are added last to deliberately override baseReducers where needed
+    reducers: { ...baseReducers, ...extraReducers(baseReducers) },
   })
 }

--- a/src/state/slices/limitOrderInputSlice/constants.ts
+++ b/src/state/slices/limitOrderInputSlice/constants.ts
@@ -13,10 +13,12 @@ export enum PriceDirection {
   SellAssetDenomination = 'sellAssetDenomination',
 }
 
-export enum PresetLimit {
+export enum LimitPriceMode {
   Market = 'market',
   OnePercent = 'onePercent',
   TwoPercent = 'twoPercent',
   FivePercent = 'fivePercent',
   TenPercent = 'tenPercent',
+  // TODO: Implement me
+  // ManualValue = 'manualValue',
 }

--- a/src/state/slices/limitOrderInputSlice/constants.ts
+++ b/src/state/slices/limitOrderInputSlice/constants.ts
@@ -12,3 +12,11 @@ export enum PriceDirection {
   BuyAssetDenomination = 'buyAssetDenomination',
   SellAssetDenomination = 'sellAssetDenomination',
 }
+
+export enum PresetLimit {
+  Market = 'market',
+  OnePercent = 'onePercent',
+  TwoPercent = 'twoPercent',
+  FivePercent = 'fivePercent',
+  TenPercent = 'tenPercent',
+}

--- a/src/state/slices/limitOrderInputSlice/constants.ts
+++ b/src/state/slices/limitOrderInputSlice/constants.ts
@@ -19,6 +19,5 @@ export enum LimitPriceMode {
   TwoPercent = 'twoPercent',
   FivePercent = 'fivePercent',
   TenPercent = 'tenPercent',
-  // TODO: Implement me
-  // ManualValue = 'manualValue',
+  CustomValue = 'customValue',
 }

--- a/src/state/slices/limitOrderInputSlice/helpers.ts
+++ b/src/state/slices/limitOrderInputSlice/helpers.ts
@@ -1,7 +1,7 @@
 import { assertUnreachable } from '@shapeshiftoss/utils'
 import dayjs from 'dayjs'
 
-import { ExpiryOption } from './constants'
+import { ExpiryOption, PriceDirection } from './constants'
 
 export const expiryOptionToUnixTimestamp = (expiry: ExpiryOption): number => {
   switch (expiry) {
@@ -18,4 +18,10 @@ export const expiryOptionToUnixTimestamp = (expiry: ExpiryOption): number => {
     default:
       assertUnreachable(expiry)
   }
+}
+
+export const getOppositePriceDirection = (priceDirection: PriceDirection) => {
+  return priceDirection === PriceDirection.BuyAssetDenomination
+    ? PriceDirection.SellAssetDenomination
+    : PriceDirection.BuyAssetDenomination
 }

--- a/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
+++ b/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
@@ -10,12 +10,12 @@ import type {
   TradeInputBaseState,
 } from '../common/tradeInputBase/createTradeInputBaseSlice'
 import { createTradeInputBaseSlice } from '../common/tradeInputBase/createTradeInputBaseSlice'
-import { ExpiryOption, PresetLimit, PriceDirection } from './constants'
+import { ExpiryOption, LimitPriceMode, PriceDirection } from './constants'
 
 export type LimitOrderInputState = {
   limitPriceDirection: PriceDirection
   limitPrice: Record<PriceDirection, string>
-  presetLimit: PresetLimit | undefined
+  presetLimit: LimitPriceMode | undefined
   expiry: ExpiryOption
 } & TradeInputBaseState
 
@@ -36,7 +36,7 @@ const initialState: LimitOrderInputState = {
     [PriceDirection.BuyAssetDenomination]: '0',
     [PriceDirection.SellAssetDenomination]: '0',
   },
-  presetLimit: PresetLimit.Market,
+  presetLimit: LimitPriceMode.Market,
   expiry: ExpiryOption.SevenDays,
 }
 
@@ -59,7 +59,7 @@ export const limitOrderInput = createTradeInputBaseSlice({
     },
     setPresetLimit: (
       state: LimitOrderInputState,
-      action: PayloadAction<PresetLimit | undefined>,
+      action: PayloadAction<LimitPriceMode | undefined>,
     ) => {
       state.presetLimit = action.payload
     },

--- a/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
+++ b/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
@@ -1,7 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { foxAssetId, usdcAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
-import { pick } from 'lodash'
+import pick from 'lodash/pick'
 import { localAssetData } from 'lib/asset-service'
 
 import { defaultAsset } from '../assetsSlice/assetsSlice'

--- a/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
+++ b/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
@@ -1,15 +1,20 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { foxAssetId, usdcAssetId } from '@shapeshiftoss/caip'
+import type { Asset } from '@shapeshiftoss/types'
 import { localAssetData } from 'lib/asset-service'
 
 import { defaultAsset } from '../assetsSlice/assetsSlice'
-import type { TradeInputBaseState } from '../common/tradeInputBase/createTradeInputBaseSlice'
+import type {
+  BaseReducers,
+  TradeInputBaseState,
+} from '../common/tradeInputBase/createTradeInputBaseSlice'
 import { createTradeInputBaseSlice } from '../common/tradeInputBase/createTradeInputBaseSlice'
-import { ExpiryOption, PriceDirection } from './constants'
+import { ExpiryOption, PresetLimit, PriceDirection } from './constants'
 
 export type LimitOrderInputState = {
   limitPriceDirection: PriceDirection
   limitPrice: Record<PriceDirection, string>
+  presetLimit: PresetLimit | undefined
   expiry: ExpiryOption
 } & TradeInputBaseState
 
@@ -30,18 +35,25 @@ const initialState: LimitOrderInputState = {
     [PriceDirection.BuyAssetDenomination]: '0',
     [PriceDirection.SellAssetDenomination]: '0',
   },
+  presetLimit: PresetLimit.Market,
   expiry: ExpiryOption.SevenDays,
 }
 
 export const limitOrderInput = createTradeInputBaseSlice({
   name: 'limitOrderInput',
   initialState,
-  extraReducers: {
+  extraReducers: (baseReducers: BaseReducers<LimitOrderInputState>) => ({
     setLimitPrice: (
       state: LimitOrderInputState,
       action: PayloadAction<Record<PriceDirection, string>>,
     ) => {
       state.limitPrice = action.payload
+    },
+    setPresetLimit: (
+      state: LimitOrderInputState,
+      action: PayloadAction<PresetLimit | undefined>,
+    ) => {
+      state.presetLimit = action.payload
     },
     setLimitPriceDirection: (
       state: LimitOrderInputState,
@@ -52,5 +64,14 @@ export const limitOrderInput = createTradeInputBaseSlice({
     setExpiry: (state: LimitOrderInputState, action: PayloadAction<ExpiryOption>) => {
       state.expiry = action.payload
     },
-  },
+    setBuyAsset: (state, action: PayloadAction<Asset>) => {
+      baseReducers.setBuyAsset(state, action)
+    },
+    setSellAsset: (state, action: PayloadAction<Asset>) => {
+      baseReducers.setSellAsset(state, action)
+    },
+    switchAssets: state => {
+      baseReducers.switchAssets(state)
+    },
+  }),
 })

--- a/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
+++ b/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
@@ -1,6 +1,7 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
 import { foxAssetId, usdcAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
+import { pick } from 'lodash'
 import { localAssetData } from 'lib/asset-service'
 
 import { defaultAsset } from '../assetsSlice/assetsSlice'
@@ -39,6 +40,13 @@ const initialState: LimitOrderInputState = {
   expiry: ExpiryOption.SevenDays,
 }
 
+const resetLimitOrderConfig = (state: LimitOrderInputState) => {
+  Object.assign(
+    state,
+    pick(initialState, ['limitPrice', 'limitPriceDirection', 'presetLimit', 'expiry']),
+  )
+}
+
 export const limitOrderInput = createTradeInputBaseSlice({
   name: 'limitOrderInput',
   initialState,
@@ -66,12 +74,15 @@ export const limitOrderInput = createTradeInputBaseSlice({
     },
     setBuyAsset: (state: LimitOrderInputState, action: PayloadAction<Asset>) => {
       baseReducers.setBuyAsset(state, action)
+      resetLimitOrderConfig(state)
     },
     setSellAsset: (state: LimitOrderInputState, action: PayloadAction<Asset>) => {
       baseReducers.setSellAsset(state, action)
+      resetLimitOrderConfig(state)
     },
     switchAssets: (state: LimitOrderInputState) => {
       baseReducers.switchAssets(state)
+      resetLimitOrderConfig(state)
     },
   }),
 })

--- a/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
+++ b/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
@@ -64,13 +64,13 @@ export const limitOrderInput = createTradeInputBaseSlice({
     setExpiry: (state: LimitOrderInputState, action: PayloadAction<ExpiryOption>) => {
       state.expiry = action.payload
     },
-    setBuyAsset: (state, action: PayloadAction<Asset>) => {
+    setBuyAsset: (state: LimitOrderInputState, action: PayloadAction<Asset>) => {
       baseReducers.setBuyAsset(state, action)
     },
-    setSellAsset: (state, action: PayloadAction<Asset>) => {
+    setSellAsset: (state: LimitOrderInputState, action: PayloadAction<Asset>) => {
       baseReducers.setSellAsset(state, action)
     },
-    switchAssets: state => {
+    switchAssets: (state: LimitOrderInputState) => {
       baseReducers.switchAssets(state)
     },
   }),

--- a/src/state/slices/limitOrderInputSlice/selectors.ts
+++ b/src/state/slices/limitOrderInputSlice/selectors.ts
@@ -2,7 +2,7 @@ import { bn, toBaseUnit } from '@shapeshiftoss/utils'
 import { createSelector } from 'reselect'
 
 import { createTradeInputBaseSelectors } from '../common/tradeInputBase/createTradeInputBaseSelectors'
-import { PriceDirection } from './constants'
+import { getOppositePriceDirection } from './helpers'
 import type { LimitOrderInputState } from './limitOrderInputSlice'
 
 // Shared selectors from the base trade input slice that handle common functionality like input
@@ -42,17 +42,15 @@ export const selectLimitPriceDirection = createSelector(
 export const selectLimitPriceOppositeDirection = createSelector(
   selectLimitPriceDirection,
   priceDirection => {
-    return priceDirection === PriceDirection.BuyAssetDenomination
-      ? PriceDirection.SellAssetDenomination
-      : PriceDirection.BuyAssetDenomination
+    return getOppositePriceDirection(priceDirection)
   },
 )
 
 export const selectLimitPrice = createSelector(selectBaseSlice, baseSlice => baseSlice.limitPrice)
 
-export const selectPresetLimitPrice = createSelector(
+export const selectLimitPriceMode = createSelector(
   selectBaseSlice,
-  baseSlice => baseSlice.presetLimit,
+  baseSlice => baseSlice.limitPriceMode,
 )
 
 export const selectLimitPriceForSelectedPriceDirection = createSelector(

--- a/src/state/slices/limitOrderInputSlice/selectors.ts
+++ b/src/state/slices/limitOrderInputSlice/selectors.ts
@@ -50,6 +50,11 @@ export const selectLimitPriceOppositeDirection = createSelector(
 
 export const selectLimitPrice = createSelector(selectBaseSlice, baseSlice => baseSlice.limitPrice)
 
+export const selectPresetLimitPrice = createSelector(
+  selectBaseSlice,
+  baseSlice => baseSlice.presetLimit,
+)
+
 export const selectLimitPriceForSelectedPriceDirection = createSelector(
   selectBaseSlice,
   selectLimitPriceDirection,

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -1,3 +1,4 @@
+import type { SliceCaseReducers } from '@reduxjs/toolkit'
 import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { localAssetData } from 'lib/asset-service'
 
@@ -24,7 +25,7 @@ const initialState: TradeInputState = {
 export const tradeInput = createTradeInputBaseSlice({
   name: 'tradeInput',
   initialState,
-  extraReducers: {
+  extraReducers: (_baseReducers: SliceCaseReducers<TradeInputState>) => ({
     // Add any reducers specific to tradeInput slice here that aren't shared with other slices
-  },
+  }),
 })

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -3,7 +3,7 @@ import type { ReduxState } from 'state/reducer'
 import { defaultAsset } from 'state/slices/assetsSlice/assetsSlice'
 import {
   ExpiryOption,
-  PresetLimit,
+  LimitPriceMode,
   PriceDirection,
 } from 'state/slices/limitOrderInputSlice/constants'
 import { CurrencyFormats, HomeMarketView } from 'state/slices/preferencesSlice/preferencesSlice'
@@ -259,7 +259,7 @@ export const mockStore: ReduxState = {
       [PriceDirection.BuyAssetDenomination]: '0',
       [PriceDirection.SellAssetDenomination]: '0',
     },
-    presetLimit: PresetLimit.Market,
+    presetLimit: LimitPriceMode.Market,
     expiry: ExpiryOption.SevenDays,
     limitPriceDirection: PriceDirection.BuyAssetDenomination,
   },

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -1,7 +1,11 @@
 import { DEFAULT_HISTORY_TIMEFRAME } from 'constants/Config'
 import type { ReduxState } from 'state/reducer'
 import { defaultAsset } from 'state/slices/assetsSlice/assetsSlice'
-import { ExpiryOption, PriceDirection } from 'state/slices/limitOrderInputSlice/constants'
+import {
+  ExpiryOption,
+  PresetLimit,
+  PriceDirection,
+} from 'state/slices/limitOrderInputSlice/constants'
 import { CurrencyFormats, HomeMarketView } from 'state/slices/preferencesSlice/preferencesSlice'
 
 const mockApiFactory = <T extends unknown>(reducerPath: T) => ({
@@ -255,6 +259,7 @@ export const mockStore: ReduxState = {
       [PriceDirection.BuyAssetDenomination]: '0',
       [PriceDirection.SellAssetDenomination]: '0',
     },
+    presetLimit: PresetLimit.Market,
     expiry: ExpiryOption.SevenDays,
     limitPriceDirection: PriceDirection.BuyAssetDenomination,
   },

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -259,7 +259,7 @@ export const mockStore: ReduxState = {
       [PriceDirection.BuyAssetDenomination]: '0',
       [PriceDirection.SellAssetDenomination]: '0',
     },
-    presetLimit: LimitPriceMode.Market,
+    limitPriceMode: LimitPriceMode.Market,
     expiry: ExpiryOption.SevenDays,
     limitPriceDirection: PriceDirection.BuyAssetDenomination,
   },


### PR DESCRIPTION
## Description

Fixes issue where custom limit price input is lost when navigating back to limit input from preview step.

Moves `presetLimit` into redux and moves the reset of limit order config on asset change into redux, so component mount doesn't trigger a reset.

Includes an improvement to `createTradeInputBaseSlice` to allow us to compose redux actions (needed for this PR).

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8216

## Risk

> High Risk PRs Require 2 approvals

Low risk. Review redux changes with care though.

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Check limit orders config is only reset when changing assets.

Worth giving spot trades a test in case the are broken for some surprise reason.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo:
https://jam.dev/c/d1b1416d-d0d8-48f4-b6d2-c162a7801dc2