### PR TITLE
fix: use nth-of-type selector

### DIFF
--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -152,7 +152,7 @@ const styles = {
         '.chakra-alert': {
           justifyContent: 'space-between',
         },
-        '.chakra-alert > div:nth-child(2)': {
+        '.chakra-alert > div:nth-of-type(2)': {
           width: '100%',
           justifyContent: 'space-between',
           button: {


### PR DESCRIPTION
## Description

Use `nth-of-type` over `nth-child` selector to "improve SSR" - but that isn't super useful for us.
The main benefit here is to make the annoying console log spew go away by replacing it with a best practice equivalent selector.

<img width="1247" alt="Screenshot 2025-01-13 at 14 07 13" src="https://github.com/user-attachments/assets/73e30963-5474-47b0-a8d1-ff8a77ad9887" />

Still target the same `div`:

<img width="629" alt="Screenshot 2025-01-13 at 14 19 12" src="https://github.com/user-attachments/assets/18efa2c4-f233-4150-9c2e-a8c7203a0ecb" />

and toasts still look good (tripled to test rendering):

<img width="380" alt="Screenshot 2025-01-13 at 14 15 23" src="https://github.com/user-attachments/assets/2c4618de-7ac5-4574-9997-395a7ce548c0" />

## Issue (if applicable)

QOL

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

See description.

### Engineering

N/A

### Operations

N/A

## Screenshots (if applicable)

See above.