### PR TITLE
feat: markets page support more assets

### DIFF
--- a/packages/caip/src/adapters/coingecko/index.ts
+++ b/packages/caip/src/adapters/coingecko/index.ts
@@ -17,6 +17,7 @@ import {
   gnosisChainId,
   optimismChainId,
   polygonChainId,
+  solanaChainId,
   thorchainChainId,
 } from '../../constants'
 import * as adapters from './generated'
@@ -141,6 +142,8 @@ export const coingeckoAssetPlatformToChainId = (
       return cosmosChainId
     case CoingeckoAssetPlatform.Thorchain:
       return thorchainChainId
+    case CoingeckoAssetPlatform.Solana:
+      return solanaChainId
     default:
       return undefined
   }

--- a/src/lib/coingecko/constants.ts
+++ b/src/lib/coingecko/constants.ts
@@ -11,6 +11,7 @@ import {
   gnosisAssetId,
   ltcAssetId,
   polygonAssetId,
+  solAssetId,
   thorchainAssetId,
 } from '@shapeshiftoss/caip'
 
@@ -28,4 +29,5 @@ export const COINGECKO_NATIVE_ASSET_ID_TO_ASSET_ID: Partial<Record<string, Asset
   [adapters.CoingeckoAssetPlatform.Base]: baseAssetId,
   // This isn't a mistake - the network and id are different in the case of BSC
   binanceCoin: bscAssetId,
+  solana: solAssetId,
 }

--- a/src/lib/coingecko/utils.ts
+++ b/src/lib/coingecko/utils.ts
@@ -5,12 +5,16 @@ import {
   ASSET_NAMESPACE,
   avalancheChainId,
   baseChainId,
+  bchChainId,
   bscChainId,
+  btcChainId,
   cosmosChainId,
   ethChainId,
   gnosisChainId,
+  ltcChainId,
   optimismChainId,
   polygonChainId,
+  solanaChainId,
   thorchainChainId,
   toAssetId,
 } from '@shapeshiftoss/caip'
@@ -53,7 +57,8 @@ const getCoinDetails = async (
 
     const address = data.platforms?.[asset_platform_id]
 
-    if (!address) return
+    // No token address, and not present in our native assets mapping - this is most likely a native asset we don't support
+    if (!address && !COINGECKO_NATIVE_ASSET_ID_TO_ASSET_ID[id]) return
 
     const assetId = (() => {
       // Handles native assets, which *may* not contain a platform_id
@@ -189,6 +194,10 @@ export const getCoingeckoSupportedChainIds = () => {
     baseChainId,
     cosmosChainId,
     thorchainChainId,
+    btcChainId,
+    bchChainId,
+    ltcChainId,
+    solanaChainId,
     ...(getConfig().REACT_APP_FEATURE_ARBITRUM_NOVA ? [arbitrumNovaChainId] : []),
   ]
 }


### PR DESCRIPTION
## Description

Supports more assets/chainIds in the markets page: BTC, BCH, LTC and Solana.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8482

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- The aforementioned assets are surfaced in the markets page and available wherever relevant (i.e market data / volume should show most/all of them)
- Top Gainers / Losers will most likely show Solana tokens (double-check on Coingecko's https://www.coingecko.com/en/crypto-gainers-losers) since Solana shitcoins are all the rage these days.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<img width="1415" alt="Screenshot 2025-01-14 at 19 32 22" src="https://github.com/user-attachments/assets/606b9a89-ae8d-48f4-95c9-3fbd6c153ce6" />
<img width="1405" alt="Screenshot 2025-01-14 at 19 19 53" src="https://github.com/user-attachments/assets/07e0b8bf-9140-4f8f-ab94-cb5efc795130" />
<img width="1398" alt="Screenshot 2025-01-14 at 19 19 36" src="https://github.com/user-attachments/assets/e6dba935-aa07-4b31-895b-a75f4dc69bb8" />
<img width="1410" alt="Screenshot 2025-01-14 at 19 19 30" src="https://github.com/user-attachments/assets/69f27ed4-7c76-4eff-9d96-0780ad943be1" />
<img width="1403" alt="Screenshot 2025-01-14 at 19 19 23" src="https://github.com/user-attachments/assets/ca3c344a-cd46-4f37-837f-0b85395039a6" />
<img width="1401" alt="Screenshot 2025-01-14 at 19 19 16" src="https://github.com/user-attachments/assets/b6b0db24-7cc9-4d6e-8282-49675eb96b1e" />
<img width="1422" alt="Screenshot 2025-01-14 at 19 19 08" src="https://github.com/user-attachments/assets/cf7a2f60-9586-4041-8318-82aa7311c322" />
<img width="1405" alt="Screenshot 2025-01-14 at 19 19 00" src="https://github.com/user-attachments/assets/9d2b9206-5030-412d-82dd-bdbacef6f3ef" />
<img width="1410" alt="Screenshot 2025-01-14 at 19 18 53" src="https://github.com/user-attachments/assets/8e8202c4-c7df-46c4-9ccf-4f5f0a8303ae" />
<img width="1433" alt="Screenshot 2025-01-14 at 19 18 46" src="https://github.com/user-attachments/assets/adb54ca7-5d52-46ce-82fb-c227b7a1c6ed" />
<img width="1409" alt="Screenshot 2025-01-14 at 19 18 27" src="https://github.com/user-attachments/assets/e1a23b79-51c5-4169-b4fe-192de9dfd1c2" />
<img width="1418" alt="Screenshot 2025-01-14 at 19 18 20" src="https://github.com/user-attachments/assets/9f6efb50-24b8-4208-998d-c69650ab9480" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
