### PR TITLE
fix: ensure receiveAddress query -> string | null

### DIFF
--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -52,7 +52,7 @@ export const useReceiveAddress = ({
     return false
   }, [buyAsset, wallet])
 
-  const { data: walletReceiveAddress, isLoading } = useQuery({
+  const { data: walletReceiveAddress, isLoading } = useQuery<string | null>({
     queryKey: [
       'receiveAddress',
       buyAsset?.assetId,
@@ -67,7 +67,7 @@ export const useReceiveAddress = ({
         ? async () => {
             // Already partially covered in isInitializing, but TypeScript lyfe mang.
             if (!buyAsset || !wallet || !buyAccountId || !buyAccountMetadata || !deviceId) {
-              return undefined
+              return null
             }
 
             const buyAssetChainId = buyAsset.chainId
@@ -80,7 +80,7 @@ export const useReceiveAddress = ({
              * super dangerous - don't use the wrong bip44 params to generate receive addresses
              */
             if (buyAssetChainId !== buyAssetAccountChainId) {
-              return undefined
+              return null
             }
 
             if (isUtxoAccountId(buyAccountId) && !buyAccountMetadata?.accountType)
@@ -95,11 +95,14 @@ export const useReceiveAddress = ({
               pubKey: shouldFetchUnchainedAddress ? fromAccountId(buyAccountId).account : undefined,
             })
 
-            return walletReceiveAddress
+            return walletReceiveAddress ?? null
           }
         : skipToken,
     staleTime: Infinity,
   })
 
-  return { walletReceiveAddress, isLoading: isInitializing || isLoading }
+  return {
+    walletReceiveAddress: walletReceiveAddress ?? undefined,
+    isLoading: isInitializing || isLoading,
+  }
 }


### PR DESCRIPTION
## Description

Ensures the receiveAddress query does not return `undefined`, which can cause issues due to the way TanStack query handles query state.

## Issue (if applicable)

Spotted by @NeOMakinG in https://github.com/shapeshift/web/pull/8543?new_mergebox=false#pullrequestreview-2546023848

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure we no longer see the console warning.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="1854" alt="Screenshot 2025-01-14 at 15 38 50" src="https://github.com/user-attachments/assets/94e6ab9f-96f4-4e2d-8af8-e96dc90b0c27" />
