### PR TITLE
feat: unrug lifi in release

### DIFF
--- a/packages/swapper/src/swappers/LifiSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/endpoints.ts
@@ -4,6 +4,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { fromChainId } from '@shapeshiftoss/caip'
 import { evm } from '@shapeshiftoss/chain-adapters'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { bn } from '@shapeshiftoss/utils'
 import type { Result } from '@sniptt/monads/build'
 import { Err } from '@sniptt/monads/build'
 import type { InterpolationOptions } from 'node-polyglot'
@@ -153,7 +154,9 @@ export const lifiApi: SwapperApi = {
       adapter: assertGetEvmChainAdapter(chainId),
       data: data.toString(),
       to,
-      value,
+      // This looks odd but we need this, else unchained estimate calls will fail with:
+      // "invalid decimal value (argument=\"value\", value=\"0x0\", code=INVALID_ARGUMENT, version=bignumber/5.7.0)"
+      value: bn(value.toString()).toString(),
       from,
       supportsEIP1559,
     })

--- a/packages/swapper/src/swappers/LifiSwapper/utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/utils/getNetworkFeeCryptoBaseUnit/getNetworkFeeCryptoBaseUnit.ts
@@ -4,6 +4,7 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { evm } from '@shapeshiftoss/chain-adapters'
 import { viemClientByChainId } from '@shapeshiftoss/contracts'
 import type { EvmChainId, KnownChainIds } from '@shapeshiftoss/types'
+import { bn } from '@shapeshiftoss/utils'
 import { getContract } from 'viem'
 
 import type { SwapperDeps } from '../../../../types'
@@ -46,7 +47,9 @@ export const getNetworkFeeCryptoBaseUnit = async ({
       adapter,
       data,
       to,
-      value,
+      // This looks odd but we need this, else unchained estimate calls will fail with:
+      // "invalid decimal value (argument=\"value\", value=\"0x0\", code=INVALID_ARGUMENT, version=bignumber/5.7.0)"
+      value: bn(value.toString()).toString(),
       from,
       supportsEIP1559,
     })


### PR DESCRIPTION
## Description

Does what it says on the code comments, see release thread https://discord.com/channels/554694662431178782/876953436908822568/1315820902285574144

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low to none, only brings *back* weird double `toString()` in Li.Fi's `getUnsignedEvmTransaction()`, and in the newly added Li.Fi estimates in `getNetworkFeeCryptoBaseUnit` 

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Li.Fi token sells with a token allowance granted for the token do not fail with either `Failed to estimate network fees` (locally development server) or `Failed to execute 'json' on 'Response'` (upstream builds)
- Li.Fi native asset sells do not fail with either `Failed to estimate network fees` (locally development server) or `Failed to execute 'json' on 'Response'` (upstream builds)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- Token with allowance granted

<img width="1485" alt="Screenshot 2024-12-10 at 12 25 48" src="https://github.com/user-attachments/assets/b967e6a4-9ca8-4bfb-aed7-f3cf0f4ca0e3">

- Native asset

<img width="1491" alt="Screenshot 2024-12-10 at 12 26 30" src="https://github.com/user-attachments/assets/da10fd36-2526-476f-a006-24b2a48552e9">

Note the "Not enough gas" in Rabby is because Rabby autoselects fast:

<img width="454" alt="image" src="https://github.com/user-attachments/assets/bff0f1a2-0bbf-4037-9f8b-1a88226cd16f">

If going with "Normal", we're gucci:

<img width="430" alt="image" src="https://github.com/user-attachments/assets/589096a9-0e05-4179-919b-bd0ec60437df">
