### PR TITLE
feat: add warnings to open orders when order cannot be filled

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1079,7 +1079,13 @@
     },
     "orders": "Orders",
     "viewOrders": "View Orders",
-    "loadingOrderList": "Loading your limit orders..."
+    "loadingOrderList": "Loading your limit orders...",
+    "orderCard": {
+      "warning": {
+        "insufficientBalance": "Your wallet currently has insufficient %{symbol} balance on %{chainName} to execute this order. The order is still open and will become executable when you top up your %{symbol} balance on %{chainName}.",
+        "insufficientAllowance": "This order requires a additional allowance of %{symbol} on %{chainName} to be approved for CoW Swap to execute this order. The order is still open and will become executable when you complete the allowance approval."
+      }
+    }
   },
   "modals": {
     "assetSearch": {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -71,9 +71,9 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
     filter,
   )
 
-  const hasSufficientBalance = bnOrZero(sellAssetBalanceCryptoBaseUnit).gte(
-    sellAmountCryptoBaseUnit,
-  )
+  const hasSufficientBalance = useMemo(() => {
+    return bnOrZero(sellAssetBalanceCryptoBaseUnit).gte(sellAmountCryptoBaseUnit)
+  }, [sellAmountCryptoBaseUnit, sellAssetBalanceCryptoBaseUnit])
 
   const from = useMemo(() => {
     return fromAccountId(accountId).account
@@ -83,11 +83,15 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
     assetId: sellAssetId,
     spender: COW_SWAP_VAULT_RELAYER_ADDRESS,
     from,
+    // Don't fetch allowance if there is insufficient balance, because we wont display the allowance
+    // warning in this case.
     isDisabled: !hasSufficientBalance || status !== OrderStatus.OPEN,
   })
 
   const hasSufficientAllowance = useMemo(() => {
-    if (!allowanceOnChainCryptoBaseUnit) return
+    // If the request failed, default to true since this is just a helper and not safety critical.
+    if (!allowanceOnChainCryptoBaseUnit) return true
+
     return bn(sellAmountCryptoBaseUnit).lte(allowanceOnChainCryptoBaseUnit)
   }, [allowanceOnChainCryptoBaseUnit, sellAmountCryptoBaseUnit])
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -131,10 +131,11 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
                 )}
                 {openLimitOrders !== undefined &&
                   openLimitOrders.length > 0 &&
-                  openLimitOrders.map(({ sellAssetId, buyAssetId, order }) => (
+                  openLimitOrders.map(({ accountId, sellAssetId, buyAssetId, order }) => (
                     <LimitOrderCard
                       key={order.uid}
                       uid={order.uid}
+                      accountId={accountId}
                       sellAmountCryptoBaseUnit={order.sellAmount}
                       buyAmountCryptoBaseUnit={order.buyAmount}
                       buyAssetId={buyAssetId}
@@ -158,10 +159,11 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
             <TabPanel px={0} py={0}>
               <CardBody px={0} overflowY='auto' flex='1 1 auto'>
                 {historicalLimitOrders !== undefined && historicalLimitOrders.length > 0 ? (
-                  historicalLimitOrders.map(({ sellAssetId, buyAssetId, order }) => (
+                  historicalLimitOrders.map(({ accountId, sellAssetId, buyAssetId, order }) => (
                     <LimitOrderCard
                       key={order.uid}
                       uid={order.uid}
+                      accountId={accountId}
                       sellAmountCryptoBaseUnit={order.sellAmount}
                       buyAmountCryptoBaseUnit={order.buyAmount}
                       buyAssetId={buyAssetId}


### PR DESCRIPTION
## Description

We want 2 warnings when an order is "unable to be filled"

- Insufficient balance
- Insufficient allowance

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8217

## Risk

> High Risk PRs Require 2 approvals

Very low risk - display only.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

- Check open limit orders without sufficient balance are warned as such
- Check open limit orders without sufficient allowance are warned as such
- Check open limit orders with enough of both dont have a warning
- Check historical limit orders dont have warnings

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Demo of both cases (monkey patched)
https://jam.dev/c/91883077-b719-457f-9d37-bfc18c4d76f3

One with a warning, one without
<img src="https://github.com/user-attachments/assets/b1b5aaa7-1207-47a9-8496-b0a4beb36a2c" width="200">

