### PR TITLE
fix: don't refetch final quotes after swap Tx has been initiated

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -220,6 +220,8 @@ export const useGetTradeQuotes = () => {
   // Don't memo me, this is a ref and needs to re-evaluate every-render
   const swapperName = activeQuoteMetaRef.current?.swapperName
 
+  console.log({ hopExecutionMetadata })
+
   // Is the step we're in a step which requires final quote fetching?
   const isFetchStep = useMemo(() => {
     if (!swapperName) return
@@ -231,9 +233,16 @@ export const useGetTradeQuotes = () => {
           permit2?.state === TransactionExecutionState.AwaitingConfirmation) ||
         (!permit2?.isRequired && hopExecutionMetadata?.state === HopExecutionState.AwaitingSwap)
       )
-
-    return hopExecutionMetadata?.state === HopExecutionState.AwaitingSwap
-  }, [hopExecutionMetadata?.permit2, hopExecutionMetadata?.state, swapperName])
+    return (
+      hopExecutionMetadata?.state === HopExecutionState.AwaitingSwap &&
+      hopExecutionMetadata?.swap?.state === TransactionExecutionState.AwaitingConfirmation
+    )
+  }, [
+    hopExecutionMetadata?.permit2,
+    hopExecutionMetadata?.state,
+    hopExecutionMetadata?.swap?.state,
+    swapperName,
+  ])
 
   const shouldFetchTradeQuotes = useMemo(() => {
     return Boolean(

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -220,8 +220,6 @@ export const useGetTradeQuotes = () => {
   // Don't memo me, this is a ref and needs to re-evaluate every-render
   const swapperName = activeQuoteMetaRef.current?.swapperName
 
-  console.log({ hopExecutionMetadata })
-
   // Is the step we're in a step which requires final quote fetching?
   const isFetchStep = useMemo(() => {
     if (!swapperName) return


### PR DESCRIPTION
## Description

Does what it says on the box: we weren't guarding things well enough, and final quotes *could* potentially refetched (they shouldn't, but they may in rare conditions with THORChain streaming swaps, see https://github.com/shapeshift/web/pull/8526 for more context) after clicking sign and swap.


## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8521

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium - touches final quotes logic

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Add the monkey patch below for THOR streaming swaps

```diff
diff --git a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1Rate.ts b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1Rate.ts
index 7531cdba77..46f8e41e8d 100644
--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1Rate.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1Rate.ts
@@ -84,7 +84,7 @@ export const getL1Rate = async (
     {
       sellAsset,
       buyAssetId: buyAsset.assetId,
-      sellAmountCryptoBaseUnit,
+      sellAmountCryptoBaseUnit: bnOrZero(sellAmountCryptoBaseUnit).times(1000000).toFixed(0),
       receiveAddress,
       streaming: false,
       affiliateBps: requestedAffiliateBps,
@@ -100,7 +100,7 @@ export const getL1Rate = async (
         {
           sellAsset,
           buyAssetId: buyAsset.assetId,
-          sellAmountCryptoBaseUnit,
+          sellAmountCryptoBaseUnit: bnOrZero(sellAmountCryptoBaseUnit).times(1000000).toFixed(0),
           receiveAddress,
           streaming: true,
           affiliateBps: requestedAffiliateBps,
diff --git a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
index 728d92ec91..7cce1a3dc1 100644
--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getL1quote.ts
@@ -84,7 +84,7 @@ export const getL1Quote = async (
     {
       sellAsset,
       buyAssetId: buyAsset.assetId,
-      sellAmountCryptoBaseUnit,
+      sellAmountCryptoBaseUnit: bnOrZero(sellAmountCryptoBaseUnit).times(1000000).toFixed(0),
       receiveAddress,
       streaming: false,
       affiliateBps: requestedAffiliateBps,
@@ -100,7 +100,7 @@ export const getL1Quote = async (
         {
           sellAsset,
           buyAssetId: buyAsset.assetId,
-          sellAmountCryptoBaseUnit,
+          sellAmountCryptoBaseUnit: bnOrZero(sellAmountCryptoBaseUnit).times(1000000).toFixed(0),
           receiveAddress,
           streaming: true,
           affiliateBps: requestedAffiliateBps,
```

- Ensure final quotes are not refetched after clicking sign and swap
- Ensure Portals swaps are still happy e2e
- Ensure ZRX swaps are still happy e2e
- Ensure Li.Fi swaps are still happy e2e


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- Ensure final quotes are not refetched after clicking sign and swap

https://jam.dev/c/4d34b1f1-bfe1-4758-9744-cf2fcb700d9b


- Ensure Portals swaps are still happy e2e

https://jam.dev/c/5e922526-f3cb-4f65-a80b-e9ea99c3c3c7

- Ensure ZRX swaps are still happy e2e

https://jam.dev/c/142e8753-7a0f-4946-b480-7be66722f123

- Ensure Li.Fi swaps are still happy e2e

https://jam.dev/c/4b832473-853c-475d-919c-926a247b70b4

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
