### PR TITLE
feat: swapper trade complete actual on-chain receive amounts

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
@@ -62,7 +62,7 @@ export const LimitOrderConfirm = () => {
   const buyAmountCryptoBaseUnit = useAppSelector(selectBuyAmountCryptoBaseUnit)
   const quoteId = useAppSelector(selectActiveQuoteId)
   const sellAmountCryptoPrecision = useAppSelector(selectActiveQuoteSellAmountCryptoPrecision)
-  const buyAmountCryptoPrecision = useAppSelector(selectActiveQuoteBuyAmountCryptoPrecision)
+  const quoteBuyAmountCryptoPrecision = useAppSelector(selectActiveQuoteBuyAmountCryptoPrecision)
   const feeAsset = useAppSelector(selectActiveQuoteFeeAsset)
   const feeAssetRateUserCurrency = useAppSelector(selectActiveQuoteFeeAssetRateUserCurrency)
 
@@ -142,7 +142,7 @@ export const LimitOrderConfirm = () => {
           sellAsset={sellAsset}
           buyAsset={buyAsset}
           sellAmountCryptoPrecision={sellAmountCryptoPrecision}
-          buyAmountCryptoPrecision={buyAmountCryptoPrecision}
+          quoteBuyAmountCryptoPrecision={quoteBuyAmountCryptoPrecision}
         />
       )
     }
