### PR TITLE
fix: count both defi & asset balances

### DIFF
--- a/src/components/ChainDropdown/ChainDropdown.tsx
+++ b/src/components/ChainDropdown/ChainDropdown.tsx
@@ -18,7 +18,7 @@ import { GridIcon } from 'components/Icons/GridIcon'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectPortfolioTotalBalanceByChainIdIncludeStaking,
-  selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
+  selectPortfolioTotalUserCurrencyBalance,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -46,9 +46,7 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
   buttonProps,
   ...menuProps
 }) => {
-  const totalPortfolioUserCurrencyBalance = useAppSelector(
-    selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
-  )
+  const totalPortfolioUserCurrencyBalance = useAppSelector(selectPortfolioTotalUserCurrencyBalance)
   const fiatBalanceByChainId = useAppSelector(selectPortfolioTotalBalanceByChainIdIncludeStaking)
 
   const translate = useTranslate()

--- a/src/pages/Dashboard/components/DashboardChart.tsx
+++ b/src/pages/Dashboard/components/DashboardChart.tsx
@@ -24,7 +24,7 @@ import {
   selectChartTimeframe,
   selectIsPortfolioLoading,
   selectPortfolioAssetIds,
-  selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
+  selectPortfolioTotalUserCurrencyBalance,
 } from 'state/slices/selectors'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -63,9 +63,7 @@ export const DashboardChart = () => {
 
   const assetIds = useAppSelector(selectPortfolioAssetIds)
 
-  const portfolioTotalUserCurrencyBalance = useAppSelector(
-    selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
-  )
+  const portfolioTotalUserCurrencyBalance = useAppSelector(selectPortfolioTotalUserCurrencyBalance)
   const loading = useAppSelector(selectIsPortfolioLoading)
   const isLoaded = !loading
 

--- a/src/pages/Dashboard/components/DashboardHeader/WalletBalance.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader/WalletBalance.tsx
@@ -11,7 +11,7 @@ import {
   selectClaimableRewards,
   selectEarnBalancesUserCurrencyAmountFull,
   selectIsPortfolioLoading,
-  selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
+  selectPortfolioTotalUserCurrencyBalance,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -41,7 +41,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = memo(
       selectEarnBalancesUserCurrencyAmountFull,
     ).toFixed()
     const portfolioTotalUserCurrencyBalance = useAppSelector(
-      selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes,
+      selectPortfolioTotalUserCurrencyBalance,
     )
     const netWorth = useMemo(
       () =>

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from '@reduxjs/toolkit'
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { FEE_ASSET_IDS, foxyAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
+import { FEE_ASSET_IDS, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type {
   AccountMetadata,
   AccountMetadataById,
@@ -205,28 +205,6 @@ export const selectPortfolioTotalUserCurrencyBalance = createSelector(
         bn(0),
       )
       .toFixed(2),
-)
-
-export const selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes = createSelector(
-  selectPortfolioUserCurrencyBalances,
-  selectGetReadOnlyOpportunities,
-  (portfolioUserCurrencyBalances, readOnlyOpportunities): string => {
-    const readOnlyOpportunitiesDuplicates = Object.values(
-      readOnlyOpportunities.data?.opportunities ?? {},
-    ).map(opportunity => opportunity.assetId)
-    // ETH/FOX LP token, FOXy, and other held tokens can be both portfolio assets, but also part of DeFi opportunities
-    // With the current architecture (having them both as portfolio assets and earn opportunities), we have to remove these two some place or another
-    // This obviously won't scale as we support more LP tokens, but for now, this at least gives this deduction a sane home we can grep with `dupes` or `duplicates`
-    const portfolioEarnAssetIdsDuplicates = [foxEthLpAssetId, foxyAssetId].concat(
-      readOnlyOpportunitiesDuplicates,
-    )
-    return Object.entries(portfolioUserCurrencyBalances)
-      .reduce<BN>((acc, [assetId, assetUserCurrencyBalance]) => {
-        if (portfolioEarnAssetIdsDuplicates.includes(assetId)) return acc
-        return acc.plus(bnOrZero(assetUserCurrencyBalance))
-      }, bn(0))
-      .toFixed(2)
-  },
 )
 
 export const selectPortfolioUserCurrencyBalanceByAssetId = createCachedSelector(


### PR DESCRIPTION
## Description

The logic in `selectPortfolioTotalUserCurrencyBalanceExcludeEarnDupes` appears to not do what it claims (it's possibly been rugged by upstream changes since it's inception).

The current logic to calculate the total portfolio balance filters out the balances of assets that _also_ exist as an opportunity on that wallet.

This is problematic, illustrated in a few cases below:

**UniswapV2 ETH/FOX Pool**

<img width="1132" alt="Screenshot 2025-01-13 at 17 13 46" src="https://github.com/user-attachments/assets/4f61b972-2820-42ae-858a-23ee746ec00b" />

In this case, the $7.79 is ignored when calculating my balance, but the DeFi amounts are included. We actually want _all_ balances to be included.

**Sablier streams**

<img width="1132" alt="Screenshot 2025-01-13 at 17 17 06" src="https://github.com/user-attachments/assets/12488338-2cab-4347-abc0-366efc405301" />

The presence of FOX as an opportunity causes the value of the FOX in the wallet to be ignored, causing the balances to be off.

<img width="1146" alt="Screenshot 2025-01-13 at 17 18 26" src="https://github.com/user-attachments/assets/d470362b-8ccd-49cb-b44f-f9b28d31a09c" />

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8530

## Risk

> High Risk PRs Require 2 approvals

Medium - low impact, but medium chance a downstream selector is affected in an unanticipated way.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

Ensure balances look correct app-wide.

In particular for wallets with both DeFi and asset balances - specifically where an asset if in _both_ categories and a balance is held for both (e.g. UniswapV2 ETH/FOX Pool, or FOX on a Sablier stream)

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See examples above.