### PR TITLE
fix: add default buy asset and set assets to inner swappers

### DIFF
--- a/src/components/AssetAccountDetails.tsx
+++ b/src/components/AssetAccountDetails.tsx
@@ -1,10 +1,12 @@
 import type { StackDirection } from '@chakra-ui/react'
 import { Flex, Stack } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
+import { fromAssetId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
 import type { Route } from 'Routes/helpers'
 import { MultiHopTrade } from 'components/MultiHopTrade/MultiHopTrade'
 import { AssetTransactionHistory } from 'components/TransactionHistory/AssetTransactionHistory'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { selectMarketDataByAssetIdUserCurrency } from 'state/slices/selectors'
 import { useAppSelector } from 'state/store'
 
@@ -39,6 +41,10 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
     [assetId, accountId],
   )
 
+  const nativeSellAssetId = useMemo(() => {
+    return getChainAdapterManager().get(fromAssetId(assetId).chainId)?.getFeeAssetId()
+  }, [assetId])
+
   return (
     <Main headerComponent={assetHeader} py={contentPaddingY} isSubPage>
       <Stack alignItems='flex-start' spacing={4} mx='auto' direction={direction}>
@@ -53,7 +59,11 @@ export const AssetAccountDetails = ({ assetId, accountId }: AssetDetailsProps) =
         </Stack>
         <Flex flexDir='column' flex='1 1 0%' width='full' maxWidth={maxWidth} gap={4}>
           <Flex display={display}>
-            <MultiHopTrade isCompact defaultBuyAssetId={assetId} />
+            <MultiHopTrade
+              isCompact
+              defaultBuyAssetId={assetId}
+              defaultSellAssetId={nativeSellAssetId}
+            />
           </Flex>
           {marketData && <AssetMarketData assetId={assetId} />}
           <AssetDescription assetId={assetId} />

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -36,6 +36,7 @@ const TradeRouteEntries = [
 
 export type TradeCardProps = {
   defaultBuyAssetId?: AssetId
+  defaultSellAssetId?: AssetId
   isCompact?: boolean
   isRewritingUrl?: boolean
 }
@@ -55,7 +56,7 @@ const GetTradeRates = () => {
 }
 
 export const MultiHopTrade = memo(
-  ({ defaultBuyAssetId, isCompact, isRewritingUrl }: TradeCardProps) => {
+  ({ defaultBuyAssetId, defaultSellAssetId, isCompact, isRewritingUrl }: TradeCardProps) => {
     const location = useLocation()
     const dispatch = useAppDispatch()
     const methods = useForm({ mode: 'onChange' })
@@ -67,7 +68,6 @@ export const MultiHopTrade = memo(
     const history = useHistory()
     const sellInputAmountCryptoBaseUnit = useAppSelector(selectInputSellAmountCryptoBaseUnit)
     const [isInitialized, setIsInitialized] = useState(false)
-    const hasUrlParams = Boolean(sellChainId && sellAssetSubId && chainId && assetSubId)
 
     const buyAssetId = useMemo(() => {
       if (defaultBuyAssetId) return defaultBuyAssetId
@@ -75,12 +75,13 @@ export const MultiHopTrade = memo(
       return ''
     }, [defaultBuyAssetId, chainId, assetSubId])
 
-    const routeSellAsset = useAppSelector(state =>
-      selectAssetById(
-        state,
-        sellChainId && sellAssetSubId ? `${sellChainId}/${sellAssetSubId}` : '',
-      ),
-    )
+    const sellAssetId = useMemo(() => {
+      if (defaultSellAssetId) return defaultSellAssetId
+      if (sellChainId && sellAssetSubId) return `${sellChainId}/${sellAssetSubId}`
+      return ''
+    }, [defaultSellAssetId, sellChainId, sellAssetSubId])
+
+    const routeSellAsset = useAppSelector(state => selectAssetById(state, sellAssetId))
 
     const routeBuyAsset = useAppSelector(state => selectAssetById(state, buyAssetId))
 
@@ -102,31 +103,24 @@ export const MultiHopTrade = memo(
         return
       }
 
-      if (hasUrlParams) {
-        if (routeSellAsset) {
-          dispatch(tradeInput.actions.setSellAsset(routeSellAsset))
-        }
-        if (routeBuyAsset) {
-          dispatch(tradeInput.actions.setBuyAsset(routeBuyAsset))
-        }
-        if (sellAmountCryptoBaseUnit && routeSellAsset) {
-          dispatch(
-            tradeInput.actions.setSellAmountCryptoPrecision(
-              fromBaseUnit(sellAmountCryptoBaseUnit, routeSellAsset.precision),
-            ),
-          )
-        }
+      if (routeBuyAsset) {
+        dispatch(tradeInput.actions.setBuyAsset(routeBuyAsset))
+      }
+
+      if (routeSellAsset) {
+        dispatch(tradeInput.actions.setSellAsset(routeSellAsset))
+      }
+
+      if (sellAmountCryptoBaseUnit && routeSellAsset) {
+        dispatch(
+          tradeInput.actions.setSellAmountCryptoPrecision(
+            fromBaseUnit(sellAmountCryptoBaseUnit, routeSellAsset.precision),
+          ),
+        )
       }
 
       setIsInitialized(true)
-    }, [
-      dispatch,
-      routeBuyAsset,
-      routeSellAsset,
-      sellAmountCryptoBaseUnit,
-      hasUrlParams,
-      isInitialized,
-    ])
+    }, [dispatch, routeBuyAsset, routeSellAsset, sellAmountCryptoBaseUnit, isInitialized])
 
     useEffect(() => {
       if (isRewritingUrl) {


### PR DESCRIPTION
## Description

I broke the buyAsset auto selection in asset pages, this PR bring it back but also improve the logic behind:
- If the buyAsset is selected, populate the sellAsset with the native asset of the selected buyAsset chain so we don't end up with things like ETH to LP WAVAX/PENDLE Joe on AVAX, using Native asset to token ensure we have a route for this default swapper config
- If it's a native asset, it auto populate it as sellAsset to ETH
- Did this for both account swapper, asset page swapper

I think before merging this, it would be cool to confirm with @shapeshift/product the behavior

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

n/a

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go to account details page, assets should be populated properly depending on which account you selected
- Go to multiple asset page, asset should be populated as buyAsset with the native asset as sellAsset
- Pre-populated swapper links should work as expected

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
http://localhost:3000/#/trade/eip155:8453/erc20:0xacfe6019ed1a7dc6f7b508c02d1b04ec88cc21bf/eip155:8453/slip44:60/10000000000000000 works as expected ( Base to VVV)

<img width="359" alt="image" src="https://github.com/user-attachments/assets/71761a6d-80df-483c-b948-51a43a89b59b" />
<img width="1162" alt="image" src="https://github.com/user-attachments/assets/de010149-0413-4f24-9d3a-ec999e4bb5e4" />
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/19338b1d-b613-4a6e-af47-cbec5f6122b2" />
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/22d4b095-495b-48e0-98b0-ceab721dde91" />
