### PR TITLE
fix: longer countdown durations with days

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -156,6 +156,27 @@ export const ExpandableStepperSteps = ({
     }
   }, [sellTxHash, timeLeft])
 
+  const formattedDuration = useMemo(() => {
+    const duration = dayjs.duration(timeLeft)
+    const hasDays = duration.days() > 0
+    const hasHours = duration.hours() > 0
+    const hasMinutes = duration.minutes() > 0
+
+    // Show all units from highest non-zero to seconds
+    if (hasDays) {
+      return `${duration.format('D')}d ${duration.format('H')}h ${duration.format(
+        'm',
+      )}m ${duration.format('ss')}s`
+    }
+    if (hasHours) {
+      return `${duration.format('H')}h ${duration.format('m')}m ${duration.format('ss')}s`
+    }
+    if (hasMinutes) {
+      return `${duration.format('m')}m ${duration.format('ss')}s`
+    }
+    return `${duration.format('ss')}s`
+  }, [timeLeft])
+
   const estimatedCompletionTimeElement = useMemo(() => {
     if (estimatedCompletionTimeForStepMs <= 0) return null
     return (
@@ -170,15 +191,11 @@ export const ExpandableStepperSteps = ({
       >
         <Text color='text.subtle' translation='trade.estimatedCompletionTime' />
         <RawText color='text.subtle' ml='auto'>
-          <RawText>
-            {dayjs.duration(timeLeft).hours() > 0 && `${dayjs.duration(timeLeft).format('H')}h `}
-            {dayjs.duration(timeLeft).minutes() > 0 && `${dayjs.duration(timeLeft).format('m')}m `}
-            {dayjs.duration(timeLeft).format('ss')}s
-          </RawText>
+          <RawText>{formattedDuration}</RawText>
         </RawText>
       </Flex>
     )
-  }, [estimatedCompletionTimeForStepMs, timeLeft])
+  }, [estimatedCompletionTimeForStepMs, formattedDuration])
 
   if (!titleElement) return null
 


### PR DESCRIPTION
## Description

The existing countdown logic did not handle longer durations such as bridges, which can take days.

This rectifies that, along with another bug where the seconds/hours would now show if they were 0 (happens once a minute and once an hour!)

## Issue (if applicable)

Addresses @gomesalexandre review feedback here: https://github.com/shapeshift/web/pull/8687#pullrequestreview-2580837331

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

Ensure countdowns work as expected, including longer bridges.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="388" alt="Screenshot 2025-01-30 at 19 54 34" src="https://github.com/user-attachments/assets/dab90e21-b253-4735-8dc1-ebf968aa3fc0" />
<img width="391" alt="Screenshot 2025-01-30 at 19 54 53" src="https://github.com/user-attachments/assets/2e75c2c4-8a82-40c2-8f50-6aeb21427555" />
