### PR TITLE
fix: new wallet flow back button shenanigans

### DIFF
--- a/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
@@ -130,6 +130,10 @@ export const NewWalletViewsSwitch = () => {
     await cancelWalletRequests()
   }, [cancelWalletRequests, dispatch, history])
 
+  const handleRouteReset = useCallback(() => {
+    history.replace(INITIAL_WALLET_MODAL_ROUTE)
+  }, [history])
+
   const onClose = useCallback(async () => {
     if (disposition === 'initializing' || disposition === 'recovering') {
       await wallet?.cancel()
@@ -214,9 +218,12 @@ export const NewWalletViewsSwitch = () => {
   const body = useCallback(
     (routeProps: RouteComponentProps<{}, StaticContext, unknown>) => {
       // These routes do not have a previous step, so don't display back button
-      const isRootRoute =
-        routeProps.history.location.pathname === '/' ||
-        routeProps.history.location.pathname === '/metamask/connect'
+      const isRootRoute = ['/', '/keepkey/enter-pin'].includes(routeProps.history.location.pathname)
+      // The main connect route for a given wallet. If we're here, clicking back should reset the route to the initial native CTA one
+      const isConnectRoute =
+        /^\/[^/]+\/connect$/.test(routeProps.history.location.pathname) ||
+        routeProps.history.location.pathname === '/native/enter-password'
+
       return (
         <Box flex={1} bg={bodyBgColor} p={6} position='relative'>
           {!isRootRoute || isMobile ? (
@@ -236,7 +243,7 @@ export const NewWalletViewsSwitch = () => {
                 size='sm'
                 isRound
                 position='static'
-                onClick={handleBack}
+                onClick={isConnectRoute ? handleRouteReset : handleBack}
               />
             </Box>
           ) : null}
@@ -254,7 +261,15 @@ export const NewWalletViewsSwitch = () => {
         </Box>
       )
     },
-    [bodyBgColor, buttonContainerBgColor, error, handleBack, isLoading, translate],
+    [
+      bodyBgColor,
+      buttonContainerBgColor,
+      error,
+      handleBack,
+      handleRouteReset,
+      isLoading,
+      translate,
+    ],
   )
 
   const bodyDesktopOnly = useCallback(

--- a/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
@@ -19,6 +19,7 @@ import type { RouteComponentProps } from 'react-router-dom'
 import { Route, Switch, useHistory } from 'react-router-dom'
 import { Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
+import { KeepKeyRoutes as KeepKeyRoutesEnum } from 'context/WalletProvider/routes'
 import { useWallet } from 'hooks/useWallet/useWallet'
 
 import type { KeyManager } from '../KeyManager'
@@ -218,7 +219,9 @@ export const NewWalletViewsSwitch = () => {
   const body = useCallback(
     (routeProps: RouteComponentProps<{}, StaticContext, unknown>) => {
       // These routes do not have a previous step, so don't display back button
-      const isRootRoute = ['/', '/keepkey/enter-pin'].includes(routeProps.history.location.pathname)
+      const isRootRoute = ['/', KeepKeyRoutesEnum.Pin].includes(
+        routeProps.history.location.pathname,
+      )
       // The main connect route for a given wallet. If we're here, clicking back should reset the route to the initial native CTA one
       const isConnectRoute =
         /^\/[^/]+\/connect$/.test(routeProps.history.location.pathname) ||


### PR DESCRIPTION
## Description

Tackles this spotted issue by @0xApotheosis on new wallet flow:

> Noticed one bug that is not a regression in these PR where Brave breaks the back button 

https://github.com/shapeshift/web/pull/8616#pullrequestreview-2563422890

And indeed, Brave (as well as other non-first-class MIPD wallets *do* have borked back button i.e not displaying.

Fixed back behaviour two ways:

1. Displays it for said mipd providers by changing the display heuristics
2. Ensures that the back button resets (i.e routes back to the native CTA) when needed, vs. doing a dumb history.back(), which may produce weird behaviour as you cycle through options.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/8471

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - new wallet flow only

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- With the `REACT_APP_FEATURE_NEW_WALLET_FLOW` flag on, cycle through wallet options and their own respective flows, and ensure everything looks sane

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

None

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/f68d9f28-dac4-48e0-a18d-a498e2f12247


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
