### PR TITLE
Fix redundancy in `investor.md`

### DIFF
--- a/docs/investor.md
+++ b/docs/investor.md
@@ -240,7 +240,7 @@ However, many protocols implement additional features.
 
 We support some common additional features through `Extension` interfaces.
 
-If your protocol implements a feature that's also common among other protocols, you may submit an Issue or PR to add an additional `Extension`.
+If your protocol implements a feature that's also common among other protocols, you may submit an Issue or PR to add an `Extension`.
 
 ## `ApprovalRequired<T>`
 


### PR DESCRIPTION
This PR corrects a redundancy in the documentation by revising the phrase "add an additional `Extension`" to "add an `Extension`." This improves clarity and eliminates unnecessary repetition in the `investor.md` file.

## Risk

This change is **low-risk** as it only updates the documentation without affecting any functionality or code.

