### PR TITLE
fix: limit orders display buy amount

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1059,7 +1059,7 @@
     "confirmInfo": "The limit order may not fill exactly when on-chain prices reach the limit price.",
     "learnMore": "Learn More",
     "previewOrder": "Preview Order",
-    "youGet": "You Get",
+    "youGet": "You get at least",
     "whenPriceReaches": "When price reaches",
     "expiry": "Expiry",
     "noOpenOrders": "No open orders yet.",

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -410,6 +410,7 @@ export const LimitOrderInput = ({
       >
         <Stack>
           <LimitOrderBuyAsset
+            isLoading={isLoading}
             asset={buyAsset}
             accountId={buyAccountId}
             isInputtingFiatSellAmount={isInputtingFiatSellAmount}

--- a/src/state/slices/limitOrderInputSlice/selectors.ts
+++ b/src/state/slices/limitOrderInputSlice/selectors.ts
@@ -1,4 +1,4 @@
-import { bn, convertPrecision } from '@shapeshiftoss/utils'
+import { bn, convertPrecision, fromBaseUnit } from '@shapeshiftoss/utils'
 import { createSelector } from 'reselect'
 
 import { createTradeInputBaseSelectors } from '../common/tradeInputBase/createTradeInputBaseSelectors'
@@ -82,5 +82,21 @@ export const selectBuyAmountCryptoBaseUnit = createSelector(
       inputExponent: sellAsset.precision,
       outputExponent: buyAsset.precision,
     }).toFixed(0)
+  },
+)
+
+export const selectBuyAmountCryptoPrecision = createSelector(
+  selectBuyAmountCryptoBaseUnit,
+  selectInputBuyAsset,
+  (buyAmountCryptoBaseUnit, buyAsset) => fromBaseUnit(buyAmountCryptoBaseUnit, buyAsset.precision),
+)
+
+export const selectBuyAmountUserCurrency = createSelector(
+  selectBuyAmountCryptoPrecision,
+  selectInputBuyAssetUserCurrencyRate,
+  (buyAmountCryptoPrecision, buyAssetUserCurrencyRate) => {
+    return bn(buyAmountCryptoPrecision)
+      .times(buyAssetUserCurrencyRate ?? '0')
+      .toFixed(2)
   },
 )


### PR DESCRIPTION
## Description

Does what it says on the box, confirmed with product this was an actual ommission in mocks.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8413

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, literally swapper/shared component across the app (`<TradeAssetInput />` code reuse

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get limit rates for USDC <-> FOX (both ways, USDC <-> FOX is always the preferred pair to test with to ensure there is no precision conversion issues)
- Ensure that buy amount crypto looks sane
- Ensure that buy amount in fiat looks sane

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/87566594-df46-4614-ab61-fe9691b23575

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
