### PR TITLE
fix: new trade flow multi-hop Txs

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
@@ -1,5 +1,5 @@
 import type { SupportedTradeQuoteStepIndex, TradeQuoteStep } from '@shapeshiftoss/swapper'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { useHistory } from 'react-router-dom'
 import { useGetTradeQuotes } from 'components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes'
 import { TradeRoutePaths } from 'components/MultiHopTrade/types'
@@ -41,7 +41,6 @@ export const useTradeButtonProps = ({
   activeTradeId,
   isExactAllowance,
 }: UseTradeButtonPropsProps): TradeButtonProps | undefined => {
-  const [isSignTxLoading, setIsSignTxLoading] = useState(false)
   const dispatch = useAppDispatch()
   const history = useHistory()
   const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
@@ -82,8 +81,6 @@ export const useTradeButtonProps = ({
       console.error('attempted to execute in-progress swap')
       return
     }
-
-    setIsSignTxLoading(true)
 
     executeTrade()
   }, [executeTrade, swapTxState])
@@ -131,7 +128,7 @@ export const useTradeButtonProps = ({
       return {
         onSubmit: handleSignTx,
         buttonText,
-        isLoading: isSignTxLoading || isFetching,
+        isLoading: isFetching,
         isDisabled: !tradeQuoteQueryData,
       }
     case HopExecutionState.Complete:


### PR DESCRIPTION
## Description

<!-- Please describe your changes -->

Second hop Txs were broken with the new trade flow. The reason for that was the superfluous `isSignTxLoading` loading state directive.

This was being set to true on *trade* (not hop) initiation, and was never being set to false thereafter, meaning the second hop Tx would always be in a perma-loading state.

Fixed by removing `isSignTxLoading`. We actually have this guy which does what `isSignTxLoading` actually intended to:

https://github.com/shapeshift/web/blob/1b2fac1445ef5b49853957d1213cf4d1a9c4fee7/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx#L36

The difference being `hasClickedButton` actually resets to false on *hop* state changes, vs. being perma-set to true, so it achieves what the former intended to without breaking things.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8469

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get a multi-hop quote e.g ETH.ARB -> BNB.BNB
- Ensure after the first hop completes (i.e 15-20mn for those Allbridge Txs), button becomes clickable again and triggers the second hop.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

Note the rug in the Jam as I got rate-limited, but CTA actually did the do

https://jam.dev/c/5a5cdc4e-806e-4fb6-99d1-0ed243992776

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
