### PR TITLE
fix: make longtail data serializable

### DIFF
--- a/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
@@ -150,12 +150,15 @@ export const thorchainApi: SwapperApi = {
       case TradeType.LongTailToL1: {
         assert(aggregator, 'aggregator required for thorchain longtail to l1 swaps')
 
-        const expectedAmountOut = longtailData?.longtailToL1ExpectedAmountOut ?? 0n
+        const expectedAmountOut = longtailData?.longtailToL1ExpectedAmountOut ?? '0'
         // Paranoia assertion - expectedAmountOut should never be 0 as it would likely lead to a loss of funds.
-        assert(expectedAmountOut > 0n, 'expected expectedAmountOut to be a positive amount')
+        assert(
+          bnOrZero(expectedAmountOut).gt(0),
+          'expected expectedAmountOut to be a positive amount',
+        )
 
         const amountOutMin = BigInt(
-          bnOrZero(expectedAmountOut.toString())
+          bnOrZero(expectedAmountOut)
             .times(bn(1).minus(slippageTolerancePercentageDecimal ?? 0))
             .toFixed(0, BigNumber.ROUND_UP),
         )
@@ -198,9 +201,12 @@ export const thorchainApi: SwapperApi = {
         }
       }
       case TradeType.L1ToLongTail:
-        const expectedAmountOut = longtailData?.L1ToLongtailExpectedAmountOut ?? 0n
+        const expectedAmountOut = longtailData?.L1ToLongtailExpectedAmountOut ?? '0'
         // Paranoia assertion - expectedAmountOut should never be 0 as it would likely lead to a loss of funds.
-        assert(expectedAmountOut > 0n, 'expected expectedAmountOut to be a positive amount')
+        assert(
+          bnOrZero(expectedAmountOut).gt(0),
+          'expected expectedAmountOut to be a positive amount',
+        )
 
         const { router: updatedRouter } = await getEvmThorTxInfo({
           sellAsset,
@@ -308,12 +314,15 @@ export const thorchainApi: SwapperApi = {
       case TradeType.LongTailToL1: {
         assert(aggregator, 'aggregator required for thorchain longtail to l1 swaps')
 
-        const expectedAmountOut = longtailData?.longtailToL1ExpectedAmountOut ?? 0n
+        const expectedAmountOut = longtailData?.longtailToL1ExpectedAmountOut ?? '0'
         // Paranoia assertion - expectedAmountOut should never be 0 as it would likely lead to a loss of funds.
-        assert(expectedAmountOut > 0n, 'expected expectedAmountOut to be a positive amount')
+        assert(
+          bnOrZero(expectedAmountOut).gt(0),
+          'expected expectedAmountOut to be a positive amount',
+        )
 
         const amountOutMin = BigInt(
-          bnOrZero(expectedAmountOut.toString())
+          bnOrZero(expectedAmountOut)
             .times(bn(1).minus(slippageTolerancePercentageDecimal ?? 0))
             .toFixed(0, BigNumber.ROUND_UP),
         )
@@ -349,9 +358,12 @@ export const thorchainApi: SwapperApi = {
         return networkFeeCryptoBaseUnit
       }
       case TradeType.L1ToLongTail:
-        const expectedAmountOut = longtailData?.L1ToLongtailExpectedAmountOut ?? 0n
+        const expectedAmountOut = longtailData?.L1ToLongtailExpectedAmountOut
         // Paranoia assertion - expectedAmountOut should never be 0 as it would likely lead to a loss of funds.
-        assert(expectedAmountOut > 0n, 'expected expectedAmountOut to be a positive amount')
+        assert(
+          bnOrZero(expectedAmountOut).gt(0),
+          'expected expectedAmountOut to be a positive amount',
+        )
 
         const { router: updatedRouter } = await getEvmThorTxInfo({
           sellAsset,

--- a/packages/swapper/src/swappers/ThorchainSwapper/types.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/types.ts
@@ -276,8 +276,8 @@ type ThorTradeQuoteSpecificMetadata = {
   tradeType: TradeType
   expiry: number
   longtailData?: {
-    longtailToL1ExpectedAmountOut?: bigint
-    L1ToLongtailExpectedAmountOut?: bigint
+    longtailToL1ExpectedAmountOut?: string
+    L1ToLongtailExpectedAmountOut?: string
   }
 }
 

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getCallDataFromQuote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getCallDataFromQuote.ts
@@ -42,9 +42,9 @@ export const getCallDataFromQuote = async ({
       return data
     }
     case TradeType.LongTailToL1: {
-      const expectedAmountOut = longtailData?.longtailToL1ExpectedAmountOut ?? 0n
+      const expectedAmountOut = longtailData?.longtailToL1ExpectedAmountOut ?? '0'
       const amountOutMin = BigInt(
-        bnOrZero(expectedAmountOut.toString())
+        bnOrZero(expectedAmountOut)
           .times(bn(1).minus(slippageTolerancePercentageDecimal ?? 0))
           .toFixed(0, BigNumber.ROUND_UP),
       )

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1ToLongtailQuote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1ToLongtailQuote.ts
@@ -161,7 +161,7 @@ export const getL1ToLongtailQuote = async (
         })) as MultiHopTradeQuoteSteps, // assuming multi-hop quote steps here since we're mapping over quote steps,
         isLongtail: true,
         longtailData: {
-          L1ToLongtailExpectedAmountOut: quotedAmountOut,
+          L1ToLongtailExpectedAmountOut: quotedAmountOut.toString(),
         },
       })
     }),

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1ToLongtailRate.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1ToLongtailRate.ts
@@ -142,7 +142,7 @@ export const getL1ToLongtailRate = async (
         })) as MultiHopTradeRateSteps, // assuming multi-hop rate steps here since we're mapping over quote steps,
         isLongtail: true,
         longtailData: {
-          L1ToLongtailExpectedAmountOut: quotedAmountOut,
+          L1ToLongtailExpectedAmountOut: quotedAmountOut.toString(),
         },
       })
     }),

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getLongtailQuote.ts
@@ -87,21 +87,24 @@ export const getLongtailToL1Quote = async (
   )
 
   return thorchainQuotes.andThen(quotes => {
-    const updatedQuotes: ThorTradeQuote[] = quotes.map(q => ({
-      ...q,
-      aggregator: bestAggregator,
-      // This logic will need to be updated to support multi-hop, if that's ever implemented for THORChain
-      steps: q.steps.map(s => ({
-        ...s,
-        sellAmountIncludingProtocolFeesCryptoBaseUnit,
-        sellAsset,
-        allowanceContract: TS_AGGREGATOR_TOKEN_TRANSFER_PROXY_CONTRACT_MAINNET,
-      })) as MultiHopTradeQuoteSteps, // assuming multi-hop quote steps here since we're mapping over quote steps
-      isLongtail: true,
-      longtailData: {
-        longtailToL1ExpectedAmountOut: quotedAmountOut,
-      },
-    }))
+    const updatedQuotes = quotes.map(
+      q =>
+        ({
+          ...q,
+          aggregator: bestAggregator,
+          // This logic will need to be updated to support multi-hop, if that's ever implemented for THORChain
+          steps: q.steps.map(s => ({
+            ...s,
+            sellAmountIncludingProtocolFeesCryptoBaseUnit,
+            sellAsset,
+            allowanceContract: TS_AGGREGATOR_TOKEN_TRANSFER_PROXY_CONTRACT_MAINNET,
+          })) as MultiHopTradeQuoteSteps, // assuming multi-hop quote steps here since we're mapping over quote steps
+          isLongtail: true,
+          longtailData: {
+            longtailToL1ExpectedAmountOut: quotedAmountOut.toString(),
+          },
+        }) satisfies ThorTradeQuote,
+    )
 
     return Ok(updatedQuotes)
   })

