### PR TITLE
feat: limit orders display warning when selling lower than market

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1064,6 +1064,7 @@
     "expiry": "Expiry",
     "noOpenOrders": "No open orders yet.",
     "noHistoricalOrders": "No historical orders yet.",
+    "limitPriceIsPercentLowerThanMarket": "Limit price is %{percent}% lower than market price",
     "expiryOption": {
       "oneHour": "1 hour",
       "oneDay": "1 day",
@@ -1080,6 +1081,9 @@
       "zeroFunds": "Non-zero sell asset balance needed",
       "insufficientFundsForGas": "Insufficient funds for gas",
       "allowanceResetRequired": "Allowance Reset Required"
+    },
+    "warnings": {
+      "limitPriceIsPercentLowerThanMarket": "Price is %{percent}% below market.\n\nWhile CoW always aims to get you the best available price, this could result in selling your %{sellAssetSymbol} at a loss. Consider clicking 'Market' instead."
     },
     "usdtAllowanceReset": {
       "title": "Unable to approve allowance for USDT",


### PR DESCRIPTION
## Description

Does what it says on the box, see screenshots.

Also tackles a fix wrt the delta showing with broken NaN% when there's no sell amount/limit price yet.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8411

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get a limit quote
- Input an amount below market
- Notice you see the warning in addition to the delta
- Notice you don't see the delta anymore (nor the delta) on default state without a sell amount/limit price populated yet

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<img width="562" alt="Screenshot 2024-12-19 at 16 43 46" src="https://github.com/user-attachments/assets/54d10427-6e9a-466a-a965-6e069d72ff60" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix_limit_display_delta","parentHead":"e66758e0b50aabba5c2fb72bbb462c6b59ca2e31","parentPull":8412,"trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
