### PR TITLE
feat: limit orders card amounts polish

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1072,7 +1072,7 @@
     "status": {
       "open": "Open",
       "fulfilled": "Fulfilled",
-      "cancelled": "Cancelled",
+      "cancelled": "Canceled",
       "expired": "Expired"
     },
     "orders": "Orders",

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Center, Flex, Progress, Tag } from '@chakra-ui/react'
+import { Box, Button, Center, Flex, Progress, Tag, Tooltip } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { OrderStatus } from '@shapeshiftoss/types'
 import { bn, fromBaseUnit } from '@shapeshiftoss/utils'
@@ -10,6 +10,7 @@ import { Amount } from 'components/Amount/Amount'
 import { AssetIconWithBadge } from 'components/AssetIconWithBadge'
 import { SwapBoldIcon } from 'components/Icons/SwapBold'
 import { RawText, Text } from 'components/Text'
+import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -41,6 +42,9 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
   onCancelClick,
 }) => {
   const translate = useTranslate()
+  const {
+    number: { toCrypto },
+  } = useLocaleFormatter()
 
   const buyAsset = useAppSelector(state => selectAssetById(state, buyAssetId))
   const sellAsset = useAppSelector(state => selectAssetById(state, sellAssetId))
@@ -104,6 +108,16 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
     [status, validTo],
   )
 
