### PR TITLE
fix: swapper paranoia ledger signing fix

### DIFF
--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeNetworkFeeCryptoBaseUnit.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeNetworkFeeCryptoBaseUnit.tsx
@@ -21,9 +21,11 @@ import {
   selectActiveQuote,
   selectActiveSwapperName,
   selectConfirmedTradeExecution,
+  selectHopExecutionMetadata,
   selectHopSellAccountId,
   selectTradeSlippagePercentageDecimal,
 } from 'state/slices/tradeQuoteSlice/selectors'
+import { HopExecutionState, TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
 import { useAppSelector } from 'state/store'
 
 export const useTradeNetworkFeeCryptoBaseUnit = ({
@@ -60,6 +62,24 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
   const hop = useMemo(() => getHopByIndex(tradeQuote, hopIndex), [tradeQuote, hopIndex])
   const swapper = useMemo(() => (swapperName ? swappers[swapperName] : undefined), [swapperName])
 
+  const activeTrade = useAppSelector(selectActiveQuote)
+  const activeTradeId = activeTrade?.id
+
+  const hopExecutionMetadataFilter = useMemo(() => {
+    if (!activeTradeId) return undefined
+
+    return {
+      tradeId: activeTradeId,
+      hopIndex,
+    }
+  }, [activeTradeId, hopIndex])
+
+  const hopExecutionMetadata = useAppSelector(state =>
+    hopExecutionMetadataFilter
+      ? selectHopExecutionMetadata(state, hopExecutionMetadataFilter)
+      : undefined,
+  )
+
   const quoteNetworkFeesCryptoBaseUnitQuery = useQuery({
     queryKey: ['quoteNetworkFeesCryptoBaseUnit', tradeQuote],
     refetchInterval: 15_000,
@@ -72,7 +92,10 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
       sellAssetAccountId &&
       swapper &&
       hop &&
-      isExecutableTradeQuote(tradeQuote)
+      isExecutableTradeQuote(tradeQuote) &&
+      // Stop fetching once the Tx is executed for this step
+      hopExecutionMetadata?.state === HopExecutionState.AwaitingSwap &&
+      hopExecutionMetadata?.swap?.state === TransactionExecutionState.AwaitingConfirmation
         ? async () => {
             const { accountType, bip44Params } = accountMetadata
             const accountNumber = bip44Params.accountNumber

--- a/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeNetworkFeeCryptoBaseUnit.tsx
+++ b/src/components/MultiHopTrade/components/MultiHopTradeConfirm/hooks/useTradeNetworkFeeCryptoBaseUnit.tsx
@@ -1,5 +1,6 @@
-import { bchAssetId, CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
+import { bchAssetId, CHAIN_NAMESPACE, fromAccountId, fromChainId } from '@shapeshiftoss/caip'
 import { supportsETH } from '@shapeshiftoss/hdwallet-core'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import type { SupportedTradeQuoteStepIndex } from '@shapeshiftoss/swapper'
 import {
   getHopByIndex,
@@ -110,6 +111,8 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
             const { chainNamespace: stepSellAssetChainNamespace } =
               fromChainId(stepSellAssetChainId)
 
+            const pubKey = fromAccountId(sellAssetAccountId).account
+
             switch (stepSellAssetChainNamespace) {
               case CHAIN_NAMESPACE.Evm: {
                 if (!swapper.getEvmTransactionFees) throw Error('missing getEvmTransactionFees')
@@ -141,6 +144,7 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
                   accountNumber,
                   accountType,
                   wallet,
+                  ...(isLedger(wallet) ? { pubKey } : {}),
                 })
                 const senderAddress =
                   stepSellAssetAssetId === bchAssetId
@@ -165,7 +169,11 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
                   throw Error('missing getCosmosSdkTransactionFees')
 
                 const adapter = assertGetCosmosSdkChainAdapter(stepSellAssetChainId)
-                const from = await adapter.getAddress({ accountNumber, wallet })
+                const from = await adapter.getAddress({
+                  accountNumber,
+                  wallet,
+                  ...(isLedger(wallet) ? { pubKey } : {}),
+                })
 
                 const output = await swapper.getCosmosSdkTransactionFees({
                   stepIndex: hopIndex,
@@ -183,7 +191,11 @@ export const useTradeNetworkFeeCryptoBaseUnit = ({
                   throw Error('missing getSolanaTransactionFees')
 
                 const adapter = assertGetSolanaChainAdapter(stepSellAssetChainId)
-                const from = await adapter.getAddress({ accountNumber, wallet })
+                const from = await adapter.getAddress({
+                  accountNumber,
+                  wallet,
+                  ...(isLedger(wallet) ? { pubKey } : {}),
+                })
 
                 const output = await swapper.getSolanaTransactionFees({
                   tradeQuote,


### PR DESCRIPTION
## Description

Follows up on https://github.com/shapeshift/web/pull/8570 (the accidental, actual fix for https://github.com/shapeshift/web/issues/8574) with another paranoia fix for consistency, which, if we used in the first place, would *also* be an actual fix.

The reason why Ledger signing was borked was because of `useTradeNetworkFeesCryptoBaseUnit` calling `adapter.getAddress()` without a `pubKey` property, meaning we use on-device derivation to get the address.
This would *normally* be fine when we're able to get an address from the Ledger, we definitely should prefer that vs. using a pubKey we got somewhere from the app state, unfortunately, that's not always possible.
Unfortunately, in this precise case, it was not: making a device call to get the address while Tx signing is in-flight will result in an error being thrown, which will throw (pun intended) swapper into an errored state itself. 

That shouldn't be an issue anymore after #8570, but, just for the sake of consistency and paranoia, this PR ensures we don't do on-device derivation here and pass the pubKey in instead, resulting in either it being used directly for address-based accounts, or using unchained to derive addy from xpub using unchained for UTXOs.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/8574

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Signing with Ledger is still happy with all chain families: UTXOs, EVMs, Cosmos SDK (THOR or Cosmos), Solana
- For each of these, ensure that, after seeing the signing prompt on-device, you wait some time (say, 15 seconds) before signing, and the swapper doesn't error in that interim

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/11f7e8a6-685d-4357-b15b-bafa82becbb9

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_stop_refetching_hop_executed","parentHead":"c6c63e132fd77636b78479eb1cff8420c503af2e","parentPull":8570,"trunk":"develop"}
```
-->
