### PR TITLE
fix: trade confirm ShapeShift fee handle user currency rate

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/FeeStep.tsx
@@ -9,9 +9,12 @@ import { RawText } from 'components/Text'
 import { useLocaleFormatter } from 'hooks/useLocaleFormatter/useLocaleFormatter'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { THORSWAP_MAXIMUM_YEAR_TRESHOLD, THORSWAP_UNIT_THRESHOLD } from 'lib/fees/model'
-import { selectCalculatedFees, selectThorVotingPower } from 'state/apis/snapshot/selectors'
+import { selectThorVotingPower } from 'state/apis/snapshot/selectors'
 import { selectInputSellAmountUsd } from 'state/slices/tradeInputSlice/selectors'
-import { selectActiveQuoteAffiliateBps } from 'state/slices/tradeQuoteSlice/selectors'
+import {
+  selectActiveQuoteAffiliateBps,
+  selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
+} from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from './StepperStep'
@@ -41,13 +44,8 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   // use the fee data from the actual quote in case it varies from the theoretical calculation
   const affiliateBps = useAppSelector(selectActiveQuoteAffiliateBps)
 
-  const feeModel = 'SWAPPER'
-  const calculatedFeesFilter = useMemo(
-    () => ({ feeModel, inputAmountUsd }),
-    [feeModel, inputAmountUsd],
-  )
-  const { feeUsd: amountAfterDiscountUsd } = useAppSelector(state =>
-    selectCalculatedFees(state, calculatedFeesFilter),
+  const affiliateFeeAfterDiscountUserCurrency = useAppSelector(
+    selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
   )
 
   const handleOpenFeeModal = useCallback(() => setShowFeeModal(true), [])
@@ -62,10 +60,10 @@ export const FeeStep = ({ isLastStep }: FeeStepProps) => {
   }, [])
 
   const { title, titleProps } = useMemo(() => {
-    return bnOrZero(amountAfterDiscountUsd).gt(0)
-      ? { title: toFiat(amountAfterDiscountUsd.toFixed()) }
+    return bnOrZero(affiliateFeeAfterDiscountUserCurrency).gt(0)
+      ? { title: toFiat(bnOrZero(affiliateFeeAfterDiscountUserCurrency).toFixed()) }
       : { title: translate('trade.free'), titleProps: { color: 'text.success' } }
-  }, [amountAfterDiscountUsd, toFiat, translate])
+  }, [affiliateFeeAfterDiscountUserCurrency, toFiat, translate])
 
   const description = useMemo(() => {
     return (


### PR DESCRIPTION
## Description

This PR ensures that the ShapeShift fee at quote confirm time is displayed in user currency, vs. Frankenstein user currency symbol, but USD value currently.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8360

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Select a non-USD user currency and get a trade rate
- Ensure that the amount at confirm screen time is matching the one at rate time

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^
- In case you have to low of a balance to get fees (lower than the minimum in the fee curve), you can apply the monkey-patch below to disable balance checks:

 ```diff
 diff --git a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
index 476f5334be..30dbdd3b5d 100644
--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -226,0 +227,2 @@ export const ConfirmSummary = ({
+    return 'trade.previewTrade'
+
@@ -386 +388 @@ export const ConfirmSummary = ({
-      isError={quoteHasError}
+      isError={false}
diff --git a/src/state/apis/swapper/helpers/validateTradeQuote.ts b/src/state/apis/swapper/helpers/validateTradeQuote.ts
index a956b8a6db..fdd4b5ee48 100644
--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -300,20 +299,0 @@ export const validateTradeQuote = (
-      walletId &&
-        !firstHopHasSufficientBalanceForGas && {
-          error: TradeQuoteValidationError.InsufficientFirstHopFeeAssetBalance,
-          meta: {
-            assetSymbol: firstHopSellFeeAsset?.symbol,
-            chainSymbol: firstHopSellFeeAsset
-              ? getChainShortName(firstHopSellFeeAsset.chainId as KnownChainIds)
-              : '',
-          },
-        },
-      walletId &&
-        !secondHopHasSufficientBalanceForGas && {
-          error: TradeQuoteValidationError.InsufficientSecondHopFeeAssetBalance,
-          meta: {
-            assetSymbol: secondHopSellFeeAsset?.symbol,
-            chainSymbol: secondHopSellFeeAsset
-              ? getChainShortName(secondHopSellFeeAsset.chainId as KnownChainIds)
-              : '',
-          },
-        },
@@ -322,2 +301,0 @@ export const validateTradeQuote = (
-
-      ...insufficientBalanceForProtocolFeesErrors,
```

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="601" alt="Screenshot 2024-12-13 at 17 03 15" src="https://github.com/user-attachments/assets/a7322601-3714-464a-bba3-f8956085d704" />
<img width="582" alt="Screenshot 2024-12-13 at 17 03 21" src="https://github.com/user-attachments/assets/85f94422-2b5a-44ec-aefe-59b67b6a9a48" />


- This diff

<img width="582" alt="Screenshot 2024-12-13 at 17 03 21" src="https://github.com/user-attachments/assets/46b770b5-15bf-4878-950b-c3a319ee1bbb" />
<img width="582" alt="Screenshot 2024-12-13 at 17 03 21" src="https://github.com/user-attachments/assets/678d2f10-4e7c-4f63-9a7e-ab7bf903d34e" />
<img width="583" alt="Screenshot 2024-12-13 at 17 04 41" src="https://github.com/user-attachments/assets/907e08f7-650a-4022-bfd1-56c0e57b3443" />
<img width="583" alt="Screenshot 2024-12-13 at 17 04 41" src="https://github.com/user-attachments/assets/158e8007-0823-46e9-8c8c-3f4e3eb72618" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
