### PR TITLE
fix: new swapper flow incorrect Tx link base URL

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -156,8 +156,9 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
         {firstHopAllowanceReset.txHash && tradeQuoteFirstHop && firstHopSellAccountId && (
           <TxLabel
             txHash={firstHopAllowanceReset.txHash}
-            explorerTxLink={tradeQuoteFirstHop.sellAsset.explorerTxLink}
+            explorerBaseUrl={tradeQuoteFirstHop.sellAsset.explorerTxLink}
             accountId={firstHopSellAccountId}
+            swapperName={undefined} // no swapper base URL here, this is an allowance Tx
           />
         )}
       </Flex>
@@ -182,8 +183,9 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             {firstHopAllowanceApproval.txHash && tradeQuoteFirstHop && firstHopSellAccountId && (
               <TxLabel
                 txHash={firstHopAllowanceApproval.txHash}
-                explorerTxLink={tradeQuoteFirstHop.sellAsset.explorerTxLink}
+                explorerBaseUrl={tradeQuoteFirstHop.sellAsset.explorerTxLink}
                 accountId={firstHopSellAccountId}
+                swapperName={undefined} // no swapper base URL here, this is an allowance Tx
               />
             )}
           </>
@@ -214,15 +216,17 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             {firstHopSwap.sellTxHash && (
               <TxLabel
                 txHash={firstHopSwap.sellTxHash}
-                explorerTxLink={tradeQuoteFirstHop.sellAsset.explorerTxLink}
+                explorerBaseUrl={tradeQuoteFirstHop.sellAsset.explorerTxLink}
                 accountId={firstHopSellAccountId}
+                swapperName={swapperName}
               />
             )}
             {firstHopSwap.buyTxHash && firstHopSwap.buyTxHash !== firstHopSwap.sellTxHash && (
               <TxLabel
                 txHash={firstHopSwap.buyTxHash}
-                explorerTxLink={tradeQuoteFirstHop.buyAsset.explorerTxLink}
+                explorerBaseUrl={tradeQuoteFirstHop.buyAsset.explorerTxLink}
                 accountId={firstHopSellAccountId}
+                swapperName={swapperName}
               />
             )}
           </VStack>
@@ -235,6 +239,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     firstHopStreamingProgress,
     firstHopSwap.buyTxHash,
     firstHopSwap.sellTxHash,
+    swapperName,
     tradeQuoteFirstHop,
   ])
 
@@ -245,8 +250,9 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
         {lastHopAllowanceReset.txHash && tradeQuoteLastHop && lastHopSellAccountId && (
           <TxLabel
             txHash={lastHopAllowanceReset.txHash}
-            explorerTxLink={tradeQuoteLastHop.sellAsset.explorerTxLink}
+            explorerBaseUrl={tradeQuoteLastHop.sellAsset.explorerTxLink}
             accountId={lastHopSellAccountId}
+            swapperName={undefined} // no swapper base URL here, this is an allowance Tx
           />
         )}
       </Flex>
@@ -271,8 +277,9 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             {lastHopAllowanceApproval.txHash && tradeQuoteLastHop && lastHopSellAccountId && (
               <TxLabel
                 txHash={lastHopAllowanceApproval.txHash}
-                explorerTxLink={tradeQuoteLastHop.sellAsset.explorerTxLink}
+                explorerBaseUrl={tradeQuoteLastHop.sellAsset.explorerTxLink}
                 accountId={lastHopSellAccountId}
+                swapperName={undefined} // no swapper base URL here, this is an allowance Tx
               />
             )}
           </>
@@ -303,15 +310,17 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             {lastHopSwap.sellTxHash && (
               <TxLabel
                 txHash={lastHopSwap.sellTxHash}
-                explorerTxLink={tradeQuoteLastHop.sellAsset.explorerTxLink}
+                explorerBaseUrl={tradeQuoteLastHop.sellAsset.explorerTxLink}
                 accountId={lastHopSellAccountId}
+                swapperName={swapperName}
               />
             )}
             {lastHopSwap.buyTxHash && lastHopSwap.buyTxHash !== lastHopSwap.sellTxHash && (
               <TxLabel
                 txHash={lastHopSwap.buyTxHash}
-                explorerTxLink={tradeQuoteLastHop.buyAsset.explorerTxLink}
+                explorerBaseUrl={tradeQuoteLastHop.buyAsset.explorerTxLink}
                 accountId={lastHopSellAccountId}
+                swapperName={swapperName}
               />
             )}
           </VStack>
@@ -324,6 +333,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     lastHopSwap.buyTxHash,
     lastHopSwap.sellTxHash,
     secondHopStreamingProgress,
+    swapperName,
     tradeQuoteLastHop,
   ])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/TxLabel.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TxLabel.tsx
@@ -1,17 +1,20 @@
 import { Link } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
+import type { SwapSource } from '@shapeshiftoss/swapper'
 import { MiddleEllipsis } from 'components/MiddleEllipsis/MiddleEllipsis'
 import { useSafeTxQuery } from 'hooks/queries/useSafeTx'
 import { getTxLink } from 'lib/getTxLink'
 
 export const TxLabel = ({
   txHash,
-  explorerTxLink,
+  explorerBaseUrl,
   accountId,
+  swapperName,
 }: {
   txHash: string
-  explorerTxLink: string
+  explorerBaseUrl: string
   accountId: AccountId
+  swapperName: SwapSource | undefined
 }) => {
   const { data: maybeSafeTx } = useSafeTxQuery({
     maybeSafeTxHash: txHash,
@@ -19,10 +22,11 @@ export const TxLabel = ({
   })
 
   const txLink = getTxLink({
-    defaultExplorerBaseUrl: explorerTxLink,
+    defaultExplorerBaseUrl: explorerBaseUrl,
     maybeSafeTx,
     tradeId: txHash,
     accountId,
+    name: swapperName,
   })
 
   return txLink ? (


### PR DESCRIPTION
## Description

Ensures the correct base URL is used:

- Tx explorer link for approval Txs
- Tx explorer link *or* swapper link (e.g CoW explorer) for actual swap Txs or message signing, leveraging existing `getTxLink` logic

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8458

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - this logic already exists throughout the app and we're only passing the `name` prop down to `getTxLink` which allows this

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Initiate a CoW swap with the new swapper flow 
- Ensure the explorer link is CoW's, not etherscan or etherscan likes

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- None, this is still under flag

## Screenshots (if applicable)

- develop

<img width="1332" alt="Screenshot 2025-01-03 at 19 37 07" src="https://github.com/user-attachments/assets/e607eddf-cf5b-474c-8348-20acd559f3dd" />


- this diff

<img width="900" alt="Screenshot 2025-01-03 at 19 51 23" src="https://github.com/user-attachments/assets/cc51a5f5-fa86-41c5-9490-fd485a777069" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
