### PR TITLE
fix: fix escaping of dots in regex replacement

### DIFF
--- a/scripts/verifyWebpackHashes.sh
+++ b/scripts/verifyWebpackHashes.sh
@@ -20,7 +20,7 @@ find ./build/static -type f -regextype posix-extended -regex '.*\.[0-9a-f]{8}\.[
     # Take the filename ([chunkId].)([hash])(.[ext]) and get the concatenation of the first and last groups
     STRIPPEDNAME="$(printf '%s' "$NAME" | sed -r 's/^(.*\.)([0-9a-f]{8})(\.[^.]+)$/\1\3/')"
     # Take the stripped filename and build a sed s///g command, escaping all instances of '.' to '\.'
-    REPLACER="$(printf 's/%s/%s/g' "$NAME" "$STRIPPEDNAME" | sed -r 's/\./\./g')"
+    REPLACER="$(printf 's/%s/%s/g' "$NAME" "$STRIPPEDNAME" | sed -r 's/\./\\./g')"
     # On the first and last lines of the file, run the replacer command to swap NAME with STRIPPEDNAME
     # Then hash that and truncate to the first 8 characters
     NEWHASH="$(sed -r "1${REPLACER};\$${REPLACER}" "$FILE" | shasum -a 256 | cut -d ' ' -f 1 | dd bs=8 count=1 status=none)"


### PR DESCRIPTION
## Description

The current code doesn't properly escape dots in the regex replacement string. The `sed` command `s/\./\./g` doesn't actually escape dots, as it just replaces a dot with a dot. This can cause issues when the regex is applied, since dots are special characters in regex.  

I've updated the code to correctly escape dots by using `\\.` in the `sed` command. Now, the replacement string will work as expected for filenames containing dots.  

Example:  
For `$NAME = "main.abcd1234.js"` and `$STRIPPEDNAME = "main..js"`, the corrected output will be:  
`s/main\.abcd1234\.js/main\.\.js/g`  

This ensures proper regex handling.
