### PR TITLE
fix: empty chain dropdown when no wallet connected

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -911,7 +911,9 @@
       "gasFee": "This is the estimated gas fee to complete this trade.",
       "slippageWithAmount": "If the price moves so that you will receive less than %{amount}, your transaction will be reverted. This is the minimum amount you are guaranteed to receive.",
       "slippage": "Your transaction will revert if the price changes unfavorably by more than this percentage.",
-      "noRelatedAssets": "This asset is only available on %{chainDisplayName}"
+      "noRelatedAssets": "This asset is only available on %{chainDisplayName}",
+      "chainNotSupportedByWallet": "This chain is not supported by your wallet. Switch to a different wallet to trade this asset.",
+      "chainNotConnected": "This chain is not connected to your wallet. Connect %{chainDisplayName} to trade this asset."
     },
     "rates": {
       "tags": {

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -1,5 +1,6 @@
 import type { ButtonProps } from '@chakra-ui/react'
 import {
+  Box,
   Button,
   Menu,
   MenuButton,
@@ -10,14 +11,19 @@ import {
 } from '@chakra-ui/react'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
-import { memo, useCallback, useMemo } from 'react'
+import { memo, useCallback, useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { getStyledMenuButtonProps } from 'components/AssetSelection/helpers'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { assertGetChainAdapter } from 'lib/utils'
 import { isAssetSupportedByWallet } from 'state/slices/portfolioSlice/utils'
 import { selectRelatedAssetIdsInclusiveSorted } from 'state/slices/related-assets-selectors'
-import { selectChainDisplayNameByAssetId } from 'state/slices/selectors'
-import { useAppSelector } from 'state/store'
+import {
+  selectChainDisplayNameByAssetId,
+  selectIsWalletConnected,
+  selectWalletConnectedChainIds,
+} from 'state/slices/selectors'
+import { useAppSelector, useSelectorWithArgs } from 'state/store'
 
 import { AssetRowLoading } from '../AssetRowLoading'
 import { AssetChainRow } from './AssetChainRow'
@@ -48,7 +54,7 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
     isError,
     isLoading,
     onChangeAsset,
-    onlyConnectedChains,
+    onlyConnectedChains: _onlyConnectedChains,
     assetFilterPredicate,
     chainIdFilterPredicate,
   }) => {
@@ -59,13 +65,24 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
     const chainDisplayName = useAppSelector(state =>
       selectChainDisplayNameByAssetId(state, assetId ?? ''),
     )
+    const isWalletConnected = useAppSelector(selectIsWalletConnected)
+    const onlyConnectedChains = isWalletConnected ? _onlyConnectedChains : false
+
     const relatedAssetIdsFilter = useMemo(
-      () => ({ assetId, onlyConnectedChains }),
-      [assetId, onlyConnectedChains],
+      () => ({
+        assetId,
+        // We want all related assetIds, and conditionally mark the disconnected/unsupported ones as
+        // disabled in the UI. This allows users to see our product supports more assets than they
+        // have connected chains for.
+        onlyConnectedChains: false,
+      }),
+      [assetId],
     )
-    const relatedAssetIds = useAppSelector(state =>
-      selectRelatedAssetIdsInclusiveSorted(state, relatedAssetIdsFilter),
+    const relatedAssetIds = useSelectorWithArgs(
+      selectRelatedAssetIdsInclusiveSorted,
+      relatedAssetIdsFilter,
     )
+    const walletConnectedChainIds = useAppSelector(selectWalletConnectedChainIds)
 
     const filteredRelatedAssetIds = useMemo(() => {
       const filteredRelatedAssetIds = relatedAssetIds.filter(assetId => {
@@ -78,19 +95,92 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
       return filteredRelatedAssetIds.filter(relatedAssetId => assetIds.includes(relatedAssetId))
     }, [assetFilterPredicate, assetIds, chainIdFilterPredicate, relatedAssetIds])
 
+    const isAssetChainIdSupported = useCallback(
+      (assetId: AssetId) => {
+        const isSupported = wallet && isAssetSupportedByWallet(assetId, wallet)
+        return isSupported
+      },
+      [wallet],
+    )
+
+    const isAssetChainIdConnected = useCallback(
+      (assetId: AssetId) => {
+        const isConnected = walletConnectedChainIds.includes(fromAssetId(assetId).chainId)
+        return isConnected
+      },
+      [walletConnectedChainIds],
+    )
+
+    const isAssetChainIdDisabled = useCallback(
+      (assetId: AssetId) => {
+        const isDisabled =
+          onlyConnectedChains &&
+          (!isAssetChainIdConnected(assetId) || !isAssetChainIdSupported(assetId))
+        return isDisabled
+      },
+      [isAssetChainIdConnected, isAssetChainIdSupported, onlyConnectedChains],
+    )
+
+    // If the currently selected assetId becomes disabled (by switching assets or disconnecting a
+    // chain), switch to the first enabled related assetId
+    useEffect(() => {
+      const isCurrentAssetIdDisabled = assetId ? isAssetChainIdDisabled(assetId) : false
+
+      if (isCurrentAssetIdDisabled) {
+        const firstEnabledAssetId = filteredRelatedAssetIds.find(
+          assetId => !isAssetChainIdDisabled(assetId),
+        )
+        if (firstEnabledAssetId) {
+          onChangeAsset(firstEnabledAssetId)
+        }
+      }
+    }, [
+      filteredRelatedAssetIds,
+      isAssetChainIdConnected,
+      assetId,
+      onChangeAsset,
+      isAssetChainIdSupported,
+      isAssetChainIdDisabled,
+    ])
+
     const renderedChains = useMemo(() => {
       if (!assetId) return null
       return filteredRelatedAssetIds.map(relatedAssetId => {
-        const isSupported =
-          !onlyConnectedChains || (wallet && isAssetSupportedByWallet(relatedAssetId, wallet))
+        const { chainId } = fromAssetId(relatedAssetId)
+        const chainDisplayName = assertGetChainAdapter(chainId).getDisplayName()
+        const isChainIdDisabled = !isAssetChainIdConnected(relatedAssetId)
+        const isChainIdUnsupported = !isAssetChainIdSupported(relatedAssetId)
+        const isDisabled = isAssetChainIdDisabled(relatedAssetId)
+
+        const tooltipLabel = (() => {
+          switch (true) {
+            case isChainIdUnsupported:
+              return translate('trade.tooltip.chainNotSupportedByWallet', { chainDisplayName })
+            case isChainIdDisabled:
+              return translate('trade.tooltip.chainNotConnected', { chainDisplayName })
+            default:
+              return ''
+          }
+        })()
 
         return (
-          <MenuItemOption value={relatedAssetId} key={relatedAssetId} isDisabled={!isSupported}>
-            <AssetChainRow assetId={relatedAssetId} mainImplementationAssetId={assetId} />
+          <MenuItemOption value={relatedAssetId} key={relatedAssetId} isDisabled={isDisabled}>
+            <Tooltip isDisabled={!isDisabled} label={tooltipLabel}>
+              <Box width='100%' height='100%'>
+                <AssetChainRow assetId={relatedAssetId} mainImplementationAssetId={assetId} />
+              </Box>
+            </Tooltip>
           </MenuItemOption>
         )
       })
-    }, [assetId, filteredRelatedAssetIds, onlyConnectedChains, wallet])
+    }, [
+      assetId,
+      filteredRelatedAssetIds,
+      isAssetChainIdConnected,
+      isAssetChainIdDisabled,
+      isAssetChainIdSupported,
+      translate,
+    ])
 
     const handleChangeAsset = useCallback(
       (value: string | string[]) => {
@@ -122,8 +212,10 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
 
     return (
       <Menu isLazy>
-        {/* If we do have related assets (or we're loading/errored), assume everything is happy. 
-            Else if there's no related assets for that asset, display a tooltip explaining "This asset is only available on <currentChain>  
+        {/* 
+          If we do have related assets (or we're loading/errored), assume everything is happy. 
+          Else if there's no related assets for that asset, display a tooltip explaining 
+          "This asset is only available on <currentChain>"
         */}
         <Tooltip isDisabled={isTooltipExplainerDisabled} label={buttonTooltipText}>
           <MenuButton as={Button} isDisabled={isButtonDisabled} {...buttonProps}>


### PR DESCRIPTION
## Description

Fixes the chain dropdown appearing as empty when no wallet is connected.

But this PR includes a bunch of bonus features:
- If no wallet is connected, ALL chains are available to select from, allowing user to freely use our app without restrictions
- When the connected wallet supports a chain but doesn't have a connected account for that chain, the chain appears in the drop-down but with a disabled state and tooltip `This chain is not connected to your wallet. Connect %{chainDisplayName} to trade this asset.`
- When the connected wallet does NOT support a chain, the chain appears in the drop-down but with a disabled state and tooltip `This chain is not supported by your wallet. Switch to a different wallet to trade this asset.`
- If the currently selected chain is no longer supported/connected by the wallet (no idea how this is possible), the first available one is auto-selected.
- If the user has an unsupported/disconnected chain selected as the buy asset (valid) and then switches asset, the first available one is auto-selected.

## Issue (if applicable)

closes #8541

## Risk

> High Risk PRs Require 2 approvals

Low/moderate risk, this affects user input for trades and any issue will be immediately obvious to a user.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Affects a lot:
- Spot trade buy/sell
- Limit orders buy/sell
- Lending Borrow/Repay
- rFOX Stake
- THORChain LP add liquidity

## Testing

Check asset selection across the following features:
- Spot trade buy/sell
- Limit orders buy/sell
- Lending Borrow/Repay
- rFOX Stake
- THORChain LP add liquidity

To check for each feature (where applicable):
- Normie case - can select an asset and a related asset
- Can switch assets correctly
- Can see and select all available chains for a given asset when wallet disconnected
- When wallet connected:
  - Can see but not click chain if disconnected from wallet (with tooltip)
  - Can see but not click chain if not supported by wallet (with tooltip)
  - Switching assets where it would make the selection invalid causes the first item to be auto-selected
  - Disconnecting the chain for the currently selected chain causes the first item to be auto-selected

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Overview of the feature set
https://jam.dev/c/e2aee90b-8260-4cd9-a454-97f91a69b3d1
