### PR TITLE
fix: limit order never keep stale values for buy asset market price

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -218,6 +218,8 @@ export const LimitOrderInput = ({
   } = useQuoteLimitOrderQuery(limitOrderQuoteParams)
 
   const marketPriceBuyAsset = useMemo(() => {
+    // Ensure we zero out the price if there is an error, and when we are fetching, as `quoteResponse` will be stale data in both cases
+    if (isLimitOrderQuoteFetching || quoteResponseError) return '0'
     // RTK query returns stale data when `skipToken` is used, so we need to handle that case here.
     if (!quoteResponse || limitOrderQuoteParams === skipToken) return '0'
 
@@ -227,7 +229,14 @@ export const LimitOrderInput = ({
       sellAsset,
       buyAsset,
     })
-  }, [quoteResponse, limitOrderQuoteParams, sellAsset, buyAsset])
+  }, [
+    isLimitOrderQuoteFetching,
+    quoteResponseError,
+    quoteResponse,
+    limitOrderQuoteParams,
+    sellAsset,
+    buyAsset,
+  ])
 
   // Update the limit price when the market price changes.
   useEffect(() => {


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

Buy asset market data price looks like it's a purely derived value as a product of the *input* buy amount and sell amount, however, it is derived from the *quote* buy and sell amounts.

A quote however, is RTK query data, and stale RTK query data will stil be present when:
- fetching 
- current query is errored, but previous (stale) one was happy

This was producing odd bugs where failures in getting a CoW quote (i.e inputting too low of am amount) would return the previous stale quote, however, the previous quote was for an entirely different asset, and possibly a different precision, which will lead to amounts being off.

Fixed by zero'ing amounts out when fetching/errored. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8414

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- In limit orders, try to sell a non-18 precision asset that's much higher than FOX (the default USDC -> FOX pair is perfect for that)
- Sell high enough of an amount e.g 100 USDC
- Then, choose another, much cheaper, and ideally non-18 precision asset (selecting FOX i.e FOX -> USDC is perfect for that)
- Try inputting some low amount e.g the same 100 as previously (i.e 100 FOX -> USDC)
- Notice there is no longer amounts which are totally off

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/7ef95c99-ae34-4902-ac15-6302d26ef7ab

- this diff

https://jam.dev/c/d9e4e20e-6239-43d4-afa7-4fbaab9336b4

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
