### PR TITLE
feat: best effort fetch buy Tx amount for manual receive address

### DIFF
--- a/packages/chain-adapters/src/api.ts
+++ b/packages/chain-adapters/src/api.ts
@@ -81,6 +81,8 @@ export type ChainAdapter<T extends ChainId> = {
     onError?: (err: SubscribeError) => void,
   ): Promise<void>
 
+  parseTx(tx: unknown, pubkey: string): Promise<Transaction>
+
   unsubscribeTxs(input?: SubscribeTxsInput): void
 
   closeTxs(): void

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -414,7 +414,7 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
     }
   }
 
-  protected async parseTx(tx: unchained.cosmossdk.Tx, pubkey: string): Promise<Transaction> {
+  async parseTx(tx: unchained.cosmossdk.Tx, pubkey: string): Promise<Transaction> {
     const { address: _, ...parsedTx } = await this.parser.parse(tx, pubkey)
 
     return {

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -712,7 +712,7 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
     }
   }
 
-  private async parseTx(tx: unchained.evm.types.Tx, pubkey: string): Promise<Transaction> {
+  async parseTx(tx: unchained.evm.types.Tx, pubkey: string): Promise<Transaction> {
     const { address: _, ...parsedTx } = await this.parser.parse(tx, pubkey)
 
     return {

--- a/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
+++ b/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
@@ -666,7 +666,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.SolanaMainnet> 
     return parsedTx.status
   }
 
-  private async parseTx(tx: unchained.solana.Tx, pubkey: string): Promise<Transaction> {
+  async parseTx(tx: unchained.solana.Tx, pubkey: string): Promise<Transaction> {
     const { address: _, ...parsedTx } = await this.parser.parse(tx, pubkey)
 
     return {

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -125,7 +125,7 @@ export const TradeSuccess = ({
     return receiveTransfer?.value
       ? fromBaseUnit(receiveTransfer.value, buyAsset.precision)
       : undefined
-  }, [transfers, buyAsset, receiveAddress])
+  }, [transfers, buyAsset])
 
   const AmountsLine = useCallback(() => {
     if (!(sellAsset && buyAsset)) return null

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -117,8 +117,6 @@ export const TradeSuccess = ({
   const txTransfers = useTxDetailsQuery(buyTxId ?? '')?.transfers
   const manualReceiveAddressTransfers = useTxDetailsQuery(buyTxId ?? '')?.transfers
 
-  console.log({ txTransfers, manualReceiveAddressTransfers })
-
   const transfers = manualReceiveAddressTransfers || txTransfers
   const actualBuyAmountCryptoPrecision = useMemo(() => {
     if (!transfers?.length || !buyAsset) return undefined

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -29,7 +29,7 @@ import { AnimatedCheck } from 'components/AnimatedCheck'
 import { AssetIcon } from 'components/AssetIcon'
 import { SlideTransition } from 'components/SlideTransition'
 import { Text } from 'components/Text'
-import { useTxDetails } from 'hooks/useTxDetails/useTxDetails'
+import { useTxDetailsQuery } from 'hooks/useTxDetails/useTxDetails'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import {
@@ -114,9 +114,14 @@ export const TradeSuccess = ({
     return serializeTxIndex(accountId, txHash, receiveAddress)
   }, [tradeExecution, isMultiHop, buyAsset, receiveAddress])
 
-  const transfers = useTxDetails(buyTxId ?? '')?.transfers ?? []
+  const txTransfers = useTxDetailsQuery(buyTxId ?? '')?.transfers
+  const manualReceiveAddressTransfers = useTxDetailsQuery(buyTxId ?? '')?.transfers
+
+  console.log({ txTransfers, manualReceiveAddressTransfers })
+
+  const transfers = manualReceiveAddressTransfers || txTransfers
   const actualBuyAmountCryptoPrecision = useMemo(() => {
-    if (!transfers.length || !buyAsset) return undefined
+    if (!transfers?.length || !buyAsset) return undefined
 
     const receiveTransfer = transfers.find(
       transfer => transfer.type === TransferType.Receive && transfer.assetId === buyAsset.assetId,

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -33,6 +33,7 @@ import { useTxDetails } from 'hooks/useTxDetails/useTxDetails'
 import { bnOrZero } from 'lib/bignumber/bignumber'
 import { fromBaseUnit } from 'lib/math'
 import {
+  selectActiveQuote,
   selectConfirmedTradeExecution,
   selectFirstHop,
   selectIsActiveQuoteMultiHop,
@@ -43,7 +44,6 @@ import {
 import { serializeTxIndex } from 'state/slices/txHistorySlice/utils'
 import { useAppSelector } from 'state/store'
 
-import { useTradeReceiveAddress } from '../TradeInput/hooks/useTradeReceiveAddress'
 import { TwirlyToggle } from '../TwirlyToggle'
 import { YouCouldHaveSaved } from './components/YouCouldHaveSaved'
 import { YouSaved } from './components/YouSaved'
@@ -72,8 +72,8 @@ export const TradeSuccess = ({
   buyAmountCryptoPrecision,
 }: TradeSuccessProps) => {
   const translate = useTranslate()
-  const { manualReceiveAddress, walletReceiveAddress } = useTradeReceiveAddress()
-  const receiveAddress = manualReceiveAddress ?? walletReceiveAddress
+  const tradeQuote = useAppSelector(selectActiveQuote)
+  const receiveAddress = tradeQuote!.receiveAddress
 
   const { isOpen, onToggle: handleToggle } = useDisclosure({
     defaultIsOpen: false,

--- a/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/TradeSuccess/TradeSuccess.tsx
@@ -115,13 +115,12 @@ export const TradeSuccess = ({
   }, [tradeExecution, isMultiHop, buyAsset, receiveAddress])
 
   const transfers = useTxDetails(buyTxId ?? '')?.transfers ?? []
-  const actualReceivedAmount = useMemo(() => {
+  const actualBuyAmountCryptoPrecision = useMemo(() => {
     if (!transfers.length || !buyAsset) return undefined
-    // Find the transfer that matches our buy asset
+
     const receiveTransfer = transfers.find(
       transfer => transfer.type === TransferType.Receive && transfer.assetId === buyAsset.assetId,
     )
-    // Convert from base units to precision format
     return receiveTransfer?.value
       ? fromBaseUnit(receiveTransfer.value, buyAsset.precision)
       : undefined
@@ -131,7 +130,7 @@ export const TradeSuccess = ({
     if (!(sellAsset && buyAsset)) return null
     if (!(sellAmountCryptoPrecision && buyAmountCryptoPrecision)) return null
 
-    const displayAmount = actualReceivedAmount || buyAmountCryptoPrecision
+    const displayAmount = actualBuyAmountCryptoPrecision || buyAmountCryptoPrecision
 
     return (
       <Flex justifyContent='center' alignItems='center' flexWrap='wrap' gap={2} px={4}>
@@ -155,7 +154,7 @@ export const TradeSuccess = ({
     buyAsset,
     sellAmountCryptoPrecision,
     buyAmountCryptoPrecision,
-    actualReceivedAmount,
+    actualBuyAmountCryptoPrecision,
   ])
 
   // NOTE: This is a temporary solution to enable the Fox discount summary only if the user did NOT

--- a/src/components/TransactionHistoryRows/TransactionRow.tsx
+++ b/src/components/TransactionHistoryRows/TransactionRow.tsx
@@ -128,5 +128,8 @@ export const TransactionRowFromTxDetails = forwardRef<TransactionRowFromTxDetail
 
 export const TransactionRow = forwardRef<TxRowProps, 'div'>((props, ref) => {
   const txDetails = useTxDetails(props.txId)
+
+  if (!txDetails) return null
+
   return <TransactionRowFromTxDetails ref={ref} {...props} txDetails={txDetails} />
 })

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -1,7 +1,10 @@
-import type { TxTransfer } from '@shapeshiftoss/chain-adapters'
+import { fromAccountId } from '@shapeshiftoss/caip'
+import type { EvmChainAdapter, TxTransfer } from '@shapeshiftoss/chain-adapters'
 import type { Asset, AssetsByIdPartial } from '@shapeshiftoss/types'
 import type * as unchained from '@shapeshiftoss/unchained-client'
+import { skipToken, useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
+import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { useSafeTxQuery } from 'hooks/queries/useSafeTx'
 import { getTxLink } from 'lib/getTxLink'
 import type { ReduxState } from 'state/reducer'
@@ -152,6 +155,83 @@ export const useTxDetails = (txId: string | undefined): TxDetails | undefined =>
     fee,
     transfers,
     type: getTxType(tx, transfers),
+    txLink,
+  }
+}
+
+// The same as above, but fetches from the network, allowing for *both* serialized Txids present in the store, and those that aren't to work similarly,
+// so long as you pass as a serialized TxId in.
+export const useTxDetailsQuery = (txId: string | undefined): TxDetails | undefined => {
+  const assets = useAppSelector(selectAssets)
+
+  const accountId = useMemo(() => {
+    if (!txId) return ''
+    return deserializeTxIndex(txId).accountId
+  }, [txId])
+
+  const txHash = useMemo(() => {
+    if (!txId) return
+    return deserializeTxIndex(txId).txid
+  }, [])
+
+  const chainId = accountId ? fromAccountId(accountId).chainId : ''
+
+  const adapter = getChainAdapterManager().get(chainId)
+
+  const { data: maybeSafeTx } = useSafeTxQuery({
+    maybeSafeTxHash: txId,
+    accountId,
+  })
+
+  const { data } = useQuery({
+    queryKey: ['txDetails', txId],
+    queryFn:
+      txHash && adapter
+        ? async () => {
+            // Casted for the sake of simplicity
+            const tx = await (adapter as EvmChainAdapter).httpProvider.getTransaction({
+              txid: txHash,
+            })
+
+            return adapter.parseTx(tx, fromAccountId(accountId).account)
+          }
+        : skipToken,
+  })
+
+  const transfers = useMemo(() => {
+    if (!data) return
+    return getTransfers(data, assets)
+  }, [data, assets])
+
+  const fee = useMemo(() => {
+    if (!data?.fee) return
+    return {
+      ...data.fee,
+      asset: assets[data.fee.assetId] ?? defaultAsset,
+    }
+  }, [data?.fee, assets])
+
+  const feeAsset = useAppSelector(state => selectFeeAssetByChainId(state, data?.chainId ?? ''))
+
+  const txLink = useMemo(() => {
+    if (!data) return
+    return getTxLink({
+      name: data.trade?.dexName,
+      defaultExplorerBaseUrl: feeAsset?.explorerTxLink ?? '',
+      txId: data.txid,
+      maybeSafeTx,
+      accountId,
+    })
+  }, [data, feeAsset?.explorerTxLink, maybeSafeTx, accountId])
+
+  console.log({data, txLink, transfers})
+  if (!data || !txLink || !transfers) return
+
+  return {
+    tx: data,
+    fee,
+    transfers,
+    type: getTxType(data, transfers),
     txLink,
   }
 }

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -172,7 +172,7 @@ export const useTxDetailsQuery = (txId: string | undefined): TxDetails | undefin
   const txHash = useMemo(() => {
     if (!txId) return
     return deserializeTxIndex(txId).txid
-  }, [])
+  }, [txId])
 
   const chainId = accountId ? fromAccountId(accountId).chainId : ''
 

--- a/src/hooks/useTxDetails/useTxDetails.ts
+++ b/src/hooks/useTxDetails/useTxDetails.ts
@@ -159,7 +159,7 @@ export const useTxDetails = (txId: string | undefined): TxDetails | undefined =>
   }
 }
 
-// The same as above, but fetches from the network, allowing for *both* serialized Txids present in the store, and those that aren't to work similarly,
+// The same as above, but fetches from the network, allowing for *both* serialized Txids present in the store, and those that aren't to yield a similar shape,
 // so long as you pass as a serialized TxId in.
 export const useTxDetailsQuery = (txId: string | undefined): TxDetails | undefined => {
   const assets = useAppSelector(selectAssets)
@@ -224,7 +224,6 @@ export const useTxDetailsQuery = (txId: string | undefined): TxDetails | undefin
     })
   }, [data, feeAsset?.explorerTxLink, maybeSafeTx, accountId])
 
-  console.log({data, txLink, transfers})
   if (!data || !txLink || !transfers) return
 
   return {


### PR DESCRIPTION
## Description

Stretch on top of #8736, using similar logic but instead fetching for the network so we're able to fetch Tx data for external Txs (i.e the ones not existing in the Tx store since those are from manual receive address accounts)
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to #8736

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low/Medium

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure trade complete step amounts still look sane without any weird flash of content

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/a2941074-961d-41f9-9281-71e6d05ec190


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"feat_accurate_receive_amounts","parentHead":"6d787c27e9222c16ee68c0de2a95f595f07c3d42","parentPull":8736,"trunk":"develop"}
```
-->
