### PR TITLE
chore: more new swapper tweaks

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/components/StepperStep.tsx
@@ -67,7 +67,11 @@ export const StepperStep = ({
   stepIndicatorVariant = 'default',
 }: StepperStepProps) => {
   const { indicator: indicatorStyles } = useStyleConfig('Stepper', {
-    variant: isError ? 'error' : stepIndicatorVariant,
+    variant: isError
+      ? stepIndicatorVariant === 'innerSteps'
+        ? 'innerStepsError'
+        : 'error'
+      : stepIndicatorVariant,
   }) as { indicator: SystemStyleObject }
 
   return (

--- a/src/components/MultiHopTrade/components/SharedConfirm/SharedConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedConfirm/SharedConfirmFooter.tsx
@@ -1,8 +1,8 @@
 import { Stack } from '@chakra-ui/react'
 
 type SharedConfirmFooterProps = {
-  detail: React.ReactNode | null
-  button: React.ReactNode
+  detail: JSX.Element | null
+  button: JSX.Element | null
 }
 
 export const SharedConfirmFooter = ({ detail, button }: SharedConfirmFooterProps) => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/EtaStep.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/EtaStep.tsx
@@ -2,8 +2,7 @@ import { ArrowDownIcon } from '@chakra-ui/icons'
 import prettyMilliseconds from 'pretty-ms'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { selectIsActiveQuoteMultiHop } from 'state/slices/tradeInputSlice/selectors'
-import { selectFirstHop, selectLastHop } from 'state/slices/tradeQuoteSlice/selectors'
+import { selectActiveQuote } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector } from 'state/store'
 
 import { StepperStep } from '../MultiHopTradeConfirm/components/StepperStep'
@@ -12,18 +11,15 @@ const etaStepProps = { alignItems: 'center', py: 2 }
 
 export const EtaStep = () => {
   const translate = useTranslate()
-  const tradeQuoteFirstHop = useAppSelector(selectFirstHop)
-  const tradeQuoteLastHop = useAppSelector(selectLastHop)
-  const isMultiHopTrade = useAppSelector(selectIsActiveQuoteMultiHop)
-  const totalEstimatedExecutionTimeMs = useMemo(() => {
-    if (!tradeQuoteFirstHop || !tradeQuoteLastHop) return undefined
-    if (!tradeQuoteFirstHop.estimatedExecutionTimeMs || !tradeQuoteLastHop.estimatedExecutionTimeMs)
-      return undefined
-    return isMultiHopTrade
-      ? tradeQuoteFirstHop.estimatedExecutionTimeMs + tradeQuoteLastHop.estimatedExecutionTimeMs
-      : tradeQuoteFirstHop.estimatedExecutionTimeMs
-  }, [isMultiHopTrade, tradeQuoteFirstHop, tradeQuoteLastHop])
-  const swapperName = tradeQuoteFirstHop?.source
+  const activeQuote = useAppSelector(selectActiveQuote)
+  const totalEstimatedExecutionTimeMs = useMemo(
+    () =>
+      activeQuote?.steps.reduce((acc, step) => {
+        return acc + (step.estimatedExecutionTimeMs ?? 0)
+      }, 0),
+    [activeQuote?.steps],
+  )
+  const swapperName = activeQuote?.steps[0].source
 
   const stepIndicator = useMemo(() => {
     return <ArrowDownIcon color='gray.500' boxSize={5} />

--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandableStepperSteps.tsx
@@ -13,14 +13,14 @@ import { TradeExecutionState, TransactionExecutionState } from 'state/slices/tra
 import { useAppSelector, useSelectorWithArgs } from 'state/store'
 
 import { StepperStep } from '../MultiHopTradeConfirm/components/StepperStep'
-import { ExpandedTradeSteps } from './ExpandedTradeSteps'
+import { ExpandedStepperSteps } from './ExpandedStepperSteps'
 import { getHopExecutionStateSummaryStepTranslation } from './helpers'
 import { useCurrentHopIndex } from './hooks/useCurrentHopIndex'
-import { useTradeSteps } from './hooks/useTradeSteps'
+import { useStepperSteps } from './hooks/useStepperSteps'
 
 const collapseStyle = { width: '100%' }
 
-export const ExpandableTradeSteps = () => {
+export const ExpandableStepperSteps = () => {
   const [isExpanded, setIsExpanded] = useState(false)
   const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
   const summaryStepProps = useMemo(
@@ -61,7 +61,7 @@ export const ExpandableTradeSteps = () => {
     }
   }, [confirmedTradeExecutionState, activeQuoteError, swapTxState])
 
-  const { totalSteps, currentTradeStepIndex: currentStep } = useTradeSteps()
+  const { totalSteps, currentTradeStepIndex: currentStep } = useStepperSteps()
   const progressValue = (currentStep / (totalSteps - 1)) * 100
 
   const titleElement = useMemo(() => {
@@ -102,7 +102,7 @@ export const ExpandableTradeSteps = () => {
       />
       <Collapse in={isExpanded} style={collapseStyle}>
         <Box py={4} pl={0}>
-          {activeTradeQuote && <ExpandedTradeSteps activeTradeQuote={activeTradeQuote} />}
+          {activeTradeQuote && <ExpandedStepperSteps activeTradeQuote={activeTradeQuote} />}
         </Box>
       </Collapse>
     </>

--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandableTradeSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandableTradeSteps.tsx
@@ -9,7 +9,7 @@ import {
   selectConfirmedTradeExecutionState,
   selectHopExecutionMetadata,
 } from 'state/slices/tradeQuoteSlice/selectors'
-import { TradeExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { TradeExecutionState, TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppSelector, useSelectorWithArgs } from 'state/store'
 
 import { StepperStep } from '../MultiHopTradeConfirm/components/StepperStep'
@@ -44,20 +44,22 @@ export const ExpandableTradeSteps = () => {
     }
   }, [activeTradeId, currentHopIndex])
   const swapperName = activeTradeQuote?.steps[0].source
-  const { state: hopExecutionState } = useSelectorWithArgs(
-    selectHopExecutionMetadata,
-    hopExecutionMetadataFilter,
-  )
+  const {
+    state: hopExecutionState,
+    swap: { state: swapTxState },
+  } = useSelectorWithArgs(selectHopExecutionMetadata, hopExecutionMetadataFilter)
 
   const summaryStepIndicator = useMemo(() => {
-    if (confirmedTradeExecutionState === TradeExecutionState.TradeComplete) {
-      return <AnimatedCheck />
-    } else if (activeQuoteError) {
-      return <WarningIcon color='red.500' />
-    } else {
-      return <Spinner thickness='3px' size='md' />
+    switch (true) {
+      case confirmedTradeExecutionState === TradeExecutionState.TradeComplete:
+        return <AnimatedCheck />
+      case !!activeQuoteError:
+      case swapTxState === TransactionExecutionState.Failed:
+        return <WarningIcon color='red.500' />
+      default:
+        return <Spinner thickness='3px' size='md' />
     }
-  }, [confirmedTradeExecutionState, activeQuoteError])
+  }, [confirmedTradeExecutionState, activeQuoteError, swapTxState])
 
   const { totalSteps, currentTradeStepIndex: currentStep } = useTradeSteps()
   const progressValue = (currentStep / (totalSteps - 1)) * 100

--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -26,10 +26,10 @@ import {
 } from 'state/slices/tradeQuoteSlice/selectors'
 import { useAppSelector, useSelectorWithArgs } from 'state/store'
 
-import { StepperStep } from '../MultiHopTradeConfirm/components/StepperStep'
-import { TradeStep } from './helpers'
+import { StepperStep as StepperStepComponent } from '../MultiHopTradeConfirm/components/StepperStep'
+import { StepperStep } from './helpers'
+import { useStepperSteps } from './hooks/useStepperSteps'
 import { useStreamingProgress } from './hooks/useStreamingProgress'
-import { useTradeSteps } from './hooks/useTradeSteps'
 import { TxLabel } from './TxLabel'
 
 const erroredStepIndicator = <WarningIcon color='red.500' />
@@ -37,11 +37,11 @@ const completedStepIndicator = <CheckCircleIcon color='text.success' />
 
 const stepProps = { alignItems: 'center', py: 2, pr: 2, pl: 1.5 }
 
-type ExpandedTradeStepsProps = {
+type ExpandedStepperStepsProps = {
   activeTradeQuote: TradeQuote | TradeRate
 }
 
-export const ExpandedTradeSteps = ({ activeTradeQuote }: ExpandedTradeStepsProps) => {
+export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsProps) => {
   const translate = useTranslate()
   // this is the account we're selling from - assume this is the AccountId of the approval Tx
   const firstHopSellAccountId = useAppSelector(selectFirstHopSellAccountId)
@@ -136,7 +136,7 @@ export const ExpandedTradeSteps = ({ activeTradeQuote }: ExpandedTradeStepsProps
     swap: lastHopSwap,
   } = useSelectorWithArgs(selectHopExecutionMetadata, lastHopExecutionMetadataFilter)
 
-  const { currentTradeStepIndex: currentStep } = useTradeSteps()
+  const { currentTradeStepIndex: currentStep } = useStepperSteps()
 
   const stepIndicator = useMemo(
     () => (
@@ -327,65 +327,65 @@ export const ExpandedTradeSteps = ({ activeTradeQuote }: ExpandedTradeStepsProps
     tradeQuoteLastHop,
   ])
 
-  const { tradeSteps, currentTradeStep } = useTradeSteps()
+  const { tradeSteps, currentTradeStep } = useStepperSteps()
 
   return (
     <Stepper variant='innerSteps' orientation='vertical' index={currentStep} gap={0}>
-      {tradeSteps[TradeStep.FirstHopReset] ? (
-        <StepperStep
+      {tradeSteps[StepperStep.FirstHopReset] ? (
+        <StepperStepComponent
           title={firstHopAllowanceResetTitle}
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === TradeStep.FirstHopReset}
+          isError={activeQuoteError && currentTradeStep === StepperStep.FirstHopReset}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
-      {tradeSteps[TradeStep.FirstHopApproval] ? (
-        <StepperStep
+      {tradeSteps[StepperStep.FirstHopApproval] ? (
+        <StepperStepComponent
           title={firstHopAllowanceApprovalTitle}
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === TradeStep.FirstHopApproval}
+          isError={activeQuoteError && currentTradeStep === StepperStep.FirstHopApproval}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
-      <StepperStep
+      <StepperStepComponent
         title={firstHopActionTitle}
         stepIndicator={stepIndicator}
         stepProps={stepProps}
         useSpacer={false}
-        isError={activeQuoteError && currentTradeStep === TradeStep.FirstHopSwap}
+        isError={activeQuoteError && currentTradeStep === StepperStep.FirstHopSwap}
         stepIndicatorVariant='innerSteps'
       />
-      {tradeSteps[TradeStep.LastHopReset] ? (
-        <StepperStep
+      {tradeSteps[StepperStep.LastHopReset] ? (
+        <StepperStepComponent
           title={lastHopAllowanceResetTitle}
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === TradeStep.LastHopReset}
+          isError={activeQuoteError && currentTradeStep === StepperStep.LastHopReset}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
-      {tradeSteps[TradeStep.LastHopApproval] ? (
-        <StepperStep
+      {tradeSteps[StepperStep.LastHopApproval] ? (
+        <StepperStepComponent
           title={lastHopAllowanceApprovalTitle}
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === TradeStep.LastHopApproval}
+          isError={activeQuoteError && currentTradeStep === StepperStep.LastHopApproval}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
-      {tradeSteps[TradeStep.LastHopSwap] ? (
-        <StepperStep
+      {tradeSteps[StepperStep.LastHopSwap] ? (
+        <StepperStepComponent
           title={lastHopActionTitle}
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === TradeStep.LastHopSwap}
+          isError={activeQuoteError && currentTradeStep === StepperStep.LastHopSwap}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmBody.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmBody.tsx
@@ -8,7 +8,7 @@ import { useAppSelector } from 'state/store'
 
 import { SharedConfirmBody } from '../SharedConfirm/SharedConfirmBody'
 import { EtaStep } from './EtaStep'
-import { ExpandableTradeSteps } from './ExpandableTradeSteps'
+import { ExpandableStepperSteps } from './ExpandableStepperSteps'
 
 const InnerSteps = () => {
   const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
@@ -20,7 +20,7 @@ const InnerSteps = () => {
     case TradeExecutionState.FirstHop:
     case TradeExecutionState.SecondHop:
     case TradeExecutionState.TradeComplete:
-      return <ExpandableTradeSteps />
+      return <ExpandableStepperSteps />
     default:
       return null
   }

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -15,10 +15,10 @@ import { useAppSelector, useSelectorWithArgs } from 'state/store'
 
 import { isPermit2Hop } from '../MultiHopTradeConfirm/hooks/helpers'
 import { SharedConfirmFooter } from '../SharedConfirm/SharedConfirmFooter'
-import { TradeStep } from './helpers'
+import { StepperStep } from './helpers'
 import { useActiveTradeAllowance } from './hooks/useActiveTradeAllowance'
 import { useCurrentHopIndex } from './hooks/useCurrentHopIndex'
-import { useTradeSteps } from './hooks/useTradeSteps'
+import { useStepperSteps } from './hooks/useStepperSteps'
 import { TradeConfirmSummary } from './TradeConfirmFooterContent/TradeConfirmSummary'
 import { TradeFooterButton } from './TradeFooterButton'
 
@@ -79,7 +79,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     .times(feeAssetUserCurrencyRate.price)
     .toFixed()
 
-  const { currentTradeStep } = useTradeSteps()
+  const { currentTradeStep } = useStepperSteps()
 
   const tradeResetStepSummary = useMemo(() => {
     return (
@@ -221,14 +221,14 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
       // No trade step is active, quote is still to be confirmed
       case undefined:
         return <TradeConfirmSummary />
-      case TradeStep.FirstHopReset:
-      case TradeStep.LastHopReset:
+      case StepperStep.FirstHopReset:
+      case StepperStep.LastHopReset:
         return tradeResetStepSummary
-      case TradeStep.FirstHopApproval:
-      case TradeStep.LastHopApproval:
+      case StepperStep.FirstHopApproval:
+      case StepperStep.LastHopApproval:
         return tradeAllowanceStepSummary
-      case TradeStep.FirstHopSwap:
-      case TradeStep.LastHopSwap:
+      case StepperStep.FirstHopSwap:
+      case StepperStep.LastHopSwap:
         return tradeExecutionStepSummary
       default:
         return null

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useStepperSteps.tsx
@@ -7,14 +7,14 @@ import {
 import { useAppSelector } from 'state/store'
 
 import {
-  countTradeSteps,
-  getCurrentTradeStep,
-  getCurrentTradeStepIndex,
-  getTradeSteps,
+  countStepperSteps,
+  getCurrentStepperStep,
+  getCurrentStepperStepIndex,
+  getStepperSteps,
 } from '../helpers'
 import { useCurrentHopIndex } from './useCurrentHopIndex'
 
-export const useTradeSteps = () => {
+export const useStepperSteps = () => {
   const activeTradeId = useAppSelector(selectActiveQuote)?.id
   const isMultiHopTrade = useAppSelector(selectIsActiveQuoteMultiHop)
 
@@ -69,19 +69,19 @@ export const useTradeSteps = () => {
     ],
   )
 
-  const tradeSteps = useMemo(() => getTradeSteps(params), [params])
-  const totalSteps = useMemo(() => countTradeSteps(params), [params])
+  const tradeSteps = useMemo(() => getStepperSteps(params), [params])
+  const totalSteps = useMemo(() => countStepperSteps(params), [params])
   const currentHopIndex = useCurrentHopIndex()
   const currentHopExecutionState = useMemo(() => {
     return currentHopIndex === 0 ? firstHopExecutionState : lastHopExecutionState
   }, [currentHopIndex, firstHopExecutionState, lastHopExecutionState])
   const currentTradeStep = useMemo(
-    () => getCurrentTradeStep(currentHopIndex, currentHopExecutionState),
+    () => getCurrentStepperStep(currentHopIndex, currentHopExecutionState),
     [currentHopIndex, currentHopExecutionState],
   )
   const currentTradeStepIndex = useMemo(
     () =>
-      getCurrentTradeStepIndex({
+      getCurrentStepperStepIndex({
         ...params,
         currentHopIndex,
         hopExecutionState: currentHopExecutionState,

--- a/src/components/Stepper.theme.ts
+++ b/src/components/Stepper.theme.ts
@@ -37,24 +37,6 @@ const baseStyle = {
       bg: 'border.base',
     },
   },
-}
-
-const variants = {
-  error: {
-    indicator: {
-      '&[data-status=active]': {
-        bg: 'background.surface.raised.base',
-        borderColor: 'red.500',
-      },
-      '&[data-status=incomplete]': {
-        bg: 'background.surface.raised.base',
-        borderColor: 'border.base',
-      },
-      '&[data-status=complete]': {
-        bg: 'background.error',
-      },
-    },
-  },
   innerSteps: {
     step: {
       '&[data-status=active]': {
@@ -79,6 +61,43 @@ const variants = {
       },
       '&[data-status=complete]': {
         borderWidth: '3px',
+      },
+    },
+  },
+}
+
+const variants = {
+  error: {
+    indicator: {
+      '&[data-status=active]': {
+        bg: 'background.surface.raised.base',
+        borderColor: 'red.500',
+      },
+      '&[data-status=incomplete]': {
+        bg: 'background.surface.raised.base',
+        borderColor: 'border.base',
+      },
+      '&[data-status=complete]': {
+        bg: 'background.error',
+      },
+    },
+  },
+  innerStepsError: {
+    ...baseStyle.innerSteps,
+    indicator: {
+      ...baseStyle.innerSteps.indicator,
+      '&[data-status=active]:not(.step-pending)': {
+        animation: 'none',
+        borderWidth: '0',
+      },
+      '&[data-status=active]': {
+        borderWidth: '0',
+      },
+      '&[data-status=incomplete]': {
+        borderWidth: '0',
+      },
+      '&[data-status=complete]': {
+        borderWidth: '0',
       },
     },
   },


### PR DESCRIPTION
## Description

Adds more improvements to the new swapper:

1. Refactor and code improvements from review comments in https://github.com/shapeshift/web/pull/8408
2. Update TradeStep vernacular to StepperStep to better disambiguate between the concepts
3. Fix the error indicator state for inner steps

## Issue (if applicable)

Contributes to https://github.com/shapeshift/web/issues/8118

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

Quick sanity check of the error state (easy to simulate by blocking connections after trade preview):

<img width="383" alt="Screenshot 2024-12-23 at 15 58 29" src="https://github.com/user-attachments/assets/611f933e-214e-40b6-ac30-8a3dbe3a3105" />

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

See above.