### PR TITLE
fix: zrx broken allowance checks

### DIFF
--- a/packages/swapper/src/swappers/ZrxSwapper/getZrxTradeRate/getZrxTradeRate.ts
+++ b/packages/swapper/src/swappers/ZrxSwapper/getZrxTradeRate/getZrxTradeRate.ts
@@ -1,3 +1,4 @@
+import { PERMIT2_CONTRACT } from '@shapeshiftoss/contracts'
 import type { AssetsByIdPartial } from '@shapeshiftoss/types'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
@@ -11,6 +12,7 @@ import type {
   TradeRate,
 } from '../../../types'
 import { SwapperName } from '../../../types'
+import { isNativeEvmAsset } from '../../utils/helpers/helpers'
 import { fetchZrxPrice } from '../utils/fetchFromZrx'
 import {
   assertValidTrade,
@@ -79,6 +81,7 @@ export async function getZrxTradeRate(
     steps: [
       {
         estimatedExecutionTimeMs: undefined,
+        allowanceContract: isNativeEvmAsset(sellAsset.assetId) ? undefined : PERMIT2_CONTRACT,
         buyAsset,
         sellAsset,
         accountNumber,


### PR DESCRIPTION
## Description

We were not returning `allowanceContract` previously, which meant that the allowance query would never run without a spender, and would never be in a loading state.
As soon as a final quote arrived, things would get fetched and loading states would work, but if you were to click "Confirm and Trade" before the final quote arrived and brought in the allowanceContract and eventually triggered allowance checks, then the allowance step would never get triggered despite being needed.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8401

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None, blatant mistake

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get a ZRX rate at input time for an asset you haven't granted allowance for to the Permit2 contract, or not enough (check on revoke.cash)
- At preview time, click "Confirm and Trade" without waiting many many seconds
- Confirm the allowance step is triggered ("Approve"), followed by the EIP-712 permit2 signing ("Sign Message")
- Confirm the swap goes through E2E


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/a84ffd76-0409-4719-9d24-324dbdbaf26a

- this diff

https://jam.dev/c/17ba39cb-fffa-403d-aa65-2487ead9aef7

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
