### PR TITLE
feat: stop refetching network fees after hop execution

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeNetworkFeeCryptoBaseUnit.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeNetworkFeeCryptoBaseUnit.tsx
@@ -21,9 +21,11 @@ import {
   selectActiveQuote,
   selectActiveSwapperName,
   selectConfirmedTradeExecution,
+  selectHopExecutionMetadata,
   selectHopSellAccountId,
   selectTradeSlippagePercentageDecimal,
 } from 'state/slices/tradeQuoteSlice/selectors'
+import { HopExecutionState, TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppSelector } from 'state/store'
 
 export const useTradeNetworkFeeCryptoBaseUnit = ({
@@ -60,6 +62,24 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
   const hop = useMemo(() => getHopByIndex(tradeQuote, hopIndex), [tradeQuote, hopIndex])
   const swapper = useMemo(() => (swapperName ? swappers[swapperName] : undefined), [swapperName])
 
+  const activeTrade = useAppSelector(selectActiveQuote)
+  const activeTradeId = activeTrade?.id
+
+  const hopExecutionMetadataFilter = useMemo(() => {
+    if (!activeTradeId) return undefined
+
+    return {
+      tradeId: activeTradeId,
+      hopIndex,
+    }
+  }, [activeTradeId, hopIndex])
+
+  const hopExecutionMetadata = useAppSelector(state =>
+    hopExecutionMetadataFilter
+      ? selectHopExecutionMetadata(state, hopExecutionMetadataFilter)
+      : undefined,
+  )
+
   const quoteNetworkFeesCryptoBaseUnitQuery = useQuery({
     queryKey: ['quoteNetworkFeesCryptoBaseUnit', tradeQuote],
     refetchInterval: 15_000,
@@ -72,7 +92,10 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
       sellAssetAccountId &&
       swapper &&
       hop &&
-      isExecutableTradeQuote(tradeQuote)
+      isExecutableTradeQuote(tradeQuote) &&
+      // Stop fetching once the Tx is executed for this step
+      hopExecutionMetadata?.state === HopExecutionState.AwaitingSwap &&
+      hopExecutionMetadata?.swap?.state === TransactionExecutionState.AwaitingConfirmation
         ? async () => {
             const { accountType, bip44Params } = accountMetadata
             const accountNumber = bip44Params.accountNumber


### PR DESCRIPTION
## Description

What the box say, this precisely does.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8560
- relates to https://github.com/shapeshift/web/issues/8574

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure network fees still refetch at 15s interval (assuming your window/tab is active) while the Tx for the current hop hasn't been initiated
- Ensure fees are *not* refetched anymore after signing and broadcasting the Tx for the current hop.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/76327510-a741-4d27-b786-24ae66c882fb

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
