### PR TITLE
fix: new wallet flow misc. UX shenanigans

### DIFF
--- a/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
@@ -133,6 +133,7 @@ export const NewWalletViewsSwitch = () => {
 
   const handleRouteReset = useCallback(() => {
     history.replace(INITIAL_WALLET_MODAL_ROUTE)
+    setSelectedWalletId(null)
   }, [history])
 
   const onClose = useCallback(async () => {
@@ -246,6 +247,7 @@ export const NewWalletViewsSwitch = () => {
                 size='sm'
                 isRound
                 position='static'
+                isDisabled={isLoading}
                 onClick={isConnectRoute ? handleRouteReset : handleBack}
               />
             </Box>


### PR DESCRIPTION
## Description

Tackles some smolish issues spotted by @NeOMakinG in https://github.com/shapeshift/web/pull/8635#pullrequestreview-2564782850, and some.

- [x] clicking back button and back to main intro view doesn't reset wallet selection
- [x] back button is clickable while pairing is in-progress
- [x] errors from one mipd provider are not reset when selecting another mipd provider
- [x] refreshing the app, native unlock view doesn't select said native wallet

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/8471

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

With the `REACT_APP_FEATURE_NEW_WALLET_FLOW` flag on:

- clicking back button and back to main intro should reset currently selected wallet 
- back button should not be clickable while pairing is in-progress
- errors from one mipd provider should be when selecting another mipd provider
- refreshing the app, native unlock route should have the wallet being unlocked as selected

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

None, all under flag 

## Screenshots (if applicable)

- clicking back button and back to main intro should reset currently selected wallet 

https://jam.dev/c/57a0b183-c58a-4e5a-a110-b2cd19a34a49

- back button should not be clickable while pairing is in-progress

https://jam.dev/c/e9c76e3e-6492-43ce-b55a-99b3360b2f3d

- errors from one mipd provider should be when selecting another mipd provider

https://jam.dev/c/fec9aec2-79c2-463b-8535-4b3078e5df1a

- refreshing the app, native unlock route should have the wallet being unlocked as selected

https://jam.dev/c/4fbe7b22-072e-4927-ac72-ace7e819e58a

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
