### PR TITLE
fix: wallet state corruption round 4

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,13 +11,7 @@ import { IconCircle } from 'components/IconCircle'
 import { useBridgeClaimNotification } from 'hooks/useBridgeClaimNotification/useBridgeClaimNotification'
 import { useHasAppUpdated } from 'hooks/useHasAppUpdated/useHasAppUpdated'
 import { useModal } from 'hooks/useModal/useModal'
-import { useWallet } from 'hooks/useWallet/useWallet'
-import {
-  selectShowConsentBanner,
-  selectShowWelcomeModal,
-  selectWalletId,
-} from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import { selectShowConsentBanner, selectShowWelcomeModal } from 'state/slices/selectors'
 
 const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
@@ -74,19 +68,6 @@ export const App = () => {
       openNativeOnboard({})
     }
   }, [isNativeOnboardOpen, openNativeOnboard, showWelcomeModal])
-
-  const portfolioWalletId = useAppSelector(selectWalletId)
-
-  const {
-    state: { deviceId: contextDeviceId },
-  } = useWallet()
-
-  useEffect(() => {
-    console.log({
-      portfolioWalletId,
-      contextDeviceId,
-    })
-  }, [contextDeviceId, portfolioWalletId])
 
   return (
     <>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,7 +11,13 @@ import { IconCircle } from 'components/IconCircle'
 import { useBridgeClaimNotification } from 'hooks/useBridgeClaimNotification/useBridgeClaimNotification'
 import { useHasAppUpdated } from 'hooks/useHasAppUpdated/useHasAppUpdated'
 import { useModal } from 'hooks/useModal/useModal'
-import { selectShowConsentBanner, selectShowWelcomeModal } from 'state/slices/selectors'
+import { useWallet } from 'hooks/useWallet/useWallet'
+import {
+  selectShowConsentBanner,
+  selectShowWelcomeModal,
+  selectWalletId,
+} from 'state/slices/selectors'
+import { useAppSelector } from 'state/store'
 
 const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
@@ -68,6 +74,19 @@ export const App = () => {
       openNativeOnboard({})
     }
   }, [isNativeOnboardOpen, openNativeOnboard, showWelcomeModal])
