### PR TITLE
feat: allow users to submit limit orders with insufficient balance

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1065,7 +1065,8 @@
       "nativeSellAssetNotSupported": "Native sell asset not supported",
       "insufficientValidTo": "Order expiry too soon",
       "excessiveValidTo": "Order expiry too far into the future",
-      "insufficientLiquidity": "Insufficient liquidity"
+      "insufficientLiquidity": "Insufficient liquidity",
+      "zeroFunds": "Non-zero sell asset balance needed"
     },
     "openOrders": "Open Orders",
     "orderHistory": "Order History",

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -426,8 +426,8 @@ export const LimitOrderInput = ({
       case !shouldShowTradeQuoteOrAwaitInput:
       case !hasUserEnteredAmount:
         return { quoteStatusTranslation: 'trade.previewTrade', isError: false }
-      case bnOrZero(sellAssetBalanceCryptoBaseUnit).lt(sellAmountCryptoBaseUnit):
-        return { quoteStatusTranslation: 'common.insufficientFunds', isError: true }
+      case bnOrZero(sellAssetBalanceCryptoBaseUnit).isZero():
+        return { quoteStatusTranslation: 'limitOrder.errors.zeroFunds', isError: true }
       case sellAsset.chainId !== buyAsset.chainId:
         return { quoteStatusTranslation: 'trade.errors.quoteCrossChainNotSupported', isError: true }
       case isNativeEvmAsset(sellAsset.assetId):
@@ -461,7 +461,6 @@ export const LimitOrderInput = ({
     quoteResponseError,
     recipientAddress,
     sellAccountId,
-    sellAmountCryptoBaseUnit,
     sellAsset.assetId,
     sellAsset.chainId,
     sellAssetBalanceCryptoBaseUnit,


### PR DESCRIPTION
## Description

So cowswap has this:

<img src="https://github.com/user-attachments/assets/eff4fdc5-1ccd-4d8d-85cc-a187ffbabaeb" width="200">

And now so do we 🎉

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

progresses #8217 (Specifically https://github.com/shapeshift/web/issues/8217#issuecomment-2506997136 )

## Risk

> High Risk PRs Require 2 approvals

Very low risk, this is a client side validation change and we are protected by the cowswap API validation.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

- Trying to order with zero balance should be prevented (not supported by cow api)
- Trying to order with non-zero, but insufficient balance should be allowed

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Full demo:
https://jam.dev/c/55da139f-a5b5-40f0-b2fd-1d995046fc49

Trying to order with zero balance should be prevented (not supported by cow api):
<img src="https://github.com/user-attachments/assets/add852b8-ea59-4309-a197-a7f121982c91" width="200">

Trying to order with non-zero, but insufficient balance should be allowed:
<img src="https://github.com/user-attachments/assets/08d309d3-bcc2-4f73-8352-9617a608d885" width="200">
