### PR TITLE
feat: thor swapper simplify status detection

### DIFF
--- a/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
@@ -652,12 +652,13 @@ export const thorchainApi: SwapperApi = {
 
       const buyTxHash = parseThorBuyTxHash(txHash, lastOutTx)
 
-      const hasOutboundTx = lastOutTx !== undefined && lastOutTx.chain !== 'THOR'
+      const hasOutboundL1Tx = lastOutTx !== undefined && lastOutTx.chain !== 'THOR'
+      const hasOutboundRuneTx = lastOutTx !== undefined && lastOutTx.chain === 'THOR'
 
       // We consider the transaction confirmed as soon as we have a buyTxHash
       // For UTXOs, this means that the swap will be confirmed as soon as Txs hit the mempool
       // Which is actually correct, as we update UTXO balances optimistically
-      if (!('error' in txData) && buyTxHash && hasOutboundTx) {
+      if (!('error' in txData) && buyTxHash && (hasOutboundL1Tx || hasOutboundRuneTx)) {
         return {
           buyTxHash,
           status: TxStatus.Confirmed,
@@ -665,7 +666,7 @@ export const thorchainApi: SwapperApi = {
         }
       }
 
-      const message = getLatestThorTxStatusMessage(txStatusData, hasOutboundTx)
+      const message = getLatestThorTxStatusMessage(txStatusData, hasOutboundL1Tx)
       return {
         buyTxHash,
         status: TxStatus.Pending,

--- a/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
@@ -666,7 +666,6 @@ export const thorchainApi: SwapperApi = {
       }
 
       const message = getLatestThorTxStatusMessage(txStatusData, hasOutboundTx)
-
       return {
         buyTxHash,
         status: TxStatus.Pending,


### PR DESCRIPTION
## Description

i.e instead of letting the API say we're done, assume done as soon as out Tx is seen (meaning it hit the mempool, and we have updated balances accordingly in app)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/8534

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Confirm THOR status detection is still happy, and as soon as you can see the out Tx, swapper goes to trade confirmed state
- Confirm status detection of swaps to ROON are still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

Non-ROON out

https://jam.dev/c/85ffba07-e940-4566-8fd6-de349fd7bf4d

ROON out

https://jam.dev/c/ef690eb4-da39-4583-beb1-fddf54087e7c

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
