### PR TITLE
fix: wallet button stale ENS addies

### DIFF
--- a/src/components/Layout/Header/NavBar/UserMenu.tsx
+++ b/src/components/Layout/Header/NavBar/UserMenu.tsx
@@ -13,13 +13,13 @@ import {
   MenuList,
   useColorModeValue,
 } from '@chakra-ui/react'
-import { viemEthMainnetClient } from '@shapeshiftoss/contracts'
 import type { FC } from 'react'
 import { memo, useCallback, useEffect, useMemo, useState } from 'react'
 import { FaWallet } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { MemoryRouter } from 'react-router-dom'
-import type { Address } from 'viem'
+import { getAddress } from 'viem'
+import { useEnsName } from 'wagmi'
 import { WalletConnectedRoutes } from 'components/Layout/Header/NavBar/hooks/useMenuRoutes'
 import { WalletConnectedMenu } from 'components/Layout/Header/NavBar/WalletConnectedMenu'
 import { WalletImage } from 'components/Layout/Header/NavBar/WalletImage'
@@ -92,7 +92,10 @@ const WalletButton: FC<WalletButtonProps> = ({
   const [walletLabel, setWalletLabel] = useState('')
   const [shouldShorten, setShouldShorten] = useState(true)
   const bgColor = useColorModeValue('gray.200', 'gray.800')
-  const [ensName, setEnsName] = useState<string | null>('')
+
+  const { data: ensName } = useEnsName({
+    address: walletInfo?.meta?.address ? getAddress(walletInfo.meta.address) : undefined,
+  })
 
   const maybeRdns = useAppSelector(selectWalletRdns)
 
@@ -101,13 +104,6 @@ const WalletButton: FC<WalletButtonProps> = ({
     () => mipdProviders.find(provider => provider.info.rdns === maybeRdns),
     [mipdProviders, maybeRdns],
   )
-
-  useEffect(() => {
-    if (!walletInfo?.meta?.address) return
-    viemEthMainnetClient
-      .getEnsName({ address: walletInfo.meta.address as Address })
-      .then(setEnsName)
-  }, [walletInfo?.meta?.address])
 
   useEffect(() => {
     setWalletLabel('')


### PR DESCRIPTION
## Description

Fixes ENS reactivity/reset issues by using a react-query, or rather using wagmi's `useEnsName` which does precisely that under the hood for us, cleaning things up a bit while at it.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8535

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- ENS is happy for EVM wallets with ENS
- Going from an EVM wallet with ENS to a Ledger without ENS doesn't display a stale ENS

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- This diff

https://jam.dev/c/56cda424-3f1b-4e4e-baad-c9a3a23e7f42

- develop

https://jam.dev/c/4635c6ea-dc26-4222-bec6-8c10f62345e1

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
