### PR TITLE
fix: pre-populated swapper assets url

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -173,12 +173,20 @@ export const routes: Route[] = [
     priority: 2,
     main: Trade,
     category: RouteCategory.Featured,
-    routes: assetIdPaths.map(assetIdPath => ({
-      label: 'Trade Asset',
-      path: assetIdPath,
-      main: Trade,
-      hide: true,
-    })),
+    routes: [
+      {
+        label: 'Trade Assets',
+        path: '/:chainId/:assetSubId/:sellChainId/:sellAssetSubId/:sellAmountCryptoBaseUnit',
+        main: Trade,
+        hide: true,
+      },
+      ...assetIdPaths.map(assetIdPath => ({
+        label: 'Trade Asset',
+        path: assetIdPath,
+        main: Trade,
+        hide: true,
+      })),
+    ],
   },
   {
     path: '/explore',

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -43,8 +43,6 @@ export type TradeCardProps = {
 type MatchParams = {
   chainId?: string
   assetSubId?: string
-  fromAssetSubId?: string
-  fromChainId?: string
   sellAssetSubId?: string
   sellChainId?: string
   sellAmountCryptoBaseUnit?: string

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -5,7 +5,13 @@ import { AnimatePresence } from 'framer-motion'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useHistory, useLocation, useParams } from 'react-router-dom'
+import { fromBaseUnit } from 'lib/math'
 import { selectAssetById } from 'state/slices/assetsSlice/selectors'
+import {
+  selectInputBuyAsset,
+  selectInputSellAmountCryptoBaseUnit,
+  selectInputSellAsset,
+} from 'state/slices/tradeInputSlice/selectors'
 import { tradeInput } from 'state/slices/tradeInputSlice/tradeInputSlice'
 import { useAppDispatch, useAppSelector } from 'state/store'
 
@@ -31,11 +37,17 @@ const TradeRouteEntries = [
 export type TradeCardProps = {
   defaultBuyAssetId?: AssetId
   isCompact?: boolean
+  isRewritingUrl?: boolean
 }
 
 type MatchParams = {
   chainId?: string
   assetSubId?: string
+  fromAssetSubId?: string
+  fromChainId?: string
+  sellAssetSubId?: string
+  sellChainId?: string
+  sellAmountCryptoBaseUnit?: string
 }
 
 // dummy component to allow us to mount or unmount the `useGetTradeRates` hook conditionally
@@ -44,51 +56,118 @@ const GetTradeRates = () => {
   return <></>
 }
 
-export const MultiHopTrade = memo(({ defaultBuyAssetId, isCompact }: TradeCardProps) => {
-  const location = useLocation()
-  const dispatch = useAppDispatch()
-  const methods = useForm({ mode: 'onChange' })
-  const { assetSubId, chainId } = useParams<MatchParams>()
-  const [initialIndex, setInitialIndex] = useState<number | undefined>()
+export const MultiHopTrade = memo(
+  ({ defaultBuyAssetId, isCompact, isRewritingUrl }: TradeCardProps) => {
+    const location = useLocation()
+    const dispatch = useAppDispatch()
+    const methods = useForm({ mode: 'onChange' })
+    const { assetSubId, chainId, sellAssetSubId, sellChainId, sellAmountCryptoBaseUnit } =
+      useParams<MatchParams>()
+    const [initialIndex, setInitialIndex] = useState<number | undefined>()
+    const sellAsset = useAppSelector(selectInputSellAsset)
+    const buyAsset = useAppSelector(selectInputBuyAsset)
+    const history = useHistory()
+    const sellInputAmountCryptoBaseUnit = useAppSelector(selectInputSellAmountCryptoBaseUnit)
+    const [isInitialized, setIsInitialized] = useState(false)
+    const hasUrlParams = Boolean(sellChainId && sellAssetSubId && chainId && assetSubId)
 
-  const routeBuyAsset = useAppSelector(state => selectAssetById(state, `${chainId}/${assetSubId}`))
-  const defaultBuyAsset = useAppSelector(state => selectAssetById(state, defaultBuyAssetId ?? ''))
+    const buyAssetId = useMemo(() => {
+      if (defaultBuyAssetId) return defaultBuyAssetId
+      if (chainId && assetSubId) return `${chainId}/${assetSubId}`
+      return ''
+    }, [defaultBuyAssetId, chainId, assetSubId])
 
-  // Handle deep linked route from other pages
-  useEffect(() => {
-    if (initialIndex !== undefined) return
-    const incomingIndex = TradeRouteEntries.indexOf(location.pathname as TradeRoutePaths)
-    setInitialIndex(incomingIndex === -1 ? 0 : incomingIndex)
-  }, [initialIndex, location])
+    const routeSellAsset = useAppSelector(state =>
+      selectAssetById(
+        state,
+        sellChainId && sellAssetSubId ? `${sellChainId}/${sellAssetSubId}` : '',
+      ),
+    )
 
-  useEffect(() => {
-    dispatch(tradeInput.actions.clear())
+    const routeBuyAsset = useAppSelector(state => selectAssetById(state, buyAssetId))
 
-    if (
-      routeBuyAsset?.chainId === KnownChainIds.SolanaMainnet ||
-      defaultBuyAsset?.chainId === KnownChainIds.SolanaMainnet
-    ) {
-      return
-    }
+    // Handle deep linked route from other pages
+    useEffect(() => {
+      if (initialIndex !== undefined) return
+      const incomingIndex = TradeRouteEntries.indexOf(location.pathname as TradeRoutePaths)
+      setInitialIndex(incomingIndex === -1 ? 0 : incomingIndex)
+    }, [initialIndex, location])
 
-    if (routeBuyAsset) {
-      dispatch(tradeInput.actions.setBuyAsset(routeBuyAsset))
-    } else if (defaultBuyAsset) {
-      dispatch(tradeInput.actions.setBuyAsset(defaultBuyAsset))
-    }
-  }, [defaultBuyAsset, defaultBuyAssetId, dispatch, routeBuyAsset])
+    useEffect(() => {
+      // Absolutely needed or else we'll end up in a loop
+      if (isInitialized) return
 
-  // Prevent default behavior overriding deep linked route
-  if (initialIndex === undefined) return null
+      if (
+        routeBuyAsset?.chainId === KnownChainIds.SolanaMainnet ||
+        routeSellAsset?.chainId === KnownChainIds.SolanaMainnet
+      ) {
+        return
+      }
 
-  return (
-    <FormProvider {...methods}>
-      <MemoryRouter initialEntries={TradeRouteEntries} initialIndex={initialIndex}>
-        <TradeRoutes isCompact={isCompact} />
-      </MemoryRouter>
-    </FormProvider>
-  )
-})
+      if (hasUrlParams) {
+        if (routeSellAsset) {
+          dispatch(tradeInput.actions.setSellAsset(routeSellAsset))
+        }
+        if (routeBuyAsset) {
+          dispatch(tradeInput.actions.setBuyAsset(routeBuyAsset))
+        }
+        if (sellAmountCryptoBaseUnit && routeSellAsset) {
+          dispatch(
+            tradeInput.actions.setSellAmountCryptoPrecision(
+              fromBaseUnit(sellAmountCryptoBaseUnit, routeSellAsset.precision),
+            ),
+          )
+        }
+      }
+
+      setIsInitialized(true)
+    }, [
+      dispatch,
+      routeBuyAsset,
+      routeSellAsset,
+      sellAmountCryptoBaseUnit,
+      hasUrlParams,
+      isInitialized,
+    ])
+
+    useEffect(() => {
+      if (isRewritingUrl) {
+        const sellAmountBaseUnit = sellInputAmountCryptoBaseUnit ?? sellAmountCryptoBaseUnit ?? ''
+
+        history.push(`/trade/${buyAsset.assetId}/${sellAsset.assetId}/${sellAmountBaseUnit ?? ''}`)
+      }
+    }, [
+      isInitialized,
+      isRewritingUrl,
+      buyAsset,
+      sellAsset,
+      routeBuyAsset?.assetId,
+      routeSellAsset?.assetId,
+      sellAmountCryptoBaseUnit,
+      history,
+      sellInputAmountCryptoBaseUnit,
+      routeBuyAsset,
+      routeSellAsset,
+    ])
+
+    useEffect(() => {
+      return () => {
+        dispatch(tradeInput.actions.clear())
+      }
+    }, [dispatch])
+
+    // Prevent default behavior overriding deep linked route
+    if (initialIndex === undefined) return null
+
+    return (
+      <FormProvider {...methods}>
+        <MemoryRouter initialEntries={TradeRouteEntries} initialIndex={initialIndex}>
+          <TradeRoutes isCompact={isCompact} />
+        </MemoryRouter>
+      </FormProvider>
+    )
+  },
+)
 
 type TradeRoutesProps = {
   isCompact?: boolean

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -20,7 +20,7 @@ export const Trade = memo(() => {
         justifyContent='center'
         gap={4}
       >
-        <MultiHopTrade />
+        <MultiHopTrade isRewritingUrl={true} />
       </Flex>
     </Main>
   )

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -20,7 +20,7 @@ export const Trade = memo(() => {
         justifyContent='center'
         gap={4}
       >
-        <MultiHopTrade isRewritingUrl={true} />
+        <MultiHopTrade isRewritingUrl />
       </Flex>
     </Main>
   )


### PR DESCRIPTION
## Description

This PR brings pre-populated asset from the URLs, bonus adds a pre-populated amount from the URL as base unit

Here is the structure:

`/trade/buyAssetId/sellAssetId/amount`

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8624

## Risk
High because swapper router

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go to the swapper route
- Select any asset to any asset
- Copy the url and try to access directly from the URL, assets should be pre-populated
- Try to input an amount, test the same thing, amount should be prepopulated

- Try also with only a sellAssetId in the url, it should work as before
- Try to come from the arb bride claim route (to test deeplinks)
- Try to switch to differents tabs (limit tab, claims tab...)
- Try a swap, should work as intended

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/3642e5b1-d36c-4791-8008-73323761f284)

http://localhost:3000/#/trade/eip155:42161/erc20:0xf929de51d91c77e42f5090069e0ad7a09e513c73/eip155:42161/slip44:60/100000000000000
http://localhost:3000/#/trade/eip155:1/erc20:0xb8c77482e45f1f44de1745f52c74426c631bdd52/eip155:1/erc20:0xdac17f958d2ee523a2206206994597c13d831ec7/10000000

Try any other routes

https://4b3a2fe8.web-29e.pages.dev/#/trade/eip155:8453/slip44:60/bip122:000000000019d6689c085ae165831e93/slip44:0/100000000