### PR TITLE
feat: polish and cleanup of limit order confirmation ui

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -47,8 +47,8 @@ export const LimitOrder = ({ isCompact, tradeInputRef, onChangeTab }: LimitOrder
   }, [])
 
   const renderPlaceOrder = useCallback(() => {
-    return <PlaceLimitOrder />
-  }, [])
+    return <PlaceLimitOrder isCompact={isCompact} />
+  }, [isCompact])
 
   return (
     <MemoryRouter initialEntries={LimitOrderRouteEntries} initialIndex={0}>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
@@ -1,7 +1,6 @@
-import { Button, Card, CardBody, CardFooter, Link } from '@chakra-ui/react'
+import { Button, Card, CardBody, CardFooter } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router'
 import { ethereum } from 'test/mocks/assets'
 import { SlideTransition } from 'components/SlideTransition'
@@ -16,12 +15,12 @@ const asset = ethereum
 
 export const PlaceLimitOrder = () => {
   const history = useHistory()
-  const translate = useTranslate()
   const [txStatus, setTxStatus] = useState(TxStatus.Pending)
 
-  // emulate tx executing
+  // Emulate tx executing for the vibes - does nothing other than spin for a sec and then show a
+  // lovely green check
   useEffect(() => {
-    setTimeout(() => setTxStatus(TxStatus.Confirmed), 3000)
+    setTimeout(() => setTxStatus(TxStatus.Confirmed), 1000)
   }, [setTxStatus])
 
   const handleSignAndBroadcast = useCallback(() => {
@@ -60,22 +59,12 @@ export const PlaceLimitOrder = () => {
       }
     })()
 
-    // TODO: get the actual tx link
-    const txLink = 'todo'
-
     return (
       <StatusBody txStatus={txStatus}>
-        <>
-          <Text translation={statusTranslation} color='text.subtle' />
-          {Boolean(txLink) && (
-            <Button as={Link} href={txLink} size='sm' variant='link' colorScheme='blue' isExternal>
-              {translate('limitOrder.viewOnChain')}
-            </Button>
-          )}
-        </>
+        <Text translation={statusTranslation} color='text.subtle' />
       </StatusBody>
     )
-  }, [translate, txStatus])
+  }, [txStatus])
 
   return (
     <SlideTransition>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
@@ -1,10 +1,11 @@
-import { Button, Card, CardBody, CardFooter } from '@chakra-ui/react'
+import { Button, Card, CardBody, CardFooter, useMediaQuery } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useHistory } from 'react-router'
 import { ethereum } from 'test/mocks/assets'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
+import { breakpoints } from 'theme/theme'
 
 import { StatusBody } from '../../StatusBody'
 import { LimitOrderRoutePaths } from '../types'
@@ -13,8 +14,9 @@ const cardBorderRadius = { base: '2xl' }
 
 const asset = ethereum
 
-export const PlaceLimitOrder = () => {
+export const PlaceLimitOrder = ({ isCompact }: { isCompact?: boolean }) => {
   const history = useHistory()
+  const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
   const [txStatus, setTxStatus] = useState(TxStatus.Pending)
 
   // Emulate tx executing for the vibes - does nothing other than spin for a sec and then show a
@@ -24,8 +26,14 @@ export const PlaceLimitOrder = () => {
   }, [setTxStatus])
 
   const handleViewOrdersList = useCallback(() => {
-    history.push(LimitOrderRoutePaths.Orders)
-  }, [history])
+    // Route to order list explicitly on compact views, otherwise go back to input since it's got
+    // the order list anyway
+    if (isCompact || isSmallerThanXl) {
+      history.push(LimitOrderRoutePaths.Orders)
+    } else {
+      history.push(LimitOrderRoutePaths.Input)
+    }
+  }, [history, isCompact, isSmallerThanXl])
 
   const handleGoBack = useCallback(() => {
     history.push(LimitOrderRoutePaths.Input)

--- a/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
@@ -23,23 +23,9 @@ export const PlaceLimitOrder = () => {
     setTimeout(() => setTxStatus(TxStatus.Confirmed), 1000)
   }, [setTxStatus])
 
-  const handleSignAndBroadcast = useCallback(() => {
-    switch (txStatus) {
-      case TxStatus.Pending:
-        setTxStatus(TxStatus.Confirmed)
-        return
-      case TxStatus.Confirmed:
-        setTxStatus(TxStatus.Failed)
-        return
-      case TxStatus.Failed:
-        setTxStatus(TxStatus.Unknown)
-        return
-      case TxStatus.Unknown:
-      default:
-        history.push(LimitOrderRoutePaths.Input)
-        return
-    }
-  }, [history, txStatus])
+  const handleViewOrdersList = useCallback(() => {
+    history.push(LimitOrderRoutePaths.Orders)
+  }, [history])
 
   const handleGoBack = useCallback(() => {
     history.push(LimitOrderRoutePaths.Input)
@@ -93,7 +79,7 @@ export const PlaceLimitOrder = () => {
             colorScheme={'blue'}
             size='lg'
             width='full'
-            onClick={handleSignAndBroadcast}
+            onClick={handleViewOrdersList}
             isLoading={false}
             isDisabled={txStatus === TxStatus.Pending}
           >

--- a/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
@@ -18,7 +18,7 @@ export const PlaceLimitOrder = () => {
   const [txStatus, setTxStatus] = useState(TxStatus.Pending)
 
   // Emulate tx executing for the vibes - does nothing other than spin for a sec and then show a
-  // lovely green check
+  // lovely green check (placing orders is instant with cow because off-chain)
   useEffect(() => {
     setTimeout(() => setTxStatus(TxStatus.Confirmed), 1000)
   }, [setTxStatus])

--- a/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/PlaceLimitOrder.tsx
@@ -71,9 +71,8 @@ export const PlaceLimitOrder = () => {
       <Card
         flex={1}
         borderRadius={cardBorderRadius}
-        width='full'
+        width='500px'
         variant='dashboard'
-        maxWidth='500px'
         borderColor='border.base'
         bg='background.surface.raised.base'
       >


### PR DESCRIPTION
## Description

When a limit order is placed, a simple ui appears showing a spinner for 1 second followed by a green check. The "view order" button takes the user to the order list (on the input page if not in a compact view).

The UI width is also no longer slenderman thin boi, but a thicc 500px as it should be.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes NA

## Risk

> High Risk PRs Require 2 approvals

Low risk.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

Place an order and click "view order":
- On mobile
- On wide desktop
- On narrow desktop

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Wide desktop
https://jam.dev/c/6985ff5e-0d19-48e5-85c6-b01226371826

Narrow desktop
https://jam.dev/c/6da704b2-3ab8-4df1-9783-8eeef825de72
