### PR TITLE
fix: chainflip final trade quote when selling Solana assets to non-So…

### DIFF
--- a/packages/swapper/src/swappers/ChainflipSwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/swapperApi/getTradeQuote.ts
@@ -122,6 +122,8 @@ export const getTradeQuote = async (
       if (!swapResponse.id) throw Error('Missing Swap Id')
       if (!swapResponse.address) throw Error('Missing Deposit Channel')
 
+      const depositAddress = swapResponse.address
+
       const getFeeData = async () => {
         const { chainNamespace } = fromAssetId(sellAsset.assetId)
 
@@ -130,7 +132,7 @@ export const getTradeQuote = async (
           case CHAIN_NAMESPACE.Solana: {
             const sellAdapter = deps.assertGetSolanaChainAdapter(sellAsset.chainId)
             const getFeeDataInput: GetFeeDataInput<KnownChainIds.SolanaMainnet> = {
-              to: input.receiveAddress,
+              to: depositAddress,
               value: sellAmount,
               chainSpecific: {
                 from: input.sendAddress!,
@@ -155,7 +157,7 @@ export const getTradeQuote = async (
       if (!step.chainflipSpecific)
         step.chainflipSpecific = {
           chainflipSwapId: swapResponse.id,
-          chainflipDepositAddress: swapResponse.address,
+          chainflipDepositAddress: depositAddress,
         }
 
       step.chainflipSpecific.chainflipSwapId = swapResponse.id


### PR DESCRIPTION
…lana assets

## Description

This fixes an error spotted by ops in [release](https://discord.com/channels/554694662431178782/1318251736351379498/1318439194124750899):

> 2) sol to eth (non manual receive address or manual receive address) ❌ 
https://jam.dev/c/8d38a189-434a-41e9-8077-2579239d9d73

And indeed, at final quote time, we were failing at "Non-base58 character".

Th reason is when calling `getFeeData()` at final quote time, the input was wrong and we were using the destination address (a non-Solana) as a `to` for fees estimations. `buildEstimationSerializedTx()` would then attempt getting a Solana pubkey from said `to` address, which would make the bs58 decoding fail from said address, fees estimation fail, and ultimately, the quote fail, meaning we would have no final trade quote and a blank screen. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, blatant mistake

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Try to sell assets on Solana (SOL, SOL.USDC) with Chainflip, to non-Solana assets (e.g ETH/ETH.USDC, BTC)
- Ensure you can proceed e2e and don't get a final trade quote blanking out

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

- develop

https://jam.dev/c/489bffc5-490d-4c01-b4c7-f383553478a3

- this diff

https://jam.dev/c/25a134d2-06f6-41af-8c4c-f2bfdfe7b8c1
