### PR TITLE
fix: runepool incorrect balance not accounting for PnL

### DIFF
--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils.ts
@@ -128,6 +128,7 @@ export const getThorchainSaversPosition = async ({
         units: runepoolInformation.units,
         asset_deposit_value: bnOrZero(runepoolInformation.deposit_amount)
           .minus(runepoolInformation.withdraw_amount)
+          .plus(runepoolInformation.pnl)
           .toFixed(),
         asset_redeem_value: runepoolInformation.value,
         growth_pct: undefined,


### PR DESCRIPTION
## Description

Staked amount wasn't accounting for PNL, hence trying to do a naive deposit amount - withdraw amount wouldn't cut it, as the former will be the *current* deposit amount, which can be lower (or higher) than the initially deposited amount.

When accounting for the pnl offset, we end up with 0 as expected e.g:

```json
{
  "rune_address": "thor125dwsa39yeylqc7pn59l079dur502nsleyrgup",
  "units": "0",
  "value": "0",
  "pnl": "60621268",
  "deposit_amount": "734392497",
  "withdraw_amount": "795013765",
  "last_deposit_height": 18731307,
  "last_withdraw_height": 19518011
}
```

734392497 - 795013765 = -60621268, which is precisely the pnl delta.

Note, this bug wasn't related to full withdraws per se. Full withdraws only made this obvious, but displayed amounts were wrong regardless.


## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8618

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Withdraw fully from RUNEPool
- Notice you don't end up neither in negative *nor* with some seemingly dust left (in case you pnl was negative)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="1028" alt="Screenshot 2025-01-20 at 22 56 18" src="https://github.com/user-attachments/assets/bf2aa93f-fec3-4bac-8bdd-5041b475cb17" />



- this diff

<img width="1027" alt="Screenshot 2025-01-20 at 23 06 21" src="https://github.com/user-attachments/assets/be79ec93-9cbc-44f5-af33-3f3dd01574c2" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
