### PR TITLE
fix: limit order wrong button copy when usdt allowance is required

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1068,7 +1068,8 @@
       "excessiveValidTo": "Order expiry too far into the future",
       "insufficientLiquidity": "Insufficient liquidity",
       "zeroFunds": "Non-zero sell asset balance needed",
-      "insufficientFundsForGas": "Insufficient funds for gas"
+      "insufficientFundsForGas": "Insufficient funds for gas",
+      "allowanceResetRequired": "Allowance Reset Required"
     },
     "usdtAllowanceReset": {
       "title": "Unable to approve allowance for USDT",

--- a/src/components/MultiHopTrade/components/LimitOrder/components/AllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/AllowanceApproval.tsx
@@ -133,11 +133,14 @@ const AllowanceApprovalInner = ({ activeQuote }: { activeQuote: LimitOrderActive
   }, [sellAsset])
 
   const { buttonTranslation, isError } = useMemo(() => {
+    if (isAllowanceResetRequired) {
+      return { buttonTranslation: 'limitOrder.errors.allowanceResetRequired', isError: true }
+    }
     if (!hasSufficientBalanceForGas) {
       return { buttonTranslation: 'limitOrder.errors.insufficientFundsForGas', isError: true }
     }
 
-    return { buttonTranslation: approveAssetTranslation, isError: isAllowanceResetRequired }
+    return { buttonTranslation: approveAssetTranslation, isError: false }
   }, [approveAssetTranslation, hasSufficientBalanceForGas, isAllowanceResetRequired])
 
   const statusBody = useMemo(() => {
@@ -219,8 +222,11 @@ const AllowanceApprovalInner = ({ activeQuote }: { activeQuote: LimitOrderActive
             size='lg'
             width='full'
             onClick={handleSignAndBroadcast}
-            isLoading={isLoading}
-            isDisabled={isLoading || isError}
+            // As soon as we detect that allowance reset is required, we go directly into a disabled state, and disregard loading states
+            // That is because we don't currently have allowance reset implemented, and Tx simulation will deterministically fail when trying to simulate a Tx with the intended amount
+            // So there's no point to display a loading state for something users cannot action
+            isLoading={isLoading && !isAllowanceResetRequired}
+            isDisabled={isLoading || isAllowanceResetRequired || isError}
           >
             <Text translation={buttonTranslation} />
           </Button>


### PR DESCRIPTION
## Description

This PR:

- Adds correct "Allowance Required" vs. insufficient funds for gas previously when allowance is required
- Ensures we don't leverage loading state which would produce flashes of loading state as gas fees refetch, and eventually fail at simulation time (trying to simulate a non-reset approval Tx for USDT when reset is required will deterministically fail simulation)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted in https://github.com/shapeshift/web/pull/8383

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have a non-zero allowance for mainnet USDT
- Get a limit sell rate for a sell amount > allowance
- Ensure that there are no flashes of loading state (only an initial one the first time around), the button is disabled and in an errored state, and the copy says "Allowance Reset Required"

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

- This diff

https://jam.dev/c/5f6a7ed5-cc78-4660-930f-cdd9b6eaff1c

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
