### PR TITLE
fix: error toast copy appearing as c

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/CancelLimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/CancelLimitOrder.tsx
@@ -25,7 +25,7 @@ import { AssetIconWithBadge } from 'components/AssetIconWithBadge'
 import { Row } from 'components/Row/Row'
 import { RawText, Text } from 'components/Text'
 import { TransactionTypeIcon } from 'components/TransactionHistory/TransactionTypeIcon'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
@@ -46,7 +46,7 @@ type CancelLimitOrderProps = {
 
 export const CancelLimitOrder = ({ orderToCancel, resetOrderToCancel }: CancelLimitOrderProps) => {
   const wallet = useWallet().state.wallet
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const queryClient = useQueryClient()
   const mixpanel = getMixPanel()
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfirm.tsx
@@ -22,7 +22,7 @@ import { SlideTransition } from 'components/SlideTransition'
 import { RawText, Text } from 'components/Text'
 import { TransactionDate } from 'components/TransactionHistoryRows/TransactionDate'
 import { useActions } from 'hooks/useActions'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { getMixPanel } from 'lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from 'lib/mixpanel/types'
@@ -55,7 +55,7 @@ export const LimitOrderConfirm = () => {
   const translate = useTranslate()
   const wallet = useWallet().state.wallet
   const { confirmSubmit, setLimitOrderInitialized } = useActions(limitOrderSlice.actions)
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const queryClient = useQueryClient()
   const mixpanel = getMixPanel()
 

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceApproval.tsx
@@ -8,7 +8,7 @@ import type { Hash } from 'viem'
 import type { AllowanceType } from 'hooks/queries/useApprovalFees'
 import { getApprovalAmountCryptoBaseUnit, useApprovalFees } from 'hooks/queries/useApprovalFees'
 import { useIsAllowanceApprovalRequired } from 'hooks/queries/useIsAllowanceApprovalRequired'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
@@ -24,7 +24,7 @@ export const useAllowanceApproval = (
   isInitiallyRequired: boolean,
 ) => {
   const dispatch = useAppDispatch()
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const wallet = useWallet().state.wallet ?? undefined
 
   const hopSellAccountIdFilter = useMemo(() => ({ hopIndex }), [hopIndex])

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceReset.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useAllowanceReset.tsx
@@ -7,7 +7,7 @@ import { reactQueries } from 'react-queries'
 import type { Hash } from 'viem'
 import { AllowanceType, useApprovalFees } from 'hooks/queries/useApprovalFees'
 import { useIsAllowanceResetRequired } from 'hooks/queries/useIsAllowanceResetRequired'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { selectHopSellAccountId } from 'state/slices/tradeQuoteSlice/selectors'
 import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
@@ -23,7 +23,7 @@ export const useAllowanceReset = (
   isInitiallyRequired: boolean,
 ) => {
   const dispatch = useAppDispatch()
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const wallet = useWallet().state.wallet ?? undefined
 
   const hopSellAccountIdFilter = useMemo(() => ({ hopIndex }), [hopIndex])

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useSignPermit2.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useSignPermit2.tsx
@@ -2,7 +2,7 @@ import { toAddressNList } from '@shapeshiftoss/chain-adapters'
 import type { TradeQuote, TradeQuoteStep } from '@shapeshiftoss/swapper'
 import assert from 'assert'
 import { useCallback, useMemo } from 'react'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { assertGetEvmChainAdapter } from 'lib/utils/evm'
 import { selectPortfolioAccountMetadataByAccountId } from 'state/slices/selectors'
@@ -17,7 +17,7 @@ export const useSignPermit2 = (
   confirmedTradeId: TradeQuote['id'],
 ) => {
   const dispatch = useAppDispatch()
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const wallet = useWallet().state.wallet ?? undefined
 
   const hopSellAccountIdFilter = useMemo(() => {

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeExecution.tsx
@@ -25,7 +25,7 @@ import type { CosmosSdkChainId } from '@shapeshiftoss/types'
 import type { TypedData } from 'eip-712'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { THORSWAP_MAXIMUM_YEAR_TRESHOLD, THORSWAP_UNIT_THRESHOLD } from 'lib/fees/model'
@@ -58,7 +58,7 @@ export const useTradeExecution = (
   const dispatch = useAppDispatch()
   const wallet = useWallet().state.wallet
   const slippageTolerancePercentageDecimal = useAppSelector(selectTradeSlippagePercentageDecimal)
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const trackMixpanelEvent = useMixpanel()
   const hasMixpanelSuccessOrFailFiredRef = useRef(false)
   const thorVotingPower = useAppSelector(selectThorVotingPower)

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -21,7 +21,7 @@ import { getMixpanelEventData } from 'components/MultiHopTrade/helpers'
 import { useInputOutputDifferenceDecimalPercentage } from 'components/MultiHopTrade/hooks/useInputOutputDifference'
 import { TradeInputTab, TradeRoutePaths } from 'components/MultiHopTrade/types'
 import { WalletActions } from 'context/WalletProvider/actions'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useFeatureFlag } from 'hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from 'hooks/useModal/useModal'
 import { useWallet } from 'hooks/useWallet/useWallet'
@@ -89,7 +89,7 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const history = useHistory()
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const { sellAssetAccountId, buyAssetAccountId, setSellAssetAccountId, setBuyAssetAccountId } =
     useAccountIds()
   const buyAssetSearch = useModal('buyTradeAssetSearch')

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/ExpiredWithdraw.tsx
@@ -18,7 +18,7 @@ import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { Text } from 'components/Text'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import { trackOpportunityEvent } from 'lib/mixpanel/helpers'
@@ -72,7 +72,7 @@ export const ExpiredWithdraw: React.FC<ExpiredWithdrawProps> = ({
   const { getUnstakeFees } = useFoxFarming(contractAddress)
 
   const methods = useForm<WithdrawValues>({ mode: 'onChange' })
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
 
   const asset = useAppSelector(state =>
     selectAssetById(state, opportunity?.underlyingAssetId ?? ''),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -17,7 +17,7 @@ import { useHistory } from 'react-router-dom'
 import { encodeFunctionData, getAddress, maxUint256 } from 'viem'
 import type { StepComponentProps } from 'components/DeFi/components/Steps'
 import { useBrowserRouter } from 'hooks/useBrowserRouter/useBrowserRouter'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { usePoll } from 'hooks/usePoll/usePoll'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { bnOrZero } from 'lib/bignumber/bignumber'
@@ -55,7 +55,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext, isReset }) 
   const { state, dispatch } = useContext(DepositContext)
   const estimatedGasCryptoPrecision = state?.approve.estimatedGasCryptoPrecision
   const history = useHistory()
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const {
     state: { wallet },
   } = useWallet()

--- a/src/hooks/useErrorToast/useErrorToast.tsx
+++ b/src/hooks/useErrorToast/useErrorToast.tsx
@@ -8,7 +8,7 @@ import { RawText } from 'components/Text'
 
 const defaultErrorMsgTranslation = 'common.generalError'
 
-export const useErrorHandler = () => {
+export const useErrorToast = () => {
   const toast = useToast()
   const translate = useTranslate()
 

--- a/src/hooks/useErrorToast/useErrorToast.tsx
+++ b/src/hooks/useErrorToast/useErrorToast.tsx
@@ -29,7 +29,7 @@ export const useErrorToast = () => {
           return [errorMsgTranslation, errorMsgTranslationOptions]
         }
 
-        return defaultErrorMsgTranslation
+        return [defaultErrorMsgTranslation]
       })()
 
       const description = translate(...translationArgs)

--- a/src/plugins/walletConnectToDapps/components/modals/EIP155TransactionConfirmation.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/EIP155TransactionConfirmation.tsx
@@ -36,7 +36,7 @@ import { fromHex, isHex } from 'viem'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { FoxIcon } from 'components/Icons/FoxIcon'
 import { Text } from 'components/Text'
-import { useErrorHandler } from 'hooks/useErrorToast/useErrorToast'
+import { useErrorToast } from 'hooks/useErrorToast/useErrorToast'
 import { useWallet } from 'hooks/useWallet/useWallet'
 import { fromBaseUnit } from 'lib/math'
 import { selectFeeAssetByChainId } from 'state/slices/selectors'
@@ -58,7 +58,7 @@ export const EIP155TransactionConfirmation: FC<
 
   const { isLoading, feeAsset, fees, feeAssetPrice } = useCallRequestEvmFees(state)
 
-  const { showErrorToast } = useErrorHandler()
+  const { showErrorToast } = useErrorToast()
   const translate = useTranslate()
   const cardBg = useColorModeValue('white', 'gray.850')
   const {


### PR DESCRIPTION
## Description

Fixes an issue where error toast appears merely as `c` 🗿

Includes mental health renaming of `useErrorHandler` to `useErrorToast`.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8372

## Risk

> High Risk PRs Require 2 approvals

Very low risk.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Begin a trade with metamask, and reject it before signing. The error message should be real readable text, not trollworthy `c`.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

`c` 🗿
https://jam.dev/c/9b9344da-c771-4fc8-b905-041025b8a6a8

Fixed:
https://jam.dev/c/9045bdc7-f18b-43ac-ae8a-4dcfcbff9e11
