### PR TITLE
fix: thor trade quote don't filter streaming routes out

### DIFF
--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
@@ -159,10 +159,7 @@ export const getL1Quote = async (
 
   const perRouteValues = [getRouteValues(swapQuote, false)]
 
-  if (
-    streamingSwapQuote &&
-    swapQuote.expected_amount_out !== streamingSwapQuote.expected_amount_out
-  ) {
+  if (streamingSwapQuote) {
     perRouteValues.push(getRouteValues(streamingSwapQuote, true))
   }
 


### PR DESCRIPTION
## Description

A one-line diff with a *lot* that goes on it, let's decipher it:

Currently in develop, both `getTradeQuote` and `getTradeRate` for THOR use some filtering logic where, if the expected_amount_out is the same for streaming and regular THOR quotes, then we filter the streaming one out so as not to produce useless dupe quote:

https://github.com/shapeshift/web/blob/ebfd6f1c3dabb5969299ce22f195da18d572cd62/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts#L162-L167

This is all nice and well except when it isn't: THOR has a tendency to *non-deterministically* yield streaming quotes every once in a blue moon. This can be seen in the testing Jam, where I had to attempt many, many tries for that pair to get a streaming quote for $3100 ETH -> BTC same like @MbMaria did when capturing this bug.

This is some weirdness on the THOR side though, as you're guaranteed not to hit those streaming routes twice in a row. The real sell amount that would lead consistent streaming routes for that ETH -> BTC pair is ~#37,000 USD.
If you ever end up with such a quote at rate time, things will look ugly. The streaming quote will be available at rate time, but won't the second time around at quote time since it is unstable by nature. 
Since we use the quote identifier (e.g `THORCHain` or `THORChain- Streaming` to go from rate to quote:

https://github.com/shapeshift/web/blob/ebfd6f1c3dabb5969299ce22f195da18d572cd62/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx#L373-L376

and there is *no* quote for said identifier, then we will silently fail, and signing will be borked without proper error-handling.

This has been fixed by keeping the streaming swaps filtering logic for rates, but removing it for quotes.

Rates are a list, and user-facing. Quotes, on the other hand, are not user-facing the same way (we only select the one we need by its `identifier`), so removing the filtering logic is not only fine, it is the fix here.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8520

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Spam THOR input until you get a streaming rate. Obviously, the higher the amount (i.e a few thousands) the better, but realistically, you may just get one for much less than that, so long as you spam input.
- Continue with the rate
- Ensure you can sign that streaming Tx and we don't silently fail

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/22b02c67-b8e2-422e-bc29-e5b6f28b0e98

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
