### PR TITLE
feat: add doge to markets

### DIFF
--- a/src/lib/coingecko/utils.ts
+++ b/src/lib/coingecko/utils.ts
@@ -8,6 +8,7 @@ import {
   bscChainId,
   btcChainId,
   cosmosChainId,
+  dogeChainId,
   ethChainId,
   gnosisChainId,
   ltcChainId,
@@ -170,6 +171,7 @@ export const getCoingeckoSupportedChainIds = () => {
     bchChainId,
     ltcChainId,
     solanaChainId,
+    dogeChainId,
     ...(getConfig().REACT_APP_FEATURE_ARBITRUM_NOVA ? [arbitrumNovaChainId] : []),
   ]
 }


### PR DESCRIPTION
## Description

Adds DOGE to the markets page, I'm not sure why that was never on the supported assets list as CoinGecko does indeed support it: https://api.coingecko.com/api/v3/asset_platforms

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8691?reload=1

## Risk

Minimal

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Market page listings only.

## Testing

Ensure DOGE is now avaiIable:

<img width="1456" alt="Screenshot 2025-01-30 at 13 24 27" src="https://github.com/user-attachments/assets/b14ecaf5-c744-40e3-80d8-dfffb3dc43b0" />

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.