### PR TITLE
feat: countdown timer during trade execution

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1005,6 +1005,7 @@
     "tradeComplete": "You now have %{cryptoAmountFormatted} in your wallet on %{chainName}.",
     "doAnotherTrade": "Do another trade",
     "summary": "Trade Summary",
+    "estimatedCompletionTime": "Estimated Completion Time",
     "transactionSuccessful": "Transaction successful, waiting for confirmations",
     "temp": {
       "tradeSuccess": "Trade complete",

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -170,7 +170,11 @@ export const ExpandableStepperSteps = ({
       >
         <Text color='text.subtle' translation='trade.estimatedCompletionTime' />
         <RawText color='text.subtle' ml='auto'>
-          <RawText>{dayjs.duration(timeLeft).format('mm:ss')}</RawText>
+          <RawText>
+            {dayjs.duration(timeLeft).hours() > 0 && `${dayjs.duration(timeLeft).format('H')}h `}
+            {dayjs.duration(timeLeft).minutes() > 0 && `${dayjs.duration(timeLeft).format('m')}m `}
+            {dayjs.duration(timeLeft).format('ss')}s
+          </RawText>
         </RawText>
       </Flex>
     )


### PR DESCRIPTION
## Description

Adds a countdown timer during trade execution for hops that we have an estimate for (some THORChain and LiFi swaps in particular).

- Does not show timer when no estimate is available
- Only shows timer during the trade portion of the swap (not approval etc)
- Shows _current_ hop estimate

https://jam.dev/c/a5f2e51c-f8cc-47e0-a4ae-39ef5893c361

<img width="399" alt="Screenshot 2025-01-29 at 18 01 15" src="https://github.com/user-attachments/assets/3f930fc2-57f5-4250-b8f9-d144f1a8c161" />

Note, there is additional step divider that I've lost my sanity trying to make go away, and won't for this PR (@reallybeard halp?):

<img width="390" alt="Screenshot 2025-01-29 at 18 35 57" src="https://github.com/user-attachments/assets/a431ba99-900e-4cf7-b1da-802da0c3fcbe" />

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8549

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Trades with time estimates.

## Testing

- Trades without time estimate data should be the same as `develop` i.e. no timer shows
- Trade _with_ time estimate data should show the estimated time to completion, which starts counting down only once a sell tx is detected

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.