+  const sellAmountCryptoFormatted = useMemo(
+    () => toCrypto(sellAmountCryptoPrecision, sellAsset?.symbol ?? ''),
+    [sellAmountCryptoPrecision, toCrypto, sellAsset],
+  )
+
+  const buyAmountCryptoFormatted = useMemo(
+    () => toCrypto(buyAmountCryptoPrecision, buyAsset?.symbol ?? ''),
+    [buyAmountCryptoPrecision, toCrypto, buyAsset],
+  )
+
   if (!buyAsset || !sellAsset) return null
 
   return (
@@ -127,29 +141,33 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
             </AssetIconWithBadge>
             <Flex gap={2} alignItems='flex-start' width='100%' minWidth={0}>
               <Flex direction='column' align='flex-start' width='100%' minWidth={0}>
-                <Box width='100%' overflow='hidden'>
-                  <Amount.Crypto
-                    value={sellAmountCryptoPrecision}
-                    symbol={sellAsset.symbol}
-                    color='gray.500'
-                    fontSize='xl'
-                    whiteSpace='nowrap'
-                    overflow='hidden'
-                    textOverflow='ellipsis'
-                    display='block'
-                  />
-                </Box>
-                <Box width='100%' overflow='hidden'>
-                  <Amount.Crypto
-                    value={buyAmountCryptoPrecision}
-                    symbol={buyAsset.symbol}
-                    fontSize='xl'
-                    whiteSpace='nowrap'
-                    overflow='hidden'
-                    textOverflow='ellipsis'
-                    display='block'
-                  />
-                </Box>
+                <Tooltip label={sellAmountCryptoFormatted}>
+                  <Box width='100%' overflow='hidden'>
+                    <Amount.Crypto
+                      value={sellAmountCryptoPrecision}
+                      symbol={sellAsset.symbol}
+                      color='gray.500'
+                      fontSize='xl'
+                      whiteSpace='nowrap'
+                      overflow='hidden'
+                      textOverflow='ellipsis'
+                      display='block'
+                    />
+                  </Box>
+                </Tooltip>
+                <Tooltip label={buyAmountCryptoFormatted}>
+                  <Box width='100%' overflow='hidden'>
+                    <Amount.Crypto
+                      value={buyAmountCryptoPrecision}
+                      symbol={buyAsset.symbol}
+                      fontSize='xl'
+                      whiteSpace='nowrap'
+                      overflow='hidden'
+                      textOverflow='ellipsis'
+                      display='block'
+                    />
+                  </Box>
+                </Tooltip>
               </Flex>
             </Flex>
           </Flex>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -119,36 +119,34 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
         {/* Asset amounts row */}
         <Flex justifyContent='space-between' alignItems='flex-start'>
           {/* Left group - icon and amounts */}
-          <Flex alignItems='flex-start' gap={4}>
+          <Flex alignItems='flex-start' gap={4} flex={1} minWidth={0}>
             <AssetIconWithBadge size='lg' assetId={buyAssetId} secondaryAssetId={sellAssetId}>
               <Center borderRadius='full' boxSize='100%' bg='purple.500'>
                 <SwapBoldIcon boxSize='100%' />
               </Center>
             </AssetIconWithBadge>
-            <Flex
-              gap={2}
-              alignItems='flex-start'
-              overflow='hidden'
-              textOverflow='ellipsis'
-              whiteSpace='nowrap'
-            >
-              <Flex direction='column' align='flex-start'>
+            <Flex gap={2} alignItems='flex-start' width='100%' minWidth={0}>
+              <Flex direction='column' align='flex-start' width='100%' minWidth={0}>
                 <Amount.Crypto
                   value={sellAmountCryptoPrecision}
                   symbol={sellAsset.symbol}
                   color='gray.500'
                   fontSize='xl'
+                  css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
                 />
                 <Amount.Crypto
                   value={buyAmountCryptoPrecision}
                   symbol={buyAsset.symbol}
                   fontSize='xl'
+                  css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
                 />
               </Flex>
             </Flex>
           </Flex>
           {/* Right group - status tag */}
-          <Tag colorScheme={tagColorScheme}>{translate(`limitOrder.status.${status}`)}</Tag>
+          <Tag flexShrink={0} colorScheme={tagColorScheme}>
+            {translate(`limitOrder.status.${status}`)}
+          </Tag>
         </Flex>
 
         {/* Price row */}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -117,13 +117,19 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
     >
       <Flex direction='column' gap={4}>
         {/* Asset amounts row */}
-        <Flex justify='space-between' align='flex-start'>
-          <Flex>
-            <AssetIconWithBadge size='lg' assetId={buyAssetId} secondaryAssetId={sellAssetId}>
-              <Center borderRadius='full' boxSize='100%' bg='purple.500'>
-                <SwapBoldIcon boxSize='100%' />
-              </Center>
-            </AssetIconWithBadge>
+        <Flex justifyContent='space-between' alignItems='flex-start'>
+          <AssetIconWithBadge size='lg' assetId={buyAssetId} secondaryAssetId={sellAssetId}>
+            <Center borderRadius='full' boxSize='100%' bg='purple.500'>
+              <SwapBoldIcon boxSize='100%' />
+            </Center>
+          </AssetIconWithBadge>
+          <Flex
+            gap={2}
+            alignItems='flex-start'
+            overflow='hidden'
+            textOverflow='ellipsis'
+            whiteSpace='nowrap'
+          >
             <Flex direction='column' align='flex-start' ml={4}>
               <Amount.Crypto
                 value={sellAmountCryptoPrecision}
@@ -138,6 +144,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
               />
             </Flex>
           </Flex>
+          {/* TODO: Warning icon with tooltip */}
           <Tag colorScheme={tagColorScheme}>{translate(`limitOrder.status.${status}`)}</Tag>
         </Flex>
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -147,7 +147,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
                       value={sellAmountCryptoPrecision}
                       symbol={sellAsset.symbol}
                       color='gray.500'
-                      fontSize='xl'
+                      fontSize='lg'
                       whiteSpace='nowrap'
                       overflow='hidden'
                       textOverflow='ellipsis'
@@ -160,7 +160,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
                     <Amount.Crypto
                       value={buyAmountCryptoPrecision}
                       symbol={buyAsset.symbol}
-                      fontSize='xl'
+                      fontSize='lg'
                       whiteSpace='nowrap'
                       overflow='hidden'
                       textOverflow='ellipsis'

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -118,33 +118,36 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
       <Flex direction='column' gap={4}>
         {/* Asset amounts row */}
         <Flex justifyContent='space-between' alignItems='flex-start'>
-          <AssetIconWithBadge size='lg' assetId={buyAssetId} secondaryAssetId={sellAssetId}>
-            <Center borderRadius='full' boxSize='100%' bg='purple.500'>
-              <SwapBoldIcon boxSize='100%' />
-            </Center>
-          </AssetIconWithBadge>
-          <Flex
-            gap={2}
-            alignItems='flex-start'
-            overflow='hidden'
-            textOverflow='ellipsis'
-            whiteSpace='nowrap'
-          >
-            <Flex direction='column' align='flex-start' ml={4}>
-              <Amount.Crypto
-                value={sellAmountCryptoPrecision}
-                symbol={sellAsset.symbol}
-                color='gray.500'
-                fontSize='xl'
-              />
-              <Amount.Crypto
-                value={buyAmountCryptoPrecision}
-                symbol={buyAsset.symbol}
-                fontSize='xl'
-              />
+          {/* Left group - icon and amounts */}
+          <Flex alignItems='flex-start' gap={4}>
+            <AssetIconWithBadge size='lg' assetId={buyAssetId} secondaryAssetId={sellAssetId}>
+              <Center borderRadius='full' boxSize='100%' bg='purple.500'>
+                <SwapBoldIcon boxSize='100%' />
+              </Center>
+            </AssetIconWithBadge>
+            <Flex
+              gap={2}
+              alignItems='flex-start'
+              overflow='hidden'
+              textOverflow='ellipsis'
+              whiteSpace='nowrap'
+            >
+              <Flex direction='column' align='flex-start'>
+                <Amount.Crypto
+                  value={sellAmountCryptoPrecision}
+                  symbol={sellAsset.symbol}
+                  color='gray.500'
+                  fontSize='xl'
+                />
+                <Amount.Crypto
+                  value={buyAmountCryptoPrecision}
+                  symbol={buyAsset.symbol}
+                  fontSize='xl'
+                />
+              </Flex>
             </Flex>
           </Flex>
-          {/* TODO: Warning icon with tooltip */}
+          {/* Right group - status tag */}
           <Tag colorScheme={tagColorScheme}>{translate(`limitOrder.status.${status}`)}</Tag>
         </Flex>
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -13,7 +13,7 @@ import { RawText, Text } from 'components/Text'
 import { selectAssetById } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
-export interface LimitOrderCardProps {
+export type LimitOrderCardProps = {
   uid: string
   buyAmountCryptoBaseUnit: string
   sellAmountCryptoBaseUnit: string
@@ -127,19 +127,29 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
             </AssetIconWithBadge>
             <Flex gap={2} alignItems='flex-start' width='100%' minWidth={0}>
               <Flex direction='column' align='flex-start' width='100%' minWidth={0}>
-                <Amount.Crypto
-                  value={sellAmountCryptoPrecision}
-                  symbol={sellAsset.symbol}
-                  color='gray.500'
-                  fontSize='xl'
-                  css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-                />
-                <Amount.Crypto
-                  value={buyAmountCryptoPrecision}
-                  symbol={buyAsset.symbol}
-                  fontSize='xl'
-                  css={{ overflow: 'hidden', textOverflow: 'ellipsis' }}
-                />
+                <Box width='100%' overflow='hidden'>
+                  <Amount.Crypto
+                    value={sellAmountCryptoPrecision}
+                    symbol={sellAsset.symbol}
+                    color='gray.500'
+                    fontSize='xl'
+                    whiteSpace='nowrap'
+                    overflow='hidden'
+                    textOverflow='ellipsis'
+                    display='block'
+                  />
+                </Box>
+                <Box width='100%' overflow='hidden'>
+                  <Amount.Crypto
+                    value={buyAmountCryptoPrecision}
+                    symbol={buyAsset.symbol}
+                    fontSize='xl'
+                    whiteSpace='nowrap'
+                    overflow='hidden'
+                    textOverflow='ellipsis'
+                    display='block'
+                  />
+                </Box>
               </Flex>
             </Flex>
           </Flex>


### PR DESCRIPTION
## Description

Adds some polish to the amounts displayed on the limit order cards:
- Handles bigly amounts with ellipsis
- Add tooltip for amounts (in case of overflow - though always enabled for simplicity)
- Reduces font size from `xl` to `lg` for better layout and more space for large amounts
- Uses 'merican spelling for `canceled`

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

prep for #8217

## Risk

> High Risk PRs Require 2 approvals

Very low risk, display of existing limit order amounts only.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Before
<img src="https://github.com/user-attachments/assets/7e6ef8da-a729-47f4-8a08-3a64f06f5edb" width="200">

After
<img src="https://github.com/user-attachments/assets/6a020439-7360-4e64-9ccf-7673ad087fbe" width="200">

With ellipsis in action
<img src="https://github.com/user-attachments/assets/781dcdab-573a-449b-9caf-f4b941003b64" width="200">
