### PR TITLE
fix: make asset key optional

### DIFF
--- a/src/state/apis/zapper/validators.ts
+++ b/src/state/apis/zapper/validators.ts
@@ -178,7 +178,7 @@ const ZapperTokenSchema: Type<ZapperToken> = z
 
 const ZapperAssetBaseSchema = z
   .object({
-    key: z.string(),
+    key: z.string().optional(),
     type: z.string(),
     appId: ZapperAppIdSchema,
     groupId: z.string(),


### PR DESCRIPTION
## Description

Follow up of https://github.com/shapeshift/web/pull/8698, makes the asset `key` optional, as it appears to sometimes be so:

![image](https://github.com/user-attachments/assets/cdd72091-08ec-4a90-abcd-37a4f25953b6)

## Issue (if applicable)

Raised in release thread here: https://discord.com/channels/554694662431178782/1334716642311274496/1334739390030942329

Confirmed this diff fixes it here: https://discord.com/channels/554694662431178782/1334716642311274496/1334748236258480138

## Risk

Tiny

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

Console should not surface this particular MyZod error.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.