### PR TITLE
fix: hide thorswap free fee banner after 2024

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -1,8 +1,10 @@
 import type { CardProps } from '@chakra-ui/react'
 import { Box, Card, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import type { FormEvent } from 'react'
+import { useMemo } from 'react'
 import type { TradeInputTab } from 'components/MultiHopTrade/types'
 import { ThorFreeFeeBanner } from 'components/ThorFreeFeeBanner/ThorFreeFeeBanner'
+import { THORSWAP_MAXIMUM_YEAR_TRESHOLD } from 'lib/fees/model'
 import { breakpoints } from 'theme/theme'
 
 import { SharedTradeInputHeader } from '../SharedTradeInput/SharedTradeInputHeader'
@@ -46,6 +48,11 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
   const totalHeight = useSharedHeight(tradeInputRef)
 
+  const shouldDisplayThorFreeFeeBanner = useMemo(
+    () => new Date().getUTCFullYear() < THORSWAP_MAXIMUM_YEAR_TRESHOLD,
+    [],
+  )
+
   return (
     <Flex
       id='test-flex'
@@ -55,7 +62,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
     >
       <Center width='inherit' alignItems='flex-end'>
         <Box width='full' maxWidth='500px'>
-          <ThorFreeFeeBanner />
+          {shouldDisplayThorFreeFeeBanner ? <ThorFreeFeeBanner /> : null}
           <Card
             flex={1}
             width='full'

--- a/src/components/MultiHopTrade/components/SlideTransitionRoute.tsx
+++ b/src/components/MultiHopTrade/components/SlideTransitionRoute.tsx
@@ -6,6 +6,7 @@ import { useHistory } from 'react-router'
 import { TradeSlideTransition } from 'components/MultiHopTrade/TradeSlideTransition'
 import type { TradeRoutePaths } from 'components/MultiHopTrade/types'
 import { ThorFreeFeeBanner } from 'components/ThorFreeFeeBanner/ThorFreeFeeBanner'
+import { THORSWAP_MAXIMUM_YEAR_TRESHOLD } from 'lib/fees/model'
 import { breakpoints } from 'theme/theme'
 
 import type { LimitOrderRoutePaths } from './LimitOrder/types'
@@ -46,10 +47,15 @@ export const SlideTransitionRoute = ({
     [width, height],
   )
 
+  const shouldDisplayThorFreeFeeBanner = useMemo(
+    () => new Date().getUTCFullYear() < THORSWAP_MAXIMUM_YEAR_TRESHOLD,
+    [],
+  )
+
   return (
     <Center width='inherit' alignItems='flex-end'>
       <Box width='full' maxWidth='500px'>
-        <ThorFreeFeeBanner />
+        {shouldDisplayThorFreeFeeBanner ? <ThorFreeFeeBanner /> : null}
         <TradeSlideTransition>
           <Flex
             width='full'


### PR DESCRIPTION
## Description

After the new year, hide the THOR Swap free fee banner, as fees will be applied again (didn't add it as early return of the component itself for easier understanding purpose

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8422

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- I personally spoofed it with a chrome extension (Time Travel), but as your own discretion!
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/6ca88a99-6e84-4e72-844d-38272ccc29df)
