### PR TITLE
fix: chain dropdown balance total

### DIFF
--- a/src/components/ChainDropdown/ChainDropdown.tsx
+++ b/src/components/ChainDropdown/ChainDropdown.tsx
@@ -10,16 +10,14 @@ import {
   MenuOptionGroup,
 } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
+import { bn } from '@shapeshiftoss/utils'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { Amount } from 'components/Amount/Amount'
 import { IconCircle } from 'components/IconCircle'
 import { GridIcon } from 'components/Icons/GridIcon'
 import { bnOrZero } from 'lib/bignumber/bignumber'
-import {
-  selectPortfolioTotalBalanceByChainIdIncludeStaking,
-  selectTotalPortfolioBalanceIncludeStakingUserCurrency,
-} from 'state/slices/selectors'
+import { selectPortfolioTotalBalanceByChainIdIncludeStaking } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
 import { ChainRow } from './ChainRow'
@@ -46,9 +44,6 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
   buttonProps,
   ...menuProps
 }) => {
-  const totalPortfolioUserCurrencyBalance = useAppSelector(
-    selectTotalPortfolioBalanceIncludeStakingUserCurrency,
-  )
   const fiatBalanceByChainId = useAppSelector(selectPortfolioTotalBalanceByChainIdIncludeStaking)
 
   const translate = useTranslate()
@@ -62,6 +57,13 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
       return bBalance.minus(aBalance).toNumber()
     })
   }, [_chainIds, fiatBalanceByChainId, includeBalance])
+
+  // Sum the balances of all chains
+  const totalSupportedMarketsBalance = chainIds
+    .reduce((acc, chainId) => {
+      return acc.plus(bnOrZero(fiatBalanceByChainId[chainId]))
+    }, bn(0))
+    .toString()
 
   const renderChains = useMemo(() => {
     return chainIds.map(chainId => (
@@ -87,7 +89,7 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
                   <GridIcon />
                 </IconCircle>
                 {translate('common.allChains')}
-                <Amount.Fiat ml='auto' value={totalPortfolioUserCurrencyBalance} />
+                <Amount.Fiat ml='auto' value={totalSupportedMarketsBalance} />
               </Flex>
             </MenuItemOption>
           )}

--- a/src/components/ChainDropdown/ChainDropdown.tsx
+++ b/src/components/ChainDropdown/ChainDropdown.tsx
@@ -18,7 +18,7 @@ import { GridIcon } from 'components/Icons/GridIcon'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import {
   selectPortfolioTotalBalanceByChainIdIncludeStaking,
-  selectPortfolioTotalUserCurrencyBalance,
+  selectTotalPortfolioBalanceIncludeStakingUserCurrency,
 } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -46,7 +46,9 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
   buttonProps,
   ...menuProps
 }) => {
-  const totalPortfolioUserCurrencyBalance = useAppSelector(selectPortfolioTotalUserCurrencyBalance)
+  const totalPortfolioUserCurrencyBalance = useAppSelector(
+    selectTotalPortfolioBalanceIncludeStakingUserCurrency,
+  )
   const fiatBalanceByChainId = useAppSelector(selectPortfolioTotalBalanceByChainIdIncludeStaking)
 
   const translate = useTranslate()

--- a/src/components/ChainDropdown/ChainDropdown.tsx
+++ b/src/components/ChainDropdown/ChainDropdown.tsx
@@ -58,12 +58,14 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
     })
   }, [_chainIds, fiatBalanceByChainId, includeBalance])
 
-  // Sum the balances of all chains
-  const totalSupportedMarketsBalance = chainIds
-    .reduce((acc, chainId) => {
-      return acc.plus(bnOrZero(fiatBalanceByChainId[chainId]))
-    }, bn(0))
-    .toString()
+  // Sum the balances of all chains in the market chain dropdown
+  const totalSupportedMarketsBalance = useMemo(() => {
+    return chainIds
+      .reduce((acc, chainId) => {
+        return acc.plus(bnOrZero(fiatBalanceByChainId[chainId]))
+      }, bn(0))
+      .toString()
+  }, [chainIds, fiatBalanceByChainId])
 
   const renderChains = useMemo(() => {
     return chainIds.map(chainId => (


### PR DESCRIPTION
## Description

Fixes the chain dropdown total balance by including staked balances, which the individual chain row balances already include. The total balance is now great (though not again, I don't think it ever was).

**Production**

<img width="270" alt="Screenshot 2025-01-13 at 16 38 45" src="https://github.com/user-attachments/assets/08f1606e-bdc3-45ae-82e3-79a50e16000b" />

**This PR**

<img width="264" alt="Screenshot 2025-01-13 at 17 36 02" src="https://github.com/user-attachments/assets/4693d46f-f2b9-4728-88ca-670ea97cbf94" />

## Issue (if applicable)

None, found whilst working on the related https://github.com/shapeshift/web/issues/8530

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

With a wallet connected that has staking balances, ensure the chain dropdown component (used on the Markets page) shows the correct total balance (the sum of all chain balances).

### Engineering

☝️

### Operations

☝️

## Screenshots (if applicable)

See above.