### PR TITLE
docs: typo fix Update asset-generation.md

### DIFF
--- a/docs/asset-generation.md
+++ b/docs/asset-generation.md
@@ -7,7 +7,7 @@ Our asset data is generated periodically using a yarn script, with the result co
 The script requires a private Zerion API key. Request the key from the engineering team and set it as an environment variable:
 
 ```bash
-export ZERION_API_KEY=<zerion api key>
+export ZERION_API_KEY=<YOUR_ZERION_API_KEY>
 ```
 
 ### Running the script


### PR DESCRIPTION
The placeholder `<zerion api key>` could be more descriptive or formatted to follow standard conventions. For instance, using `<YOUR_ZERION_API_KEY>` makes it clearer that the user needs to replace it with their actual API key.  
