### PR TITLE
fix: jupiter quote is never fetched

### DIFF
--- a/packages/swapper/src/swappers/JupiterSwapper/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/JupiterSwapper/swapperApi/getTradeRate.ts
@@ -199,7 +199,7 @@ export const getTradeRate = async (
   const tradeRate: TradeRate = {
     id: uuid(),
     rate: inputOutputRate,
-    receiveAddress,
+    receiveAddress: undefined,
     potentialAffiliateBps: affiliateBps,
     affiliateBps,
     accountNumber,


### PR DESCRIPTION
## Description

I didn't understand what 🐐 @gomesalexandre did learn me while talking about rate and quotes and it seems that I missed the fact that I was pushing the receiveAddress in the rate, which shouldn't be the case, it was disabling the sign button as the quote was never fetched because of this

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>


## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to swap using jupiter, or at least get a quote, the `Sign transaction` should not be disabled anymore and you should be able to sign the TX
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/d127a1bb-bcd3-4aa2-be3c-1bca8d36ed93