### PR TITLE
feat: allowance queries split query enabled and refetch enabled

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -86,6 +86,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
     // Don't fetch allowance if there is insufficient balance, because we wont display the allowance
     // warning in this case.
     isDisabled: !hasSufficientBalance || status !== OrderStatus.OPEN,
+    isRefetchEnabled: true,
   })
 
   const hasSufficientAllowance = useMemo(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/hooks/useAllowanceApproval.tsx
@@ -60,6 +60,7 @@ export const useAllowanceApproval = ({
     allowanceType: AllowanceType.Unlimited, // TODO: Maybe add an exact/unlimited toggle, or wait for full flow coming soon.
     spender: COW_SWAP_VAULT_RELAYER_ADDRESS,
     enabled: isInitiallyRequired && feeQueryEnabled,
+    isRefetchEnabled: true,
   })
   useEffect(() => {
     if (!feeQueryEnabled || !isInitiallyRequired || isAllowanceApprovalRequired !== false) return

--- a/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
@@ -96,9 +96,10 @@ export const LimitOrderConfirm = () => {
     approvalNetworkFeeCryptoBaseUnit,
   } = useAllowanceApproval({
     activeQuote,
-    isQueryEnabled:
-      !!allowanceApproval.isInitiallyRequired &&
-      !!activeQuote &&
+    isQueryEnabled: !!allowanceApproval.isInitiallyRequired && !!activeQuote,
+    // Stop refetching when the approval tx is pending, but keep it enabled (see above) so we can leverage stale data, see
+    // https://github.com/shapeshift/web/issues/8702
+    isRefetchEnabled:
       orderSubmissionState === LimitOrderSubmissionState.AwaitingAllowanceApproval &&
       allowanceApproval.state !== TransactionExecutionState.Pending,
   })
@@ -109,9 +110,10 @@ export const LimitOrderConfirm = () => {
     allowanceResetNetworkFeeCryptoBaseUnit,
   } = useAllowanceReset({
     activeQuote,
-    isQueryEnabled:
-      !!allowanceReset.isInitiallyRequired &&
-      !!activeQuote &&
+    isQueryEnabled: !!allowanceReset.isInitiallyRequired && !!activeQuote,
+    // Stop refetching when the reset tx is pending, but keep it enabled (see above) so we can leverage stale data, see
+    // https://github.com/shapeshift/web/issues/8702
+    isRefetchEnabled:
       orderSubmissionState === LimitOrderSubmissionState.AwaitingAllowanceReset &&
       allowanceReset.state !== TransactionExecutionState.Pending,
   })

--- a/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useAllowanceApproval.tsx
@@ -20,12 +20,14 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 type UseAllowanceApprovalProps = {
   activeQuote: LimitOrderActiveQuote | undefined
   isQueryEnabled: boolean
+  isRefetchEnabled: boolean
 }
 
 // handles allowance approval tx execution, fees, and state orchestration
 export const useAllowanceApproval = ({
   activeQuote,
   isQueryEnabled,
+  isRefetchEnabled,
 }: UseAllowanceApprovalProps) => {
   const dispatch = useAppDispatch()
   const { showErrorToast } = useErrorToast()
@@ -55,6 +57,7 @@ export const useAllowanceApproval = ({
     allowanceType: AllowanceType.Unlimited, // All limit order approvals are unlimited
     spender: COW_SWAP_VAULT_RELAYER_ADDRESS,
     enabled: isQueryEnabled,
+    isRefetchEnabled,
   })
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useAllowanceReset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useAllowanceReset.tsx
@@ -16,10 +16,15 @@ import { useAppDispatch, useAppSelector } from 'state/store'
 type UseAllowanceResetProps = {
   activeQuote: LimitOrderActiveQuote | undefined
   isQueryEnabled: boolean
+  isRefetchEnabled: boolean
 }
 
 // handles allowance reset tx execution, fees, and state orchestration
-export const useAllowanceReset = ({ activeQuote, isQueryEnabled }: UseAllowanceResetProps) => {
+export const useAllowanceReset = ({
+  activeQuote,
+  isQueryEnabled,
+  isRefetchEnabled,
+}: UseAllowanceResetProps) => {
   const dispatch = useAppDispatch()
   const { showErrorToast } = useErrorToast()
   const wallet = useWallet().state.wallet ?? undefined
@@ -48,6 +53,7 @@ export const useAllowanceReset = ({ activeQuote, isQueryEnabled }: UseAllowanceR
     allowanceType: AllowanceType.Reset,
     spender: COW_SWAP_VAULT_RELAYER_ADDRESS,
     enabled: isQueryEnabled,
+    isRefetchEnabled,
   })
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useAllowanceApproval.tsx
@@ -47,6 +47,7 @@ export const useAllowanceApproval = (
     allowanceType,
     spender: tradeQuoteStep.allowanceContract,
     enabled: isInitiallyRequired && feeQueryEnabled,
+    isRefetchEnabled: true,
   })
   useEffect(() => {
     if (!feeQueryEnabled || !isInitiallyRequired || isAllowanceApprovalRequired !== false) return

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useAllowanceReset.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useAllowanceReset.tsx
@@ -47,6 +47,7 @@ export const useAllowanceReset = (
     allowanceType,
     spender: tradeQuoteStep.allowanceContract,
     enabled: isInitiallyRequired && feeQueryEnabled,
+    isRefetchEnabled: true,
   })
 
   useEffect(() => {

--- a/src/hooks/mutations/useApprove.ts
+++ b/src/hooks/mutations/useApprove.ts
@@ -57,6 +57,7 @@ export const useApprove = ({ onSuccess: handleSuccess, ...input }: UseApprovePro
     assetId: input.assetId,
     spender: input.spender,
     from: input.from,
+    isRefetchEnabled: true,
   })
 
   const isApprovalRequired = useMemo(() => {

--- a/src/hooks/queries/useApprovalFees.ts
+++ b/src/hooks/queries/useApprovalFees.ts
@@ -20,6 +20,7 @@ type UseApprovalFeesInput = {
   amountCryptoBaseUnit: string
   allowanceType: AllowanceType
   enabled: boolean
+  isRefetchEnabled: boolean
 }
 
 export const useApprovalFees = ({
@@ -29,6 +30,7 @@ export const useApprovalFees = ({
   allowanceType,
   spender,
   enabled,
+  isRefetchEnabled,
 }: UseApprovalFeesInput) => {
   const { assetReference: to, chainId } = useMemo(() => {
     return fromAssetId(assetId)
@@ -55,8 +57,8 @@ export const useApprovalFees = ({
     chainId,
     data: approveContractData,
     enabled: Boolean(enabled),
-    refetchIntervalInBackground: true,
-    refetchInterval: enabled ? 15_000 : false,
+    refetchIntervalInBackground: isRefetchEnabled ? true : false,
+    refetchInterval: isRefetchEnabled ? 15_000 : false,
   })
 
   return {

--- a/src/hooks/queries/useIsAllowanceApprovalRequired.ts
+++ b/src/hooks/queries/useIsAllowanceApprovalRequired.ts
@@ -18,7 +18,13 @@ export const useIsAllowanceApprovalRequired = ({
   spender,
   isDisabled,
 }: UseIsApprovalRequiredProps) => {
-  const allowanceCryptoBaseUnitResult = useAllowance({ assetId, from, spender, isDisabled })
+  const allowanceCryptoBaseUnitResult = useAllowance({
+    assetId,
+    from,
+    spender,
+    isDisabled,
+    isRefetchEnabled: true,
+  })
 
   const isAllowanceApprovalRequired = useMemo(() => {
     if (!allowanceCryptoBaseUnitResult.data || !amountCryptoBaseUnit) return

--- a/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridgeApproval.tsx
+++ b/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridgeApproval.tsx
@@ -56,6 +56,7 @@ export const useRfoxBridgeApproval = ({
     assetId: confirmedQuote.sellAssetId,
     spender: allowanceContract,
     from: fromAccountId(confirmedQuote.sellAssetAccountId).account,
+    isRefetchEnabled: true,
   })
 
   const isApprovalRequired = useMemo(

--- a/src/pages/RFOX/components/Stake/hooks/useRfoxStake.tsx
+++ b/src/pages/RFOX/components/Stake/hooks/useRfoxStake.tsx
@@ -138,6 +138,7 @@ export const useRfoxStake = ({
     assetId: stakingAsset?.assetId,
     spender: getStakingContract(stakingAssetId),
     from: stakingAssetAccountAddress,
+    isRefetchEnabled: true,
   })
 
   const allowanceCryptoPrecision = useMemo(() => {

--- a/src/react-queries/hooks/useAllowance.ts
+++ b/src/react-queries/hooks/useAllowance.ts
@@ -8,13 +8,20 @@ type UseAllowanceArgs = {
   spender: string | undefined
   from: string | undefined
   isDisabled?: boolean
+  isRefetchEnabled: boolean
 }
 
-export const useAllowance = ({ assetId, spender, from, isDisabled }: UseAllowanceArgs) => {
+export const useAllowance = ({
+  assetId,
+  spender,
+  from,
+  isDisabled,
+  isRefetchEnabled,
+}: UseAllowanceArgs) => {
   const query = useQuery({
     ...reactQueries.common.allowanceCryptoBaseUnit(assetId, spender, from),
     refetchOnMount: 'always',
-    refetchInterval: 15_000,
+    refetchInterval: isRefetchEnabled ? 15_000 : undefined,
     enabled: Boolean(!isDisabled && assetId && spender && from),
     select: selectAllowanceCryptoBaseUnit,
   })


### PR DESCRIPTION
## Description

The reason why we want to be granular is precisely becaus as soon as we set `isDisabled`, we were early returning, resulting in no stale data (which we want) but instead *no* data.
With the two explicitly split, this isn't a problem anymore.

Note one user-facing difference with this: we're now so fast in refetching approval fees that loading state *is* technically present but effectively lost.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8702

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- For limit orders, approval fees should *not* go to zero after initiating the Tx
- For spot, approval fees should *not* go to zero after initiating the Tx
- For both spot and limit, refetching of approval fees should still be happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Limit 

https://jam.dev/c/d5392c0c-30df-46fc-aa31-decc06b4f56b

- Spot

https://jam.dev/c/8f16f729-21ae-4c8a-821c-d30984e62087


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
