### PR TITLE
chore: new wallet flow dont use magic strings for selectedWalletId

### DIFF
--- a/src/context/WalletProvider/NewWalletViews/sections/HardwareWalletsSection.tsx
+++ b/src/context/WalletProvider/NewWalletViews/sections/HardwareWalletsSection.tsx
@@ -58,12 +58,12 @@ export const HardwareWalletsSection = ({
   const { connect } = useWallet()
 
   const handleConnectLedger = useCallback(() => {
-    onWalletSelect('ledger', '/ledger/connect')
+    onWalletSelect(KeyManager.Ledger, '/ledger/connect')
     connect(KeyManager.Ledger, false)
   }, [connect, onWalletSelect])
 
   const handleConnectKeepKey = useCallback(() => {
-    onWalletSelect('keepkey', '/keepkey/connect')
+    onWalletSelect(KeyManager.KeepKey, '/keepkey/connect')
     connect(KeyManager.KeepKey, false)
   }, [connect, onWalletSelect])
 
@@ -77,15 +77,15 @@ export const HardwareWalletsSection = ({
       />
       <WalletOption
         connect={handleConnectLedger}
-        isSelected={selectedWalletId === 'ledger'}
-        isDisabled={isLoading && selectedWalletId !== 'ledger'}
+        isSelected={selectedWalletId === KeyManager.Ledger}
+        isDisabled={isLoading && selectedWalletId !== KeyManager.Ledger}
         icon={LedgerIcon}
         name={LedgerConfig.name}
       />
       <WalletOption
         connect={handleConnectKeepKey}
-        isSelected={selectedWalletId === 'keepkey'}
-        isDisabled={isLoading && selectedWalletId !== 'keepkey'}
+        isSelected={selectedWalletId === KeyManager.KeepKey}
+        isDisabled={isLoading && selectedWalletId !== KeyManager.KeepKey}
         icon={KeepKeyIcon}
         name={KeepKeyConfig.name}
       />

--- a/src/context/WalletProvider/NewWalletViews/sections/OthersSection.tsx
+++ b/src/context/WalletProvider/NewWalletViews/sections/OthersSection.tsx
@@ -56,7 +56,7 @@ export const OthersSection = ({
   const { connect } = useWallet()
 
   const handleConnectWalletConnect = useCallback(() => {
-    onWalletSelect('walletconnect', '/walletconnectv2/connect')
+    onWalletSelect(KeyManager.WalletConnectV2, '/walletconnectv2/connect')
     connect(KeyManager.WalletConnectV2, false)
   }, [connect, onWalletSelect])
 
@@ -65,8 +65,8 @@ export const OthersSection = ({
       <Text fontSize='sm' fontWeight='medium' color='gray.500' translation='common.others' />
       <WalletConnectOption
         connect={handleConnectWalletConnect}
-        isSelected={selectedWalletId === 'walletconnect'}
-        isDisabled={isLoading && selectedWalletId !== 'walletconnect'}
+        isSelected={selectedWalletId === KeyManager.WalletConnectV2}
+        isDisabled={isLoading && selectedWalletId !== KeyManager.WalletConnectV2}
       />
     </Stack>
   )


### PR DESCRIPTION
## Description

Spotted by @0xApotheosis in ttps://github.com/shapeshift/web/pull/8629#discussion_r1923078663:

> Is it feasible to have an enum of wallet id strings? Seems a little messy to have these string literals everywhere. 

It indeed is, here she is!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/8471

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Paranoia test that all wallet options are still happy with the `REACT_APP_FEATURE_NEW_WALLET_FLOW` flag on.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None

## Screenshots (if applicable)

https://jam.dev/c/03eaa90e-afc9-4ef8-a670-a02b735c8262


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
