### PR TITLE
fix: lifi bridges final trade quote

### DIFF
--- a/packages/swapper/src/swappers/LifiSwapper/utils/types.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/utils/types.ts
@@ -2,13 +2,18 @@ import type { Route } from '@lifi/sdk'
 
 import type { TradeQuote, TradeRate } from '../../../types'
 
+export type LifiTools = {
+  bridges: string[] | undefined
+  exchanges: string[] | undefined
+}
+
 export interface LifiTradeQuote extends TradeQuote {
   selectedLifiRoute?: Route
-  lifiTools?: string[] | undefined
+  lifiTools?: LifiTools
 }
 export interface LifiTradeRate extends TradeRate {
   selectedLifiRoute?: Route
-  lifiTools?: string[] | undefined
+  lifiTools?: LifiTools
 }
 
 export type LifiTool = {

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -29,6 +29,7 @@ import type { InterpolationOptions } from 'node-polyglot'
 import type { Address } from 'viem'
 
 import type { CowMessageToSign } from './swappers/CowSwapper/types'
+import type { LifiTools } from './swappers/LifiSwapper/utils/types'
 import type { makeSwapperAxiosServiceMonadic } from './utils'
 
 // TODO: Rename all properties in this type to be camel case and not react specific
@@ -157,7 +158,7 @@ type CommonTradeInputBase = {
   potentialAffiliateBps: string
   affiliateBps: string
   allowMultiHop: boolean
-  lifiAllowedTools?: string[] | undefined
+  lifiAllowedTools?: LifiTools
   slippageTolerancePercentageDecimal?: string
 }
 

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteInput.ts
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/getTradeQuoteInput.ts
@@ -2,6 +2,7 @@ import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
 import type { GetTradeQuoteInput } from '@shapeshiftoss/swapper'
+import type { LifiTradeQuote } from '@shapeshiftoss/swapper/src/swappers/LifiSwapper/utils/types'
 import type { Asset, CosmosSdkChainId, EvmChainId, UtxoChainId } from '@shapeshiftoss/types'
 import { UtxoAccountType } from '@shapeshiftoss/types'
 import type { TradeQuoteInputCommonArgs } from 'components/MultiHopTrade/types'
@@ -19,7 +20,7 @@ export type GetTradeQuoteInputArgs = {
   slippageTolerancePercentageDecimal?: string
   sellAmountBeforeFeesCryptoPrecision: string
   allowMultiHop: boolean
-  lifiAllowedTools?: string[]
+  lifiAllowedTools?: LifiTradeQuote['lifiTools'] | undefined
   // Potential affiliate bps - may be waved out either entirely or partially with FOX discounts
   potentialAffiliateBps: string
   // Actual affiliate bps - if the FOX discounts is off, this will be the same as *affiliateBps*


### PR DESCRIPTION
## Description

This PR ensures that we properly populate allowed bridge (as gotten from rate time as `[bridge]` at rate time), under the *bridges* allowedlist for Li.Fi, vs. us erroneously doing so under the `exchanges` umbrella previously.

This means that all bridges were guaranteed to fail at quote time, as bridges and exchanges are two different notions / schemas, and passing one in the other would fail validation upstream.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8344

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, small risk of regular trades broken but easily regression testable

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- When attempting a Li.Fi bridge, you're not getting a blank screen at final quote time
- Well, there is one ramification to that: you may still get a blank screen at final quote time, but that's an entirely different issue and unrelated to bridges: https://github.com/shapeshift/web/issues/8347
- Same-chain Li.Fi swaps are still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Li.Fi Bridges in develop

https://jam.dev/c/d583435a-75b8-4e7d-94a2-99858b1f233f

- Li.Fi Bridges in this diff

https://jam.dev/c/9c894f4e-ea0f-4a5d-a04f-29d70266c9a8

- Li.Fi same-chain swaps in this diff

https://jam.dev/c/f39adad4-1bdf-49eb-b5ad-74b2d9161c0a

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"release","parentHead":"0c7156b2db0f4a6da9dc0de4af9102e81449597b","trunk":"develop"}
```
-->
