### PR TITLE
fix: inner step styling

### DIFF
--- a/src/components/Stepper.theme.ts
+++ b/src/components/Stepper.theme.ts
@@ -37,36 +37,38 @@ const baseStyle = {
       bg: 'border.base',
     },
   },
-  innerSteps: {
-    step: {
-      '&[data-status=active]': {
-        bg: 'background.surface.raised.base',
-        borderRadius: '8px',
-      },
+}
+
+const innerSteps = {
+  step: {
+    '&[data-status=active]': {
+      bg: 'background.surface.raised.base',
+      borderRadius: '8px',
     },
-    indicator: {
-      width: '20px',
-      height: '20px',
-      minWidth: '20px',
+  },
+  indicator: {
+    width: '20px',
+    height: '20px',
+    minWidth: '20px',
+    borderWidth: '3px',
+    // Override the throbbing animation
+    '&[data-status=active]:not(.step-pending)': {
+      animation: 'none',
+    },
+    '&[data-status=active]': {
       borderWidth: '3px',
-      // Override the throbbing animation
-      '&[data-status=active]:not(.step-pending)': {
-        animation: 'none',
-      },
-      '&[data-status=active]': {
-        borderWidth: '3px',
-      },
-      '&[data-status=incomplete]': {
-        borderWidth: '3px',
-      },
-      '&[data-status=complete]': {
-        borderWidth: '3px',
-      },
+    },
+    '&[data-status=incomplete]': {
+      borderWidth: '3px',
+    },
+    '&[data-status=complete]': {
+      borderWidth: '3px',
     },
   },
 }
 
 const variants = {
+  innerSteps,
   error: {
     indicator: {
       '&[data-status=active]': {
@@ -83,9 +85,9 @@ const variants = {
     },
   },
   innerStepsError: {
-    ...baseStyle.innerSteps,
+    ...innerSteps,
     indicator: {
-      ...baseStyle.innerSteps.indicator,
+      ...innerSteps.indicator,
       '&[data-status=active]:not(.step-pending)': {
         animation: 'none',
         borderWidth: '0',


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/shapeshift/web/pull/8437 that broke the `innerStep` Stepper styling.

## Issue (if applicable)

N/A, fixes regression.

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

With the `REACT_APP_FEATURE_NEW_TRADE_FLOW` flag enabled:

Success and failure inner step indicators should be small and non-throbbing again.

<img width="396" alt="Screenshot 2025-01-06 at 17 26 57" src="https://github.com/user-attachments/assets/744d068e-495a-441a-8b06-87e8dbd86508" />
<img width="394" alt="Screenshot 2025-01-06 at 17 27 47" src="https://github.com/user-attachments/assets/185a8813-3cfe-466f-91bd-986149f1b2f0" />

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

See above.