### PR TITLE
fix: handle small screens on new swapper flow

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandableStepperSteps.tsx
@@ -92,7 +92,7 @@ export const ExpandableStepperSteps = ({
     if (!stepSummaryTranslation) return null
 
     return (
-      <Flex alignItems='center' justifyContent='space-between' flex={1}>
+      <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
         <Text translation={stepSummaryTranslation} />
         <HStack mr={2}>
           <Progress

--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -230,11 +230,14 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
 
   const firstHopActionTitle = useMemo(() => {
     return (
-      <Flex alignItems='center' justifyContent='space-between' flex={1}>
+      <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
         <HStack>
           <RawText>{firstHopActionTitleText}</RawText>
           {firstHopStreamingProgress && firstHopStreamingProgress.totalSwapCount > 0 && (
-            <Tag colorScheme={firstHopStreamingProgress.isComplete ? 'green' : 'blue'}>
+            <Tag
+              minWidth='auto'
+              colorScheme={firstHopStreamingProgress.isComplete ? 'green' : 'blue'}
+            >
               {`${firstHopStreamingProgress.attemptedSwapCount}/${firstHopStreamingProgress.totalSwapCount}`}
             </Tag>
           )}
@@ -325,11 +328,14 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
 
   const lastHopActionTitle = useMemo(() => {
     return (
-      <Flex alignItems='center' justifyContent='space-between' flex={1}>
+      <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
         <HStack>
           <RawText>{lastHopActionTitleText}</RawText>
           {secondHopStreamingProgress && secondHopStreamingProgress.totalSwapCount > 0 && (
-            <Tag colorScheme={secondHopStreamingProgress.isComplete ? 'green' : 'blue'}>
+            <Tag
+              minWidth='auto'
+              colorScheme={secondHopStreamingProgress.isComplete ? 'green' : 'blue'}
+            >
               {`${secondHopStreamingProgress.attemptedSwapCount}/${secondHopStreamingProgress.totalSwapCount}`}
             </Tag>
           )}


### PR DESCRIPTION
## Description

Improve padding on the new swapper flow to better handle small screens.

## Issue (if applicable)

Progresses https://github.com/shapeshift/web/issues/8118

## Risk

Small - style tweaks only.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

### Engineering

Check new swapper flow still looks pretty when TX links render alongside streaming progress (monkey patch https://github.com/shapeshift/web/blob/0e0deca2747dfb3aaed49d1ffbdf4a10adc8da16/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx#L334 by removing the conditional and hardcoding values if you'd like, or "trust me bro")

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

`develop`

![image](https://github.com/user-attachments/assets/4654d8a4-5509-4de5-96df-d98dd809aaf3)

<img width="406" alt="Screenshot 2025-01-08 at 08 45 55" src="https://github.com/user-attachments/assets/b79e8c29-d427-4ba3-99b8-d4a8db92ee15" />

This PR

<img width="290" alt="Screenshot 2025-01-08 at 14 50 15" src="https://github.com/user-attachments/assets/84290c9d-4c5b-44d5-b70a-3f12b25bb7e7" />
