### PR TITLE
chore: walletconnect out has helper text

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2219,7 +2219,8 @@
           "connectionError": "Can't connect to provided URI.",
           "invalidUri": "Invalid URI",
           "v1UriUnsupported": "WalletConnect V1 URI not enabled",
-          "v2UriUnsupported": "WalletConnect V2 URI not enabled"
+          "v2UriUnsupported": "WalletConnect V2 URI not enabled",
+          "disclaimerBody": "Shapeshift cannot ensure the safety or security of third-party applications. By using WalletConnect, you assume full responsibility for any risks involved."
         },
         "sessionProposal": {
           "dAppInfo": "dApp Info",

--- a/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
@@ -21,7 +21,6 @@ import { QRCodeIcon } from 'components/Icons/QRCode'
 import { WalletConnectIcon } from 'components/Icons/WalletConnectIcon'
 import { QrCodeScanner } from 'components/QrCodeScanner/QrCodeScanner'
 import { Text } from 'components/Text'
-import { AlertStyle } from 'components/Alert/Alert.theme'
 
 type FormValues = {
   uri: string
@@ -118,7 +117,7 @@ export const ConnectContent: React.FC<ConnectContentProps> = ({
             <AlertDescription>
               {translate('plugins.walletConnectToDapps.modal.connect.disclaimerBody')}
             </AlertDescription>
-          </Alert> 
+          </Alert>
           <Button
             isDisabled={!isValidUri}
             colorScheme='blue'

--- a/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertDescription,
   Box,
   Button,
   FormControl,
@@ -19,6 +21,7 @@ import { QRCodeIcon } from 'components/Icons/QRCode'
 import { WalletConnectIcon } from 'components/Icons/WalletConnectIcon'
 import { QrCodeScanner } from 'components/QrCodeScanner/QrCodeScanner'
 import { Text } from 'components/Text'
+import { AlertStyle } from 'components/Alert/Alert.theme'
 
 type FormValues = {
   uri: string
@@ -111,6 +114,11 @@ export const ConnectContent: React.FC<ConnectContentProps> = ({
             </InputGroup>
             <FormErrorMessage>{formState.errors?.uri?.message}</FormErrorMessage>
           </FormControl>
+          <Alert status='warning'>
+            <AlertDescription>
+              {translate('plugins.walletConnectToDapps.modal.connect.disclaimerBody')}
+            </AlertDescription>
+          </Alert> 
           <Button
             isDisabled={!isValidUri}
             colorScheme='blue'


### PR DESCRIPTION
## Description

Adds an alert div with some text so people know on native wallet to be careful before they jeet out walletconnections.

## Issue (if applicable)

Closes #5727  with text we aligned on. 

## Risk

Low risk, is just a warning alert.

## Testing
Spinup local, use native wallet to stare at coonect to Dapp button. 
Make sure it looks like this: 
![Screenshot 2025-01-07 at 2 11 24 PM](https://github.com/user-attachments/assets/2bd60625-9e28-424d-a145-854013a206f6)

### Engineering

Worked locally. 😅 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

is above.