### PR TITLE
fix: new swapper flow cow buy Tx links

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -248,6 +248,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             )}
             {firstHopSwap.buyTxHash && firstHopSwap.buyTxHash !== firstHopSwap.sellTxHash && (
               <TxLabel
+                isBuyTxHash
                 txHash={firstHopSwap.buyTxHash}
                 explorerBaseUrl={tradeQuoteFirstHop.buyAsset.explorerTxLink}
                 accountId={firstHopSellAccountId}

--- a/src/components/MultiHopTrade/components/TradeConfirm/TxLabel.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TxLabel.tsx
@@ -10,11 +10,13 @@ export const TxLabel = ({
   explorerBaseUrl,
   accountId,
   swapperName,
+  isBuyTxHash,
 }: {
   txHash: string
   explorerBaseUrl: string
   accountId: AccountId
   swapperName: SwapSource | undefined
+  isBuyTxHash?: boolean
 }) => {
   const { data: maybeSafeTx } = useSafeTxQuery({
     maybeSafeTxHash: txHash,
@@ -24,9 +26,9 @@ export const TxLabel = ({
   const txLink = getTxLink({
     defaultExplorerBaseUrl: explorerBaseUrl,
     maybeSafeTx,
-    tradeId: txHash,
     accountId,
     name: swapperName,
+    ...(isBuyTxHash ? { txId: txHash } : { tradeId: txHash }),
   })
 
   return txLink ? (


### PR DESCRIPTION
## Description

Does what it says on the box - buy Tx hashes were producing a Tx link which was not matching prod i.e /orders/<hash> vs /tx/<hash>.
Fixed by ensuring we use the right txId / tradeId property depending on whether or not the current Tx is a buy Tx hash.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8478

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - CoW is the only one leveraging `isOrder` property and having different Tx links programmatic on txId / tradeId.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Proceed with a CoW swap e2e
- Ensure both Tx links are valid 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="909" alt="Screenshot 2025-01-07 at 23 56 39" src="https://github.com/user-attachments/assets/baac8328-8630-487a-8d34-1c649c6ea18b" />
https://explorer.cow.fi/orders/0x58e82e87cab4e04826bb621b5c3d14bfa7e0ec29935ce6d96b2ac5b0fef2dd34?tab=orders


- this diff


<img width="894" alt="Screenshot 2025-01-07 at 23 58 39" src="https://github.com/user-attachments/assets/36af0726-c032-4617-9060-1b6ffcb46276" />
https://explorer.cow.fi/tx/0x58e82e87cab4e04826bb621b5c3d14bfa7e0ec29935ce6d96b2ac5b0fef2dd34


<img width="1265" alt="image" src="https://github.com/user-attachments/assets/b3c3e614-5c0b-4bd5-8687-abbf43975476" />
https://explorer.cow.fi/orders/0xfbd2fcba60cff21070362b6258d64a1917f9fbacf6cc8740976f7d1a1d9b52875daf465a9ccf64deb146eeae9e7bd40d6761c986677d9016?tab=overview

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
