### PR TITLE
feat: popular assets by market cap desc

### DIFF
--- a/src/components/TradeAssetSearch/TradeAssetSearch.tsx
+++ b/src/components/TradeAssetSearch/TradeAssetSearch.tsx
@@ -40,7 +40,7 @@ const assetButtonProps = {
   height: 'auto',
 }
 
-const NUM_QUICK_ACCESS_ASSETS = 5
+const NUM_QUICK_ACCESS_ASSETS = 6
 
 export type TradeAssetSearchProps = {
   onAssetClick?: (asset: Asset) => void
@@ -128,7 +128,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
 
   const quickAccessAssets = useMemo(() => {
     if (activeChainId !== 'All') {
-      return popularAssets.slice(0, 5)
+      return popularAssets.slice(0, 6)
     }
 
     // if we selected 'All' chains, we'll dedupe EVM assets in favor of ethereum mainnet

--- a/src/components/TradeAssetSearch/hooks/useGetPopularAssetsQuery.tsx
+++ b/src/components/TradeAssetSearch/hooks/useGetPopularAssetsQuery.tsx
@@ -8,7 +8,7 @@ import { store } from 'state/store'
 const queryKey = ['getPopularAssetsQuery']
 
 export const queryFn = async () => {
-  const assetIds = await getMarketServiceManager().findAllSortedByVolumeDesc(100)
+  const assetIds = await getMarketServiceManager().findAllSortedByMarketCapDesc(100)
   const result: Record<ChainId | 'All', Asset[]> = {
     All: [],
   }

--- a/src/lib/market-service/market-service-manager.ts
+++ b/src/lib/market-service/market-service-manager.ts
@@ -171,4 +171,11 @@ export class MarketServiceManager {
     const result = await coinGeckoMarketService.findAll({ count }, 'volume_desc')
     return Object.keys(result)
   }
+
+  async findAllSortedByMarketCapDesc(count: number): Promise<AssetId[]> {
+    // coingecko is the only provider that allows us to specify the sorting of assets, so we don't bother with other services
+    const coinGeckoMarketService = new CoinGeckoMarketService()
+    const result = await coinGeckoMarketService.findAll({ count }, 'market_cap_desc')
+    return Object.keys(result)
+  }
 }


### PR DESCRIPTION
## Description

Changes heuristics so that:

1. We display 6 quick-list popular assets instead of 1
2. The popular assets query used uses the market_cap_desc coingecko filter instead of volume_desc previously

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8141

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- The popular asset quick-list is a 6-count of Coingecko's assets sorted by market cap desc (i.e, the homepage of cg, which uses market cap desc as a default criteria). 
- Scrolling down from "My Assets" to "Popular Assets" also displays a sane list when comparing against cg

Note 1: the list may look slightly different depending on wallet support e.g Solana or non-EVM chains support
Note 2: BNB duplicates (or others) across chains are expected, as related assets are currently borked

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Quick-access list

<img width="1202" alt="Screenshot 2025-01-14 at 15 55 22" src="https://github.com/user-attachments/assets/6a3be9df-c0d8-4b23-b804-98690a8d9e08" />
<img width="1175" alt="Screenshot 2025-01-14 at 15 55 36" src="https://github.com/user-attachments/assets/86ad8b30-4859-4788-ba3a-2e56cd7dba67" />

- "Popular Assets" section

https://jam.dev/c/31d83cc0-a37d-44b7-b93d-66c43546fec3

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
