### PR TITLE
fix: multi-hop fees estimation

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -68,7 +68,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isRefetching: isNetworkFeeCryptoBaseUnitRefetching,
     data: networkFeeCryptoBaseUnit,
   } = useTradeNetworkFeeCryptoBaseUnit({
-    hopIndex: 0,
+    hopIndex: currentHopIndex,
     enabled:
       currentTradeStep === StepperStep.FirstHopSwap || currentTradeStep === StepperStep.LastHopSwap,
   })


### PR DESCRIPTION
## Description

Ensures that dynamic fees estimations are always done with the current hop, vs. only first hop previously.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, see  https://github.com/shapeshift/web/pull/8432/files#r1903360919

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, new swapper flow only, and isolated to fees estimation react-query query

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Perform a multi-hop swap
- Ensure fees look good for both sides

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<img width="584" alt="Screenshot 2025-01-06 at 12 20 35" src="https://github.com/user-attachments/assets/725214d9-7a52-4e3d-86f0-36f764c11f28" />
<img width="619" alt="Screenshot 2025-01-06 at 12 42 36" src="https://github.com/user-attachments/assets/b2d7db4f-885f-4519-ab0b-f9b0ee6aae30" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
