### PR TITLE
chore: display both fiat & crypto amounts throughout trade flow

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooterContent/TradeConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooterContent/TradeConfirmSummary.tsx
@@ -244,12 +244,8 @@ export const TradeConfirmSummary = () => {
             </Row.Label>
             <Row.Value color='text.base'>
               {protocolFeesParsed?.map(({ amountCryptoPrecision, assetId, symbol }) => (
-                <HStack key={`${assetId}-${amountCryptoPrecision}`} justifyContent='flex-end'>
-                  <Amount.Crypto
-                    key={`${assetId}-${amountCryptoPrecision}`}
-                    value={amountCryptoPrecision}
-                    symbol={symbol}
-                  />
+                <HStack key={assetId} justifyContent='flex-end'>
+                  <Amount.Crypto value={amountCryptoPrecision} symbol={symbol} />
                   {assetId && (
                     <Amount.Fiat
                       color={'text.subtle'}

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -341,12 +341,8 @@ export const ConfirmSummary = ({
             </Row.Label>
             <Row.Value color='text.base'>
               {protocolFeesParsed?.map(({ amountCryptoPrecision, assetId, symbol }) => (
-                <HStack key={`${assetId}-${amountCryptoPrecision}`} justifyContent='flex-end'>
-                  <Amount.Crypto
-                    key={`${assetId}-${amountCryptoPrecision}`}
-                    value={amountCryptoPrecision}
-                    symbol={symbol}
-                  />
+                <HStack key={assetId} justifyContent='flex-end'>
+                  <Amount.Crypto value={amountCryptoPrecision} symbol={symbol} />
                   {assetId && (
                     <Amount.Fiat
                       color={'text.subtle'}

--- a/src/components/MultiHopTrade/helpers.ts
+++ b/src/components/MultiHopTrade/helpers.ts
@@ -4,8 +4,8 @@ import { isExecutableTradeQuote } from '@shapeshiftoss/swapper'
 import { isThorTradeQuote } from '@shapeshiftoss/swapper/dist/swappers/ThorchainSwapper/getThorTradeQuote/getTradeQuote'
 import { isThorTradeRate } from '@shapeshiftoss/swapper/dist/swappers/ThorchainSwapper/getThorTradeRate/getTradeRate'
 import { bnOrZero, fromBaseUnit } from '@shapeshiftoss/utils'
-import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { getMaybeCompositeAssetSymbol } from 'lib/mixpanel/helpers'
+import { chainIdToChainDisplayName } from 'lib/utils'
 import type { ReduxState } from 'state/reducer'
 import { selectAssets, selectFeeAssetById } from 'state/slices/selectors'
 import {
@@ -85,9 +85,8 @@ export const parseAmountDisplayMeta = (items: AmountDisplayMeta[]): ProtocolFeeD
   items
     .filter(({ amountCryptoBaseUnit }) => bnOrZero(amountCryptoBaseUnit).gt(0))
     .forEach(({ amountCryptoBaseUnit, asset }: AmountDisplayMeta) => {
-      const key = `${asset.assetId}-${getChainAdapterManager()
-        .get(asset.chainId)
-        ?.getDisplayName()}`
+      if (!asset.assetId) return
+      const key = asset.assetId
       if (feeMap[key]) {
         // If we already have this asset+chain combination, add the amounts
         feeMap[key].amountCryptoPrecision = bnOrZero(feeMap[key].amountCryptoPrecision)
@@ -97,7 +96,7 @@ export const parseAmountDisplayMeta = (items: AmountDisplayMeta[]): ProtocolFeeD
         // First time seeing this asset+chain combination
         feeMap[key] = {
           assetId: asset.assetId,
-          chainName: getChainAdapterManager().get(asset.chainId)?.getDisplayName(),
+          chainName: chainIdToChainDisplayName(asset.chainId),
           amountCryptoPrecision: fromBaseUnit(amountCryptoBaseUnit, asset.precision),
           symbol: asset.symbol,
         }


### PR DESCRIPTION
## Description

- Unifies protocol fee display between trade input and trade preview/confirm screens by adding fiat amounts. Includes a bonus bug fix where multiple fees in the same currency would show twice - the amounts are now aggregated.
- Show both fiat and crypto tx fee amounts on the trade input summary

## Issue (if applicable)

https://github.com/shapeshift/web/issues/8460

## Risk

Small - UI changes only.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

### Engineering

With the `REACT_APP_FEATURE_NEW_TRADE_FLOW` feature enabled, ensure that:

- At trade input with show both fiat and crypto amounts for all fees (network and protocol)
- At quote confirm time we show network fees in both crypto and fiat. Confirm that multi-hop trades show as 2 separate lines)

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

**Multiple protocol fee display (with aggregated de-dupe)**

<img width="406" alt="Screenshot 2025-01-06 at 10 17 33" src="https://github.com/user-attachments/assets/68bd6f0c-47d4-48e6-9633-c4f76d9499ae" />

**Multi-hop tx fee display**

<img width="393" alt="Screenshot 2025-01-06 at 11 11 15" src="https://github.com/user-attachments/assets/5cfbf245-b3e4-42b4-b17e-de41c7eda7bf" />
