### PR TITLE
feat: lifi swapper simplify status detection

### DIFF
--- a/packages/swapper/src/swappers/LifiSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/endpoints.ts
@@ -287,17 +287,12 @@ export const lifiApi: SwapperApi = {
 
     const statusResponse = await response.json()
 
-    // We have an out Tx hash (either same or cross-chain) for this step, so we consider the Tx (effectively, the step) confirmed
-    if ((statusResponse.receiving as ExtendedTransactionInfo)?.txHash) {
-      return {
-        status: TxStatus.Confirmed,
-        buyTxHash: (statusResponse.receiving as ExtendedTransactionInfo).txHash,
-        message: statusResponse.substatusMessage,
-      }
-    }
+    const receiving: ExtendedTransactionInfo | undefined = statusResponse.receiving
 
     const status = (() => {
       switch (statusResponse.status) {
+        case 'DONE':
+          return TxStatus.Confirmed
         case 'PENDING':
           return TxStatus.Pending
         case 'FAILED':
@@ -308,8 +303,9 @@ export const lifiApi: SwapperApi = {
     })()
 
     return {
-      status,
-      buyTxHash: (statusResponse.receiving as ExtendedTransactionInfo)?.txHash,
+      // We have an out Tx hash (either same or cross-chain) for this step, so we consider the Tx (effectively, the step) confirmed
+      status: receiving?.txHash ? TxStatus.Confirmed : status,
+      buyTxHash: receiving?.txHash,
       message: statusResponse.substatusMessage,
     }
   },

--- a/packages/swapper/src/swappers/LifiSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/endpoints.ts
@@ -287,10 +287,17 @@ export const lifiApi: SwapperApi = {
 
     const statusResponse = await response.json()
 
+    // We have an out Tx hash (either same or cross-chain) for this step, so we consider the Tx (effectively, the step) confirmed
+    if ((statusResponse.receiving as ExtendedTransactionInfo)?.txHash) {
+      return {
+        status: TxStatus.Confirmed,
+        buyTxHash: (statusResponse.receiving as ExtendedTransactionInfo).txHash,
+        message: statusResponse.substatusMessage,
+      }
+    }
+
     const status = (() => {
       switch (statusResponse.status) {
-        case 'DONE':
-          return TxStatus.Confirmed
         case 'PENDING':
           return TxStatus.Pending
         case 'FAILED':


### PR DESCRIPTION
## Description

Or well, not exactly. More like being consistent with CoW and Chainflip by early returning on seen Txs - in effect, should be a no-op for the specific case of Li.Fi.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8534

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - seemingly a change of heuristics (early return on seen Tx vs. waiting for "DONE" status), though, in effect, both are true at the exact same time.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Li.Fi status detection is still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/67cdc603-08f1-4321-a648-e20439cc514d

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
