### PR TITLE
feat: cosmos sdk BIP44Params migration

### DIFF
--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -8,6 +8,7 @@ import { clearOpportunities } from './clearOpportunities'
 import { clearPortfolio } from './clearPortfolio'
 import { clearSnapshot } from './clearSnapshot'
 import { clearTxHistory } from './clearTxHistory'
+import { updateCosmosSdkAccountMetadata } from './updateCosmosSdkAccountMetadata'
 
 export const clearTxHistoryMigrations = {
   0: clearTxHistory,
@@ -17,9 +18,10 @@ export const clearOpportunitiesMigrations = {
   0: clearOpportunities,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
-export const clearPortfolioMigrations = {
+export const portfolioMigrations = {
   0: clearPortfolio,
   1: clearPortfolio,
+  2: updateCosmosSdkAccountMetadata,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
 export const localWalletMigrations = {

--- a/src/state/migrations/updateCosmosSdkAccountMetadata.ts
+++ b/src/state/migrations/updateCosmosSdkAccountMetadata.ts
@@ -1,0 +1,36 @@
+import { cosmosChainId, fromAccountId, thorchainChainId } from '@shapeshiftoss/caip'
+import type { Portfolio } from 'state/slices/portfolioSlice/portfolioSliceCommon'
+
+export const updateCosmosSdkAccountMetadata = (state: Portfolio): Portfolio => {
+  const newState = {
+    ...state,
+    accountMetadata: {
+      ...state.accountMetadata,
+      byId: Object.entries(state.accountMetadata.byId).reduce((acc, [accountId, metadata]) => {
+        const { chainId } = fromAccountId(accountId)
+
+        // Explicit isChange: false and addressIndex: 0 for Cosmos SDK accounts metadata
+        if (chainId === cosmosChainId || chainId === thorchainChainId) {
+          return {
+            ...acc,
+            [accountId]: {
+              ...metadata,
+              bip44Params: {
+                ...metadata.bip44Params,
+                isChange: false,
+                addressIndex: 0,
+              },
+            },
+          }
+        }
+
+        return {
+          ...acc,
+          [accountId]: metadata,
+        }
+      }, {}),
+    },
+  }
+
+  return newState
+}

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -19,10 +19,10 @@ import {
   clearMarketDataMigrations,
   clearNftsMigrations,
   clearOpportunitiesMigrations,
-  clearPortfolioMigrations,
   clearSnapshotMigrations,
   clearTxHistoryMigrations,
   localWalletMigrations,
+  portfolioMigrations,
 } from './migrations'
 import type { AssetsState } from './slices/assetsSlice/assetsSlice'
 import { assetApi, assets } from './slices/assetsSlice/assetsSlice'
@@ -75,8 +75,8 @@ const txHistoryPersistConfig = {
 const portfolioPersistConfig = {
   key: 'portfolio',
   storage: localforage,
-  version: Math.max(...Object.keys(clearPortfolioMigrations).map(Number)),
-  migrate: createMigrate(clearPortfolioMigrations, { debug: false }),
+  version: Math.max(...Object.keys(portfolioMigrations).map(Number)),
+  migrate: createMigrate(portfolioMigrations, { debug: false }),
 }
 
 const opportunitiesPersistConfig = {


### PR DESCRIPTION
## Description

This PR adds explicit isChange: false and accountIndex: 0 for existing Cosmos SDK accounts in portfolio.
These params were *not* present in BIP44Params previously, but now *may* (or may not) after #8261 went in.

`toPath` now has a very different behaviour after https://github.com/shapeshift/web/pull/8261 went in:


https://github.com/shapeshift/web/blob/c5da4c0aaa8ab0c9f80d012d6a99dc7ff08cd144/packages/chain-adapters/src/utils/bip44.ts#L14-L24

 i.e if these aren't passed (and they won't for cached wallets, since the cached version of BIP44Params doesn't include those explicit params), we omit them altogether in the built path, which was building wrong `addressIndex` for Cosmos SDK chains, and ultimately failing `/send` at `invalid pubkey`.
 
The previous behaviour of `toPath` was to support only a single 5-parts BIP32 standard path spec (purpose, coinType, account, change, and address_index), meaning these would always be present regardless of `never` (undefined) `isChange` and `addressIndex`, vs. us now supporting partial BIP32 paths with missing parts.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8351

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium - ensure that migrations looks sane

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- *Without* clearing your cache, ensure that a native wallet setup before https://github.com/shapeshift/web/pull/8261 went in is able to broadcast Cosmos SDK Txs

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/77cc0e21-3c58-4852-9bef-785cf33fdf30

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
