### PR TITLE
fix: limit orders don't let users preview with zero'd out limit price

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -521,7 +521,11 @@ export const LimitOrderInput = ({
         sellAccountId={sellAccountId}
         shouldDisableGasRateRowClick
         shouldDisablePreviewButton={
-          !hasUserEnteredAmount || isError || isRecipientAddressEntryActive
+          !hasUserEnteredAmount ||
+          isError ||
+          isRecipientAddressEntryActive ||
+          bnOrZero(marketPriceBuyAsset).isZero() ||
+          bnOrZero(limitPrice.buyAssetDenomination).isZero()
         }
         swapperName={SwapperName.CowSwap}
         swapSource={SwapperName.CowSwap}
@@ -539,13 +543,14 @@ export const LimitOrderInput = ({
     inputSellAmountUsd,
     isError,
     isLoading,
-    limitPrice,
+    quoteStatusTranslation,
+    limitPrice.buyAssetDenomination,
     sellAccountId,
     isRecipientAddressEntryActive,
+    marketPriceBuyAsset,
+    networkFeeUserCurrency,
     sellAsset,
     renderedRecipientAddress,
-    networkFeeUserCurrency,
-    quoteStatusTranslation,
   ])
 
   return (


### PR DESCRIPTION
## Description

i.e either limit price from quote (shouldn't happen but it may in case of errors) *or* user set limit price.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8415

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get a limit quote
- Input 0 as limit price
- Notice preview button is disabled
- Clear input altogether (empty string)
- Notice preview button is still disabled

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix_limit_display_delta_warning","parentHead":"54c5e06778efd632d1adbfcedb7bd9fa4355314f","parentPull":8417,"trunk":"develop"}
```
-->

<img width="538" alt="Screenshot 2024-12-19 at 16 43 34" src="https://github.com/user-attachments/assets/fea1e049-7393-4c1a-a4ec-164f8d23eb48" />
<img width="544" alt="Screenshot 2024-12-19 at 16 43 39" src="https://github.com/user-attachments/assets/3557cc4d-a2d1-4d12-8641-69ddff951c74" />
<img width="544" alt="Screenshot 2024-12-19 at 16 43 39" src="https://github.com/user-attachments/assets/93960713-a352-44c4-b90a-c08ff0446c0e" />



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"fix_limit_display_delta_warning","parentHead":"e66758e0b50aabba5c2fb72bbb462c6b59ca2e31","parentPull":8417,"trunk":"develop"}
```
-->