+
+  const portfolioWalletId = useAppSelector(selectWalletId)
+
+  const {
+    state: { deviceId: contextDeviceId },
+  } = useWallet()
+
+  useEffect(() => {
+    console.log({
+      portfolioWalletId,
+      contextDeviceId,
+    })
+  }, [contextDeviceId, portfolioWalletId])
 
   return (
     <>

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -305,6 +305,11 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
   }, [])
 
   const handleDone = useCallback(async () => {
+    if (!walletDeviceId) {
+      console.error('Missing walletDeviceId')
+      return
+    }
+
     if (isDemoWallet) {
       walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
       accountManagementPopover.close()
@@ -314,11 +319,6 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
 
     if (!accounts) {
       console.error('Missing accounts data')
-      return
-    }
-
-    if (!walletDeviceId) {
-      console.error('Missing walletDeviceId')
       return
     }
 

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -317,6 +317,11 @@ export const ImportAccounts = ({ chainId, onClose }: ImportAccountsProps) => {
       return
     }
 
+    if (!walletDeviceId) {
+      console.error('Missing walletDeviceId')
+      return
+    }
+
     setIsSubmitting(true)
 
     // For every new account that is active, fetch the account and upsert it into the redux state

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -66,7 +66,7 @@ export const useReceiveAddress = ({
       ? skipToken
       : async () => {
           // Already partially covered in isInitializing, but TypeScript lyfe mang.
-          if (!buyAsset || !wallet || !buyAccountId || !buyAccountMetadata) {
+          if (!buyAsset || !wallet || !buyAccountId || !buyAccountMetadata || !deviceId) {
             return undefined
           }
 

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -62,41 +62,42 @@ export const useReceiveAddress = ({
       sellAccountId,
       buyAccountId,
     ],
-    queryFn: isInitializing
-      ? skipToken
-      : async () => {
-          // Already partially covered in isInitializing, but TypeScript lyfe mang.
-          if (!buyAsset || !wallet || !buyAccountId || !buyAccountMetadata || !deviceId) {
-            return undefined
+    queryFn:
+      !isInitializing && buyAsset && wallet && buyAccountId && buyAccountMetadata && deviceId
+        ? async () => {
+            // Already partially covered in isInitializing, but TypeScript lyfe mang.
+            if (!buyAsset || !wallet || !buyAccountId || !buyAccountMetadata || !deviceId) {
+              return undefined
+            }
+
+            const buyAssetChainId = buyAsset.chainId
+            const buyAssetAccountChainId = buyAccountId
+              ? fromAccountId(buyAccountId).chainId
+              : undefined
+
+            /**
+             * do NOT remove
+             * super dangerous - don't use the wrong bip44 params to generate receive addresses
+             */
+            if (buyAssetChainId !== buyAssetAccountChainId) {
+              return undefined
+            }
+
+            if (isUtxoAccountId(buyAccountId) && !buyAccountMetadata?.accountType)
+              throw new Error(`Missing accountType for UTXO account ${buyAccountId}`)
+
+            const shouldFetchUnchainedAddress = Boolean(wallet && isLedger(wallet))
+            const walletReceiveAddress = await getReceiveAddress({
+              asset: buyAsset,
+              wallet,
+              accountMetadata: buyAccountMetadata,
+              deviceId,
+              pubKey: shouldFetchUnchainedAddress ? fromAccountId(buyAccountId).account : undefined,
+            })
+
+            return walletReceiveAddress
           }
-
-          const buyAssetChainId = buyAsset.chainId
-          const buyAssetAccountChainId = buyAccountId
-            ? fromAccountId(buyAccountId).chainId
-            : undefined
-
-          /**
-           * do NOT remove
-           * super dangerous - don't use the wrong bip44 params to generate receive addresses
-           */
-          if (buyAssetChainId !== buyAssetAccountChainId) {
-            return undefined
-          }
-
-          if (isUtxoAccountId(buyAccountId) && !buyAccountMetadata?.accountType)
-            throw new Error(`Missing accountType for UTXO account ${buyAccountId}`)
-
-          const shouldFetchUnchainedAddress = Boolean(wallet && isLedger(wallet))
-          const walletReceiveAddress = await getReceiveAddress({
-            asset: buyAsset,
-            wallet,
-            accountMetadata: buyAccountMetadata,
-            deviceId,
-            pubKey: shouldFetchUnchainedAddress ? fromAccountId(buyAccountId).account : undefined,
-          })
-
-          return walletReceiveAddress
-        },
+        : skipToken,
     staleTime: Infinity,
   })
 

--- a/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
@@ -22,7 +22,7 @@ export const KeepKeyPassphrase = () => {
     state: { deviceId, keyring },
     dispatch,
   } = useWallet()
-  const wallet = keyring.get(deviceId)
+  const wallet = keyring.get(deviceId ?? '')
   const walletId = useAppSelector(selectWalletId)
   const appDispatch = useAppDispatch()
 

--- a/src/context/WalletProvider/KeepKey/components/Pin.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Pin.tsx
@@ -38,7 +38,7 @@ export const KeepKeyPin = ({
     },
     dispatch,
   } = useWallet()
-  const wallet = keyring.get(deviceId)
+  const wallet = keyring.get(deviceId ?? '')
 
   const pinFieldRef = useRef<HTMLInputElement | null>(null)
 
@@ -138,10 +138,10 @@ export const KeepKeyPin = ({
       }
     }
 
-    keyring.on(['KeepKey', deviceId, String(MessageType.FAILURE)], handleError)
+    keyring.on(['KeepKey', deviceId ?? '', String(MessageType.FAILURE)], handleError)
 
     return () => {
-      keyring.off(['KeepKey', deviceId, String(MessageType.FAILURE)], handleError)
+      keyring.off(['KeepKey', deviceId ?? '', String(MessageType.FAILURE)], handleError)
     }
   }, [deviceId, keyring])
 

--- a/src/context/WalletProvider/KeepKey/components/Pin.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Pin.tsx
@@ -2,7 +2,7 @@ import type { ButtonProps, SimpleGridProps } from '@chakra-ui/react'
 import { Alert, AlertDescription, AlertIcon, Button, Input, SimpleGrid } from '@chakra-ui/react'
 import type { Event } from '@shapeshiftoss/hdwallet-core'
 import type { KeyboardEvent } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CircleIcon } from 'components/Icons/Circle'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
@@ -38,7 +38,11 @@ export const KeepKeyPin = ({
     },
     dispatch,
   } = useWallet()
-  const wallet = keyring.get(deviceId ?? '')
+
+  const wallet = useMemo(() => {
+    if (!deviceId) return null
+    return keyring.get(deviceId)
+  }, [deviceId, keyring])
 
   const pinFieldRef = useRef<HTMLInputElement | null>(null)
 

--- a/src/context/WalletProvider/KeepKey/components/Pin.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Pin.tsx
@@ -142,10 +142,10 @@ export const KeepKeyPin = ({
       }
     }
 
-    keyring.on(['KeepKey', deviceId ?? '', String(MessageType.FAILURE)], handleError)
+    deviceId && keyring.on(['KeepKey', deviceId, String(MessageType.FAILURE)], handleError)
 
     return () => {
-      keyring.off(['KeepKey', deviceId ?? '', String(MessageType.FAILURE)], handleError)
+      deviceId && keyring.off(['KeepKey', deviceId, String(MessageType.FAILURE)], handleError)
     }
   }, [deviceId, keyring])
 

--- a/src/context/WalletProvider/Ledger/components/Chains.tsx
+++ b/src/context/WalletProvider/Ledger/components/Chains.tsx
@@ -52,7 +52,8 @@ export const LedgerChains = () => {
 
   const handleConnectClick = useCallback(
     async (chainId: ChainId) => {
-      if (!walletState?.wallet) {
+      const { wallet, deviceId } = walletState ?? {}
+      if (!wallet || !deviceId) {
         console.error('No wallet found')
         return
       }
@@ -67,7 +68,7 @@ export const LedgerChains = () => {
         ]({
           accountNumber: 0,
           chainIds,
-          wallet: walletState.wallet,
+          wallet,
           isSnapInstalled: false,
         })
 
@@ -102,7 +103,7 @@ export const LedgerChains = () => {
           const accountMetadata = accountMetadataByAccountId[accountId]
           const payload = {
             accountMetadataByAccountId: { [accountId]: accountMetadata },
-            walletId: walletState.deviceId,
+            walletId: deviceId,
           }
 
           dispatch(portfolio.actions.upsertAccountMetadata(payload))
@@ -120,7 +121,7 @@ export const LedgerChains = () => {
         setLoadingChains(prevLoading => ({ ...prevLoading, [chainId]: false }))
       }
     },
-    [dispatch, walletState.deviceId, walletState.wallet],
+    [dispatch, walletState],
   )
 
   const chainsRows = useMemo(

--- a/src/context/WalletProvider/Ledger/components/Chains.tsx
+++ b/src/context/WalletProvider/Ledger/components/Chains.tsx
@@ -52,7 +52,8 @@ export const LedgerChains = () => {
 
   const handleConnectClick = useCallback(
     async (chainId: ChainId) => {
-      const { wallet, deviceId } = walletState ?? {}
+      const { wallet, deviceId } = walletState
+
       if (!wallet || !deviceId) {
         console.error('No wallet found')
         return

--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -47,9 +47,6 @@ export const EnterPassword = () => {
 
   const [showPw, setShowPw] = useState<boolean>(false)
 
-  // TODO: this is always null
-  console.log('EnterPassword', deviceId)
-
   const {
     setError,
     handleSubmit,
@@ -61,6 +58,7 @@ export const EnterPassword = () => {
   const onSubmit = useCallback(
     async (values: FieldValues) => {
       try {
+        if (!deviceId) return
         const wallet = keyring.get<NativeHDWallet>(deviceId)
         const Vault = await import('@shapeshiftoss/hdwallet-native-vault').then(m => m.Vault)
         const vault = await Vault.open(deviceId, values.password)

--- a/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/EnterPassword.tsx
@@ -43,9 +43,12 @@ export const EnterPassword = () => {
   const translate = useTranslate()
   const { state, dispatch, disconnect } = useWallet()
   const localWallet = useLocalWallet()
-  const { deviceId, keyring } = state
+  const { nativeWalletPendingDeviceId: deviceId, keyring } = state
 
   const [showPw, setShowPw] = useState<boolean>(false)
+
+  // TODO: this is always null
+  console.log('EnterPassword', deviceId)
 
   const {
     setError,
@@ -83,6 +86,7 @@ export const EnterPassword = () => {
           type: WalletActions.SET_IS_CONNECTED,
           payload: true,
         })
+        dispatch({ type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID })
         dispatch({ type: WalletActions.SET_LOCAL_WALLET_LOADING, payload: false })
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
       } catch (e) {

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -41,7 +41,7 @@ const walletButtonLeftIcon = (
 )
 
 export const NativeLoad = ({ history }: RouteComponentProps) => {
-  const { getAdapter, dispatch, state } = useWallet()
+  const { getAdapter, dispatch } = useWallet()
   const localWallet = useLocalWallet()
   const [error, setError] = useState<string | null>(null)
   const [wallets, setWallets] = useState<VaultInfo[]>([])
@@ -81,9 +81,6 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
     if (adapter) {
       const { name, icon } = NativeConfig
       try {
-        // // not calling disconnect from useWallet because we don't want to modify state
-        // await state.wallet?.disconnect?.()
-
         // Set a pending device ID so the event handler doesn't redirect the user to password input
         // for the previous wallet
         dispatch({

--- a/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeLoad.tsx
@@ -41,7 +41,7 @@ const walletButtonLeftIcon = (
 )
 
 export const NativeLoad = ({ history }: RouteComponentProps) => {
-  const { getAdapter, dispatch } = useWallet()
+  const { getAdapter, dispatch, state } = useWallet()
   const localWallet = useLocalWallet()
   const [error, setError] = useState<string | null>(null)
   const [wallets, setWallets] = useState<VaultInfo[]>([])
@@ -81,6 +81,16 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
     if (adapter) {
       const { name, icon } = NativeConfig
       try {
+        // // not calling disconnect from useWallet because we don't want to modify state
+        // await state.wallet?.disconnect?.()
+
+        // Set a pending device ID so the event handler doesn't redirect the user to password input
+        // for the previous wallet
+        dispatch({
+          type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID,
+          payload: deviceId,
+        })
+
         const wallet = await adapter.pairDevice(deviceId)
         if (!(await wallet?.isInitialized())) {
           // This will trigger the password modal and the modal will set the wallet on state
@@ -103,6 +113,7 @@ export const NativeLoad = ({ history }: RouteComponentProps) => {
             type: WalletActions.SET_IS_CONNECTED,
             payload: true,
           })
+          dispatch({ type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID })
           // The wallet is already initialized so we can close the modal
           dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         }

--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeEventHandler.ts
@@ -24,11 +24,6 @@ export const useNativeEventHandler = (state: InitialState, dispatch: Dispatch<Ac
             break
           }
 
-          console.log({
-            nativeWalletPendingDeviceId: state.nativeWalletPendingDeviceId,
-            deviceId: state.deviceId,
-          })
-
           // If we're on the native mobile app we don't need to handle the MNEMONIC_REQUIRED event as we use the device's native authentication instead
           // Reacting to this event will incorrectly open the native password modal after authentication completes when on the mobile app
           if (isMobileApp) break

--- a/src/context/WalletProvider/WalletConnectV2/useWalletConnectV2EventHandler.ts
+++ b/src/context/WalletProvider/WalletConnectV2/useWalletConnectV2EventHandler.ts
@@ -21,8 +21,7 @@ export const useWalletConnectV2EventHandler = (
      */
     state.wallet?.disconnect?.()
     dispatch({ type: WalletActions.RESET_STATE })
-    localWallet.clearLocalWallet()
-  }, [dispatch, localWallet, state.wallet])
+  }, [dispatch, state.wallet])
 
   useEffect(() => {
     // This effect should never run for wallets other than WalletConnectV2 since we explicitly tap into @walletconnect/ethereum-provider provider

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -354,6 +354,7 @@ const getInitialState = () => {
      */
     return {
       ...initialState,
+      nativeWalletPendingDeviceId: localWalletDeviceId,
       isLoadingLocalWallet: true,
     }
   }

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -145,7 +145,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
         store.dispatch(portfolioSlice.actions.setWalletMeta(undefined))
       }
       const { deviceId, name, wallet, icon, meta, isDemoWallet, connectedType } = action.payload
-      console.log('SET_WALLET', deviceId)
       // set wallet metadata in redux store
       const walletMeta = {
         walletId: deviceId,
@@ -220,7 +219,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
       }
       return newState
     case WalletActions.NATIVE_PASSWORD_OPEN:
-      console.log('NATIVE_PASSWORD_OPEN', action.payload)
       return {
         ...state,
         modal: action.payload.modal,
@@ -328,8 +326,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
         initialRoute: KeepKeyRoutes.Disconnect,
       }
     case WalletActions.SET_NATIVE_PENDING_DEVICE_ID:
-      console.log('SET_NATIVE_PENDING_DEVICE_ID')
-
       store.dispatch(localWalletSlice.actions.clearLocalWallet())
       store.dispatch(portfolioSlice.actions.setWalletMeta(undefined))
       return {
@@ -340,7 +336,6 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
         nativeWalletPendingDeviceId: action.payload,
       }
     case WalletActions.RESET_NATIVE_PENDING_DEVICE_ID:
-      console.log('RESET_NATIVE_PENDING_DEVICE_ID')
       return {
         ...state,
         nativeWalletPendingDeviceId: null,

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -296,7 +296,7 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
     case WalletActions.SET_LOCAL_WALLET_LOADING:
       return { ...state, isLoadingLocalWallet: action.payload }
     case WalletActions.RESET_STATE:
-      const resetProperties = omit(initialState, ['keyring', 'adapters', 'modal', 'deviceId'])
+      const resetProperties = omit(initialState, ['keyring', 'adapters', 'modal'])
       // reset wallet meta in redux store
       store.dispatch(localWalletSlice.actions.clearLocalWallet())
       store.dispatch(portfolioSlice.actions.setWalletMeta(undefined))
@@ -438,7 +438,6 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
      */
     state.wallet?.disconnect?.()
     dispatch({ type: WalletActions.RESET_STATE })
-    store.dispatch(localWalletSlice.actions.clearLocalWallet())
   }, [state.wallet])
 
   const load = useCallback(() => {

--- a/src/context/WalletProvider/WalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/WalletViewsSwitch.tsx
@@ -15,8 +15,6 @@ import { Route, Switch, useHistory, useLocation, useRouteMatch } from 'react-rou
 import { SlideTransition } from 'components/SlideTransition'
 import { WalletActions } from 'context/WalletProvider/actions'
 import { useWallet } from 'hooks/useWallet/useWallet'
-import { localWalletSlice } from 'state/slices/localWalletSlice/localWalletSlice'
-import { store } from 'state/store'
 
 import { SUPPORTED_WALLETS } from './config'
 import { KeyManager } from './KeyManager'
@@ -63,14 +61,11 @@ export const WalletViewsSwitch = () => {
     if (disposition === 'initializing' || disposition === 'recovering') {
       await wallet?.cancel()
       disconnect()
-      store.dispatch(localWalletSlice.actions.clearLocalWallet())
       dispatch({ type: WalletActions.OPEN_KEEPKEY_DISCONNECT })
     } else {
       history.replace(INITIAL_WALLET_MODAL_ROUTE)
       if (disconnectOnCloseModal) {
         disconnect()
-        dispatch({ type: WalletActions.RESET_STATE })
-        store.dispatch(localWalletSlice.actions.clearLocalWallet())
       } else {
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
       }

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -110,6 +110,6 @@ export type ActionTypes =
   | { type: WalletActions.OPEN_KEEPKEY_DISCONNECT }
   | {
       type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID
-      payload: string | null
+      payload: string
     }
   | { type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID }

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -28,6 +28,8 @@ export enum WalletActions {
   OPEN_KEEPKEY_RECOVERY = 'OPEN_KEEPKEY_RECOVERY',
   OPEN_KEEPKEY_CHARACTER_REQUEST = 'OPEN_KEEPKEY_CHARACTER_REQUEST',
   DOWNLOAD_UPDATER = 'DOWNLOAD_UPDATER',
+  SET_NATIVE_PENDING_DEVICE_ID = 'SET_NATIVE_PENDING_DEVICE_ID',
+  RESET_NATIVE_PENDING_DEVICE_ID = 'RESET_NATIVE_PENDING_DEVICE_ID',
 }
 
 export type ActionTypes =
@@ -62,7 +64,6 @@ export type ActionTypes =
       type: WalletActions.NATIVE_PASSWORD_OPEN
       payload: {
         modal: boolean
-        deviceId: string
       }
     }
   | {
@@ -107,3 +108,8 @@ export type ActionTypes =
       }
     }
   | { type: WalletActions.OPEN_KEEPKEY_DISCONNECT }
+  | {
+      type: WalletActions.SET_NATIVE_PENDING_DEVICE_ID
+      payload: string | null
+    }
+  | { type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID }

--- a/src/pages/Accounts/AddAccountModal.tsx
+++ b/src/pages/Accounts/AddAccountModal.tsx
@@ -98,6 +98,7 @@ export const AddAccountModal = () => {
     if (!wallet) return
     if (!selectedChainId) return
     if (!nextAccountNumber) return
+    if (!walletDeviceId) return
     ;(async () => {
       const accountNumber = nextAccountNumber
       const chainIds = [selectedChainId]


### PR DESCRIPTION
## Description

Patch for state corruption in wallet provider when user backs out of switching wallet. See #7904 for context.

The fix here is a patch to prevent corrupt state by preventing "back-out" of native connect into corrupt state by forcing the previous wallet to first disconnect before the password prompt is displayed.

Previous issue in simplified terms:
1. User is connected to native wallet
2. User clicks "switch wallet"
3. User clicks different native wallet and is presented with password prompt
4. WalletProvider updates the `deviceId` with the new wallet device ID
5. User exits the password prompt without entering the password
6. WalletProvider now has the wrong `deviceId` until they reconnect the wallet

This PR:
1. User is connected to native wallet
2. User clicks "switch wallet"
3. User clicks different native wallet and is presented with password prompt
4. Both the WalletProvider `deviceId` and the redux wallet ID are cleared, wallet is disconnected
5. User exits the password prompt without entering the password
6. User is in a disconnected state without mismatch of wallet device IDs

See below jam exaplaining in more detail.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #7904

## Risk

> High Risk PRs Require 2 approvals

High risk because it modifies WalletProvider and could theoretically result in inability to open a wallet.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

All wallets, especially native.

## Testing

Thoroughly test opening/closing/switching wallets, with more emphasis on native wallet.
Sanity check signin, broadcasting, trading etc is not somehow unexpectedly broken.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Have a watch of my home movie explaining everything (audio on)
https://jam.dev/c/22a2572a-aeb6-4a82-a6c2-bd79bac3079d
