### PR TITLE
fix: confirm screen shows wrong buyAsset

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/MultiHopTradeConfirm.tsx
@@ -146,7 +146,7 @@ export const MultiHopTradeConfirm = memo(() => {
               isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.tradeSuccess' : undefined
             }
             sellAsset={activeQuote?.steps[0].sellAsset}
-            buyAsset={activeQuote?.steps[0].buyAsset}
+            buyAsset={lastHop.buyAsset}
             sellAmountCryptoPrecision={fromBaseUnit(
               activeQuote.steps[0].sellAmountIncludingProtocolFeesCryptoBaseUnit,
               activeQuote.steps[0].sellAsset.precision,

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -87,7 +87,7 @@ export const TradeConfirm = () => {
             isArbitrumBridgeWithdraw ? 'bridge.arbitrum.success.tradeSuccess' : undefined
           }
           sellAsset={activeQuote?.steps[0].sellAsset}
-          buyAsset={activeQuote?.steps[0].buyAsset}
+          buyAsset={tradeQuoteLastHop.buyAsset}
           sellAmountCryptoPrecision={fromBaseUnit(
             activeQuote.steps[0].sellAmountIncludingProtocolFeesCryptoBaseUnit,
             activeQuote.steps[0].sellAsset.precision,


### PR DESCRIPTION
## Description

The swapper confirm screen was using the buyAsset of the first hop instead of the last hop


<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8494

## Risk
Low (presentational)

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Do a multihop swap (both new trade flow and old trade flow are affected, you can test both but the logic remain very similar)
- Confirm screen should show the correct buyAsset
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/17595bab-3c96-4aa9-b8f0-f4c264e0a6f1)
<img width="473" alt="image" src="https://github.com/user-attachments/assets/4084b711-9b0b-46f3-ae59-8494d49d5802" />
w