--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getLongtailRate.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getLongtailRate.ts
@@ -101,7 +101,7 @@ export const getLongtailToL1Rate = async (
       })) as MultiHopTradeRateSteps, // assuming multi-hop quote steps here since we're mapping over quote steps
       isLongtail: true,
       longtailData: {
-        longtailToL1ExpectedAmountOut: quotedAmountOut,
+        longtailToL1ExpectedAmountOut: quotedAmountOut.toString(),
       },
     }))
 


### PR DESCRIPTION
## Description

Makes `longtailToL1ExpectedAmountOut` and `L1ToLongtailExpectedAmountOut` serializable so they can be passed into React Query land and not crash the app.

Note, I'm not sure when this regression was introduced, but longtail is indeed broken rn.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8488

## Risk

Medium

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Longtail swaps

## Testing

Ensure longtail swaps are great again.

Note, I was able to successfully perform an L1 to longtail swap, though I was having gas estimate issues for longtail to L1 swaps for what I believe is a different reason.

### Engineering

### Operations

## Screenshots (if applicable)

<img width="391" alt="Screenshot 2025-01-07 at 17 44 43" src="https://github.com/user-attachments/assets/48dff675-c60f-4574-ba6b-884084e33975" />

https://viewblock.io/thorchain/tx/3806cb6b24abe0eac3b7edd747c14ab8c8d5d702d8c181bdbbdb1b6343a5c46c
https://viewblock.io/thorchain/tx/179B6E6950039C7455C57A46C5DB472AAE9DB08F2E132A6F71BCA0A4BDB332EB
