### PR TITLE
fix: only show warning ack when previewing

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
@@ -118,12 +118,16 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
   }, [tradeButtonProps, setHasClickedButton])
 
   const handleClick = useCallback(() => {
-    if (isModeratePriceImpact) {
+    const isInitializingOrPreviewing =
+      confirmedTradeExecutionState === TradeExecutionState.Initializing ||
+      confirmedTradeExecutionState === TradeExecutionState.Previewing
+    // Only show the warning acknowledgement if the user is previewing the trade
+    if (isModeratePriceImpact && isInitializingOrPreviewing) {
       setShouldShowWarningAcknowledgement(true)
     } else {
       handleSubmit()
     }
-  }, [isModeratePriceImpact, handleSubmit])
+  }, [isModeratePriceImpact, handleSubmit, confirmedTradeExecutionState])
 
   // Ratio of the fiat value of the gas fee to the fiat value of the trade value express in percentage
   const isFeeRatioOverThreshold = useMemo(() => {


### PR DESCRIPTION
## Description

Ensures we only show the price impact warning when we are in the preview stage. Once accepted at this stage we should not show it again.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8439

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

Do a high impact trade (I did Eth on Arb One to Black Angus on Arb One for cheap testing) and ensure the high impact trade modal only shows once when pressing "Confirm and Trade", and at no other time.

### Operations

- [X] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

N/A