### PR TITLE
feat: actually make permit2 allowance/sign distinct steps

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/ExpandedStepperSteps.tsx
@@ -211,21 +211,6 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             </Tooltip>
           </>
         )
-      // Allowance granted, but still waiting for the actual Permit2 signature granting temp 5mn allowance to the contract
-      if (
-        firstHopPermit2.isRequired &&
-        hopExecutionState === HopExecutionState.AwaitingPermit2Eip712Sign
-      )
-        return (
-          <>
-            <Text translation='trade.permit2Eip712.title' />
-            <Tooltip label={translate('trade.permit2Eip712.tooltip', { swapperName })}>
-              <Box ml={1}>
-                <Icon as={FaInfoCircle} color='text.subtle' fontSize='0.8em' />
-              </Box>
-            </Tooltip>
-          </>
-        )
 
       // Good ol' allowances
       return (
@@ -252,10 +237,22 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     firstHopPermit2.isRequired,
     firstHopSellAccountId,
     hopExecutionState,
-    swapperName,
     tradeQuoteFirstHop,
     translate,
   ])
+
+  const firstHopPermit2SignTitle = useMemo(() => {
+    return (
+      <Flex alignItems='center' justifyContent='space-between' flex={1}>
+        <Text translation='trade.permit2Eip712.title' />
+        <Tooltip label={translate('trade.permit2Eip712.tooltip', { swapperName })}>
+          <Box ml={1}>
+            <Icon as={FaInfoCircle} color='text.subtle' fontSize='0.8em' />
+          </Box>
+        </Tooltip>
+      </Flex>
+    )
+  }, [swapperName, translate])
 
   const firstHopActionTitle = useMemo(() => {
     return (
@@ -448,6 +445,16 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
       {tradeSteps[StepperStep.FirstHopApproval] ? (
         <StepperStepComponent
           title={firstHopAllowanceApprovalTitle}
+          stepIndicator={stepIndicator}
+          stepProps={stepProps}
+          useSpacer={false}
+          isError={isError && currentTradeStep === StepperStep.FirstHopApproval}
+          stepIndicatorVariant='innerSteps'
+        />
+      ) : null}
+      {tradeSteps[StepperStep.FirstHopPermit2Sign] ? (
+        <StepperStepComponent
+          title={firstHopPermit2SignTitle}
           stepIndicator={stepIndicator}
           stepProps={stepProps}
           useSpacer={false}

--- a/src/components/MultiHopTrade/components/TradeConfirm/helpers.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/helpers.ts
@@ -106,11 +106,11 @@ export const countStepperSteps = (params: StepperStepParams): number => {
 }
 
 const isInApprovalState = (state: HopExecutionState): boolean => {
-  return [HopExecutionState.AwaitingAllowanceApproval].includes(state)
+  return state === HopExecutionState.AwaitingAllowanceApproval
 }
 
 const isInPermit2SignState = (state: HopExecutionState): boolean => {
-  return [HopExecutionState.AwaitingPermit2Eip712Sign].includes(state)
+  return state === HopExecutionState.AwaitingPermit2Eip712Sign
 }
 
 export const getCurrentStepperStep = (

--- a/src/components/MultiHopTrade/components/TradeConfirm/helpers.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/helpers.ts
@@ -60,6 +60,7 @@ type StepperStepParams = {
 
 export enum StepperStep {
   FirstHopReset = 'firstHopReset',
+  FirstHopPermit2Sign = 'firstHopPermit2Sign',
   FirstHopApproval = 'firstHopApproval',
   FirstHopSwap = 'firstHopSwap',
   LastHopReset = 'lastHopReset',
@@ -83,9 +84,8 @@ export const getStepperSteps = (params: StepperStepParams): Record<StepperStep, 
       firstHopAllowanceReset.isRequired === true || firstHopAllowanceReset.txHash !== undefined,
     [StepperStep.FirstHopApproval]:
       firstHopAllowanceApproval.isInitiallyRequired === true ||
-      firstHopPermit2.isRequired === true ||
-      firstHopAllowanceApproval.txHash !== undefined ||
-      firstHopPermit2.permit2Signature !== undefined,
+      firstHopAllowanceApproval.txHash !== undefined,
+    [StepperStep.FirstHopPermit2Sign]: firstHopPermit2.isRequired === true,
     [StepperStep.FirstHopSwap]: true,
     [StepperStep.LastHopReset]:
       isMultiHopTrade === true &&
@@ -106,10 +106,11 @@ export const countStepperSteps = (params: StepperStepParams): number => {
 }
 
 const isInApprovalState = (state: HopExecutionState): boolean => {
-  return [
-    HopExecutionState.AwaitingAllowanceApproval,
-    HopExecutionState.AwaitingPermit2Eip712Sign,
-  ].includes(state)
+  return [HopExecutionState.AwaitingAllowanceApproval].includes(state)
+}
+
+const isInPermit2SignState = (state: HopExecutionState): boolean => {
+  return [HopExecutionState.AwaitingPermit2Eip712Sign].includes(state)
 }
 
 export const getCurrentStepperStep = (
@@ -123,6 +124,7 @@ export const getCurrentStepperStep = (
     if (hopExecutionState === HopExecutionState.AwaitingAllowanceReset)
       return StepperStep.FirstHopReset
     if (isInApprovalState(hopExecutionState)) return StepperStep.FirstHopApproval
+    if (isInPermit2SignState(hopExecutionState)) return StepperStep.FirstHopPermit2Sign
     if (hopExecutionState === HopExecutionState.AwaitingSwap) return StepperStep.FirstHopSwap
   } else if (currentHopIndex === 1) {
     if (hopExecutionState === HopExecutionState.AwaitingAllowanceReset)


### PR DESCRIPTION
## Description

Follows up on #8508 by *akschually* making the steps separate. 

While 8508 made sure we use nice copies for permit2 contract allowance / permit2 sign, this actually splits the two into separate steps.

Note, this is for new swapper flow only.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8505

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

Test with new swapper flow flag on - effectively the same as https://github.com/shapeshift/web/pull/8508, except for the first case, where there should be two explicit steps.

### 0x trade - No Permit2 allowance granted for asset 

- Infinite permit2 allowance grant step should be triggered, with sane looking copies that clearly explain what this is about
- Permit2 message signing step should be triggered, with sane looking copies as well that clearly explain the diff. between this and the previous step

### 0x trade - Infinite Permit2 allowance already granted for asset

- Ensure you have Infinite permit2 allowance already for that asset. You can check it on revoke.cash and confirm Permit2 has unlimited allowance for the asset you're selling. If you don't have it already granted, you can do so by starting the 0x swap flow, grant unlimited allowance, and hard refresh the app
- 0x swapper should *not* trigger another Permit2 infinite allowance since already granted
- 0x swapper should however trigger a Permit2 message signing, with copies looking sane

### Non-0x-trade

- Allowance stages/behaviour should look the same as before.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None yet! This only touches the new trade flow under flag.

## Screenshots (if applicable)

- 0x trade - No Permit2 allowance granted for asset 

https://jam.dev/c/22ecd401-665f-40ab-910e-c66e71019df9

- 0x trade - Permit2 allowance granted for asset 

https://jam.dev/c/ae7cf74e-90a7-4e97-b929-8e06c8116307

- Good ol' allowances

https://jam.dev/c/f1cf7bdf-4f3a-4760-9a3d-d813d175b401

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_permit2_improve","parentHead":"2821768ec3cd3c4ac185d9f2a8a2528cf2dc156f","parentPull":8508,"trunk":"develop"}
```
-->
