### PR TITLE
chore: handle holistic trade failure status in inner steps

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -363,6 +363,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
   ])
 
   const { tradeSteps, currentTradeStep } = useStepperSteps()
+  const isError = activeQuoteError || transactionExecutionStateError
 
   return (
     <Stepper variant='innerSteps' orientation='vertical' index={currentStep} gap={0}>
@@ -372,7 +373,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === StepperStep.FirstHopReset}
+          isError={isError && currentTradeStep === StepperStep.FirstHopReset}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
@@ -382,7 +383,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === StepperStep.FirstHopApproval}
+          isError={isError && currentTradeStep === StepperStep.FirstHopApproval}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
@@ -391,7 +392,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
         stepIndicator={stepIndicator}
         stepProps={stepProps}
         useSpacer={false}
-        isError={activeQuoteError && currentTradeStep === StepperStep.FirstHopSwap}
+        isError={isError && currentTradeStep === StepperStep.FirstHopSwap}
         stepIndicatorVariant='innerSteps'
       />
       {tradeSteps[StepperStep.LastHopReset] ? (
@@ -400,7 +401,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === StepperStep.LastHopReset}
+          isError={isError && currentTradeStep === StepperStep.LastHopReset}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
@@ -410,7 +411,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === StepperStep.LastHopApproval}
+          isError={isError && currentTradeStep === StepperStep.LastHopApproval}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}
@@ -420,7 +421,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}
-          isError={activeQuoteError && currentTradeStep === StepperStep.LastHopSwap}
+          isError={isError && currentTradeStep === StepperStep.LastHopSwap}
           stepIndicatorVariant='innerSteps'
         />
       ) : null}

--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -24,6 +24,7 @@ import {
   selectActiveQuoteErrors,
   selectHopExecutionMetadata,
 } from 'state/slices/tradeQuoteSlice/selectors'
+import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppSelector, useSelectorWithArgs } from 'state/store'
 
 import { StepperStep as StepperStepComponent } from '../MultiHopTradeConfirm/components/StepperStep'
@@ -136,6 +137,28 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     swap: lastHopSwap,
   } = useSelectorWithArgs(selectHopExecutionMetadata, lastHopExecutionMetadataFilter)
 
+  const transactionExecutionStateError = useMemo(() => {
+    return [
+      firstHopAllowanceApproval.state,
+      lastHopAllowanceApproval.state,
+      firstHopPermit2.state,
+      lastHopPermit2.state,
+      firstHopSwap.state,
+      lastHopSwap.state,
+      firstHopAllowanceReset.state,
+      lastHopAllowanceReset.state,
+    ].includes(TransactionExecutionState.Failed)
+  }, [
+    firstHopAllowanceApproval.state,
+    firstHopAllowanceReset.state,
+    firstHopPermit2.state,
+    firstHopSwap.state,
+    lastHopAllowanceApproval.state,
+    lastHopAllowanceReset.state,
+    lastHopPermit2.state,
+    lastHopSwap.state,
+  ])
+
   const { currentTradeStepIndex: currentStep } = useStepperSteps()
 
   const stepIndicator = useMemo(
@@ -143,10 +166,12 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
       <StepStatus
         complete={completedStepIndicator}
         incomplete={undefined}
-        active={activeQuoteError ? erroredStepIndicator : undefined}
+        active={
+          activeQuoteError || transactionExecutionStateError ? erroredStepIndicator : undefined
+        }
       />
     ),
-    [activeQuoteError],
+    [activeQuoteError, transactionExecutionStateError],
   )
 
   const firstHopAllowanceResetTitle = useMemo(() => {


### PR DESCRIPTION
## Description

Better handles trade failure status in inner steps (new trade flow):

<img width="397" alt="Screenshot 2025-01-07 at 18 24 15" src="https://github.com/user-attachments/assets/729047a3-fcbd-4211-a506-7947f2f96091" />

We now show the error icon instead of the "active blue circle".

## Issue (if applicable)

Addresses review comment: https://github.com/shapeshift/web/pull/8192#discussion_r1889896655

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

Ensure new trade flow is active (`REACT_APP_FEATURE_NEW_TRADE_FLOW`).

Cause a trade error during the confirmation flow - an easy way to do this is decline a transaction on Metamask etc.

Confirm step shows error icon.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

See description.