@@ -157,7 +157,7 @@ export const LimitOrderConfirm = () => {
     )
   }, [
     buyAmountCryptoBaseUnit,
-    buyAmountCryptoPrecision,
+    quoteBuyAmountCryptoPrecision,
     buyAsset,
     handleBack,
     innerStepsRendered,
@@ -323,7 +323,7 @@ export const LimitOrderConfirm = () => {
           sellAsset,
           buyAsset,
           sellAmountCryptoPrecision,
-          buyAmountCryptoPrecision,
+          buyAmountCryptoPrecision: quoteBuyAmountCryptoPrecision,
         })
         if (mixpanel && eventData) {
           mixpanel.track(MixPanelEvent.LimitOrderPlaced, eventData)
@@ -336,7 +336,7 @@ export const LimitOrderConfirm = () => {
     activeQuote?.params.accountId,
     allowanceApprovalMutation,
     allowanceResetMutation,
-    buyAmountCryptoPrecision,
+    quoteBuyAmountCryptoPrecision,
     buyAsset,
     dispatch,
     isConnected,

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -96,7 +96,7 @@ export const TradeConfirm = () => {
             activeQuote.steps[0].sellAmountIncludingProtocolFeesCryptoBaseUnit,
             activeQuote.steps[0].sellAsset.precision,
           )}
-          buyAmountCryptoPrecision={fromBaseUnit(
+          quoteBuyAmountCryptoPrecision={fromBaseUnit(
             tradeQuoteLastHop.buyAmountAfterFeesCryptoBaseUnit,
             tradeQuoteLastHop.buyAsset.precision,
           )}

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -114,7 +114,9 @@ export const TradeSuccess = ({
     return serializeTxIndex(accountId, txHash, receiveAddress)
   }, [tradeExecution, isMultiHop, buyAsset, receiveAddress])
 
-  const transfers = useTxDetails(buyTxId ?? '')?.transfers ?? []
+  const buyTxDetails = useTxDetails(buyTxId ?? '')
+  const transfers = useMemo(() => buyTxDetails?.transfers ?? [], [buyTxDetails])
+
   const actualBuyAmountCryptoPrecision = useMemo(() => {
     if (!transfers.length || !buyAsset) return undefined
 

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -125,7 +125,7 @@ export const TradeSuccess = ({
     return receiveTransfer?.value
       ? fromBaseUnit(receiveTransfer.value, buyAsset.precision)
       : undefined
-  }, [transfers, buyAsset, receiveAddress])
+  }, [transfers, buyAsset])
 
   const AmountsLine = useCallback(() => {
     if (!(sellAsset && buyAsset)) return null

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -57,7 +57,7 @@ export type TradeSuccessProps = {
   sellAsset?: Asset
   buyAsset?: Asset
   sellAmountCryptoPrecision?: string
-  buyAmountCryptoPrecision?: string
+  quoteBuyAmountCryptoPrecision?: string
 }
 
 export const TradeSuccess = ({
@@ -69,7 +69,7 @@ export const TradeSuccess = ({
   sellAmountCryptoPrecision,
   sellAsset,
   buyAsset,
-  buyAmountCryptoPrecision,
+  quoteBuyAmountCryptoPrecision,
 }: TradeSuccessProps) => {
   const translate = useTranslate()
   const tradeQuote = useAppSelector(selectActiveQuote)
@@ -130,9 +130,9 @@ export const TradeSuccess = ({
 
   const AmountsLine = useCallback(() => {
     if (!(sellAsset && buyAsset)) return null
-    if (!(sellAmountCryptoPrecision && buyAmountCryptoPrecision)) return null
+    if (!(sellAmountCryptoPrecision && quoteBuyAmountCryptoPrecision)) return null
 
-    const displayAmount = actualBuyAmountCryptoPrecision || buyAmountCryptoPrecision
+    const displayAmount = actualBuyAmountCryptoPrecision || quoteBuyAmountCryptoPrecision
 
     return (
       <Flex justifyContent='center' alignItems='center' flexWrap='wrap' gap={2} px={4}>
@@ -155,7 +155,7 @@ export const TradeSuccess = ({
     sellAsset,
     buyAsset,
     sellAmountCryptoPrecision,
-    buyAmountCryptoPrecision,
+    quoteBuyAmountCryptoPrecision,
     actualBuyAmountCryptoPrecision,
   ])
 

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -33,6 +33,7 @@ import { useTxDetails } from 'hooks/useTxDetails/useTxDetails'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import {
+  selectActiveQuote,
   selectConfirmedTradeExecution,
   selectFirstHop,
   selectIsActiveQuoteMultiHop,
@@ -43,7 +44,6 @@ import {
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
 
-import { useTradeReceiveAddress } from '../TradeInput/hooks/useTradeReceiveAddress'
 import { TwirlyToggle } from '../TwirlyToggle'
 import { YouCouldHaveSaved } from './components/YouCouldHaveSaved'
 import { YouSaved } from './components/YouSaved'
@@ -72,8 +72,8 @@ export const TradeSuccess = ({
   buyAmountCryptoPrecision,
 }: TradeSuccessProps) => {
   const translate = useTranslate()
-  const { manualReceiveAddress, walletReceiveAddress } = useTradeReceiveAddress()
-  const receiveAddress = manualReceiveAddress ?? walletReceiveAddress
+  const tradeQuote = useAppSelector(selectActiveQuote)
+  const receiveAddress = tradeQuote!.receiveAddress
 
   const { isOpen, onToggle: handleToggle } = useDisclosure({
     defaultIsOpen: false,

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -115,13 +115,12 @@ export const TradeSuccess = ({
   }, [tradeExecution, isMultiHop, buyAsset, receiveAddress])
 
   const transfers = useTxDetails(buyTxId ?? '')?.transfers ?? []
-  const actualReceivedAmount = useMemo(() => {
+  const actualBuyAmountCryptoPrecision = useMemo(() => {
     if (!transfers.length || !buyAsset) return undefined
-    // Find the transfer that matches our buy asset
+
     const receiveTransfer = transfers.find(
       transfer => transfer.type === TransferType.Receive && transfer.assetId === buyAsset.assetId,
     )
-    // Convert from base units to precision format
     return receiveTransfer?.value
       ? fromBaseUnit(receiveTransfer.value, buyAsset.precision)
       : undefined
@@ -131,7 +130,7 @@ export const TradeSuccess = ({
     if (!(sellAsset && buyAsset)) return null
     if (!(sellAmountCryptoPrecision && buyAmountCryptoPrecision)) return null
 
-    const displayAmount = actualReceivedAmount || buyAmountCryptoPrecision
+    const displayAmount = actualBuyAmountCryptoPrecision || buyAmountCryptoPrecision
 
     return (
       <Flex justifyContent='center' alignItems='center' flexWrap='wrap' gap={2} px={4}>
@@ -155,7 +154,7 @@ export const TradeSuccess = ({
     buyAsset,
     sellAmountCryptoPrecision,
     buyAmountCryptoPrecision,
-    actualReceivedAmount,
+    actualBuyAmountCryptoPrecision,
   ])
 
   // NOTE: This is a temporary solution to enable the Fox discount summary only if the user did NOT

--- a/src/components/TransactionHistoryRows/TransactionRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionRow.tsx
@@ -128,5 +128,8 @@ export const TransactionRowFromTxDetails = forwardRef<TransactionRowFromTxDetail
 
 export const TransactionRow = forwardRef<TxRowProps, 'div'>((props, ref) => {
   const txDetails = useTxDetails(props.txId)
+
+  if (!txDetails) return null
+
   return <TransactionRowFromTxDetails ref={ref} {...props} txDetails={txDetails} />
 })


### PR DESCRIPTION
## Description

Uses actual on-chain amounts (either in token or native asset) to display the final receive amount in trade complete.

Note: This only works for receive addresses for which accounts are in the store, and does *not* work for custom receive addresses, since we don't hold these ones in store.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8719

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test swaps *without* a custom receive address display the actual on-chain received amount in trade complete
- Notice how swaps *with* a custom receive address display the same receive amount as originally quoted (which may or may not be a discrepancy)
- Ensure limit orders are still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>


- ^

## Screenshots (if applicable)

- Custom receive addy

<img width="368" alt="Screenshot 2025-02-04 at 16 42 49" src="https://github.com/user-attachments/assets/de177ee3-4290-4571-b6a8-050dae8924fe" />
<img width="578" alt="Screenshot 2025-02-04 at 16 42 40" src="https://github.com/user-attachments/assets/bc745448-19da-436f-acfe-72b819b60bc7" />


- No custom receive addy


<img width="765" alt="Screenshot 2025-02-04 at 16 39 56" src="https://github.com/user-attachments/assets/87b1ab4f-935f-415b-a8f7-a706b0c94d34" />
<img width="320" alt="Screenshot 2025-02-04 at 16 39 37" src="https://github.com/user-attachments/assets/3b09fdc7-8b07-4966-a23f-0c4a228bc8ba" />
<img width="852" alt="Screenshot 2025-02-04 at 16 38 14" src="https://github.com/user-attachments/assets/85e3ef6d-482c-45e5-97b7-a12fd79c481e" />
<img width="305" alt="Screenshot 2025-02-04 at 16 37 54" src="https://github.com/user-attachments/assets/051ba30c-9624-43c9-bf66-fc002b4a8ec7" />
<img width="327" alt="Screenshot 2025-02-04 at 16 35 36" src="https://github.com/user-attachments/assets/e9387eb6-74c6-41ae-bf68-b464360b0689" />
<img width="483" alt="Screenshot 2025-02-04 at 16 35 21" src="https://github.com/user-attachments/assets/b358e447-6767-41aa-a8a1-7a9d1c531c54" />

- Limit

<img width="535" alt="image" src="https://github.com/user-attachments/assets/0faa28dd-6cca-4638-b658-f2e18a6fc23c" />

