### PR TITLE
fix: limit order buy asset dropdown having unsupported chains

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -73,9 +73,10 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
           onAssetClick={handleAssetClick}
           onAssetChange={onSetBuyAsset}
           onlyConnectedChains={false}
+          chainIdFilterPredicate={chainIdFilterPredicate}
         />
       ),
-      [asset.assetId, handleAssetClick, onSetBuyAsset],
+      [asset.assetId, handleAssetClick, onSetBuyAsset, chainIdFilterPredicate],
     )
 
     return (


### PR DESCRIPTION
## Description

Fixes limit order buy asset chain drop-down having unsupported chain IDs.

## Issue (if applicable)

https://discord.com/channels/554694662431178782/1324596242394644571/1325626856069660756

## Risk

Very low. If this is wrong the cowswap API will prevent a quote coming back, so users are protected from any loss of funds etc.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Check limit orders buy asset chain drop-down only displays supported cowswap chain IDs

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

See https://discord.com/channels/554694662431178782/1324596242394644571/1325626856069660756

## Screenshots (if applicable)

Before:
<img src="https://github.com/user-attachments/assets/e7597165-1c1a-429b-bd44-e555365a8e5b" width="200">

After:
<img src="https://github.com/user-attachments/assets/14b1adb3-3c42-47cd-b34f-d58c8f620e08" width="200">

