### PR TITLE
fix: undefined queryFn return

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
@@ -216,7 +216,7 @@ export const useGetTradeRates = () => {
       // Early exit on any invalid state
       if (bnOrZero(sellAmountCryptoPrecision).isZero()) {
         dispatch(tradeQuoteSlice.actions.setIsTradeQuoteRequestAborted(true))
-        return
+        return null
       }
       const sellAccountNumber = sellAccountMetadata?.bip44Params?.accountNumber
 


### PR DESCRIPTION
## Description

Fix `getTradeRateInput` query returning `undefined` which causes console spew insanity on initial swapper load.

## Issue (if applicable)

QOL.

## Risk

Low risk.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

Confirm initial load of swapper does not produce the console spew below.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="1337" alt="Screenshot 2025-01-08 at 11 51 57" src="https://github.com/user-attachments/assets/eb1b7ed0-d545-4b88-974e-b006f56a9601" />
