### PR TITLE
fix: increase settings modal size

### DIFF
--- a/src/components/Modals/Settings/Settings.tsx
+++ b/src/components/Modals/Settings/Settings.tsx
@@ -35,7 +35,7 @@ const Settings = () => {
   }, [appHistory, close, isOpen])
 
   return (
-    <Modal isOpen={isOpen} onClose={close} isCentered size='sm'>
+    <Modal isOpen={isOpen} onClose={close} isCentered size='md'>
       <ModalOverlay />
       <ModalContent>
         <MemoryRouter initialEntries={entries}>


### PR DESCRIPTION
## Description

The currency dropdown didn't have enough place and was overflowing it's container

We can't fix it anyway else than reducing the font size (less readable) or increasing the modal size

I did choose the modal size increase so everything has more place and even if we reduce the font size, on specific languages, it could be overflowing!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8485

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Open the Settings modal
- Play with it, go to currency selector
- Change the language and play with the whole component too
- Nothing should be overflowing the container

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
### This branch
![image](https://github.com/user-attachments/assets/436579ad-c4d6-49e0-832d-14cbdb925af0)
![image](https://github.com/user-attachments/assets/469e9c7a-a060-4829-aef3-ac4e610bdbfd)
![image](https://github.com/user-attachments/assets/903a1b4a-ecf1-4a4b-aca2-d2e407255c8c)

### Production
![image](https://github.com/user-attachments/assets/25bb35d0-c140-4d29-b4fa-8afe1700c247)
![image](https://github.com/user-attachments/assets/c87460e6-2264-4619-9a6f-16b589a84a01)
![image](https://github.com/user-attachments/assets/33bc8509-1491-4e14-97e6-cc1a15c70445)
