### PR TITLE
fix: add mobile dialog on mobile home page

### DIFF
--- a/src/components/MobileWalletDialog/MobileWalletDialog.tsx
+++ b/src/components/MobileWalletDialog/MobileWalletDialog.tsx
@@ -12,9 +12,14 @@ import { MobileWalletDialogRoutes } from './types'
 type MobileWalletDialogProps = {
   isOpen: boolean
   onClose: () => void
+  defaultRoute?: MobileWalletDialogRoutes
 }
 
-export const MobileWalletDialog: React.FC<MobileWalletDialogProps> = ({ isOpen, onClose }) => {
+export const MobileWalletDialog: React.FC<MobileWalletDialogProps> = ({
+  isOpen,
+  onClose,
+  defaultRoute = MobileWalletDialogRoutes.Saved,
+}) => {
   return (
     <Dialog isOpen={isOpen} onClose={onClose} height='auto' isDisablingPropagation={false}>
       <MemoryRouter>
@@ -37,7 +42,7 @@ export const MobileWalletDialog: React.FC<MobileWalletDialogProps> = ({ isOpen, 
                 <Route path={MobileWalletDialogRoutes.Create}>
                   <CreateWalletRouter onClose={onClose} />
                 </Route>
-                <Redirect exact from='/' to={MobileWalletDialogRoutes.Saved} />
+                <Redirect exact from='/' to={defaultRoute} />
               </Switch>
             </AnimatePresence>
           )}

--- a/src/components/MobileWalletDialog/routes/CreateWallet/CreateBackupConfirm.tsx
+++ b/src/components/MobileWalletDialog/routes/CreateWallet/CreateBackupConfirm.tsx
@@ -35,6 +35,8 @@ import { addWallet } from 'context/WalletProvider/MobileWallet/mobileMessageHand
 import type { RevocableWallet } from 'context/WalletProvider/MobileWallet/RevocableWallet'
 import type { MobileLocationState } from 'context/WalletProvider/MobileWallet/types'
 import { useWallet } from 'hooks/useWallet/useWallet'
+import { preferences } from 'state/slices/preferencesSlice/preferencesSlice'
+import { useAppDispatch } from 'state/store'
 
 import { MobileWalletDialogRoutes } from '../../types'
 
@@ -55,6 +57,8 @@ export const CreateBackupConfirm = () => {
   const { dispatch, getAdapter } = useWallet()
   const localWallet = useLocalWallet()
   const [isLoading, setIsLoading] = useState(false)
+  const appDispatch = useAppDispatch()
+  const { setWelcomeModal } = preferences.actions
 
   const backgroundDottedSx = useMemo(
     () => ({
@@ -162,12 +166,20 @@ export const CreateBackupConfirm = () => {
         return
       }
 
+      appDispatch(setWelcomeModal({ show: true }))
       await handleWalletSelect(wallet)
       await queryClient.invalidateQueries({ queryKey: ['listWallets'] })
       history.push(MobileWalletDialogRoutes.CreateBackupSuccess)
       wallet.revoke()
     }
-  }, [location.state?.vault, handleWalletSelect, queryClient, history])
+  }, [
+    location.state?.vault,
+    handleWalletSelect,
+    queryClient,
+    history,
+    appDispatch,
+    setWelcomeModal,
+  ])
 
   const handleWordClick = useCallback(
     (word: string) => {

--- a/src/pages/ConnectWallet/MobileConnect.tsx
+++ b/src/pages/ConnectWallet/MobileConnect.tsx
@@ -12,6 +12,7 @@ import {
   keyframes,
   Link,
   Stack,
+  useDisclosure,
 } from '@chakra-ui/react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useCallback, useEffect, useMemo, useState } from 'react'
@@ -23,6 +24,8 @@ import OrangeFox from 'assets/orange-fox.svg'
 import { CircularProgress } from 'components/CircularProgress/CircularProgress'
 import { FadeTransition } from 'components/FadeTransition'
 import { LanguageSelector } from 'components/LanguageSelector'
+import { MobileWalletDialog } from 'components/MobileWalletDialog/MobileWalletDialog'
+import { MobileWalletDialogRoutes } from 'components/MobileWalletDialog/types'
 import { SlideTransitionY } from 'components/SlideTransitionY'
 import { RawText, Text } from 'components/Text'
 import { WalletActions } from 'context/WalletProvider/actions'
@@ -61,7 +64,7 @@ const BodyText: React.FC<TextProps> = props => (
 )
 
 export const MobileConnect = () => {
-  const { create, importWallet, dispatch, state } = useWallet()
+  const { importWallet, dispatch, state } = useWallet()
   const translate = useTranslate()
   const [wallets, setWallets] = useState<RevocableWallet[]>([])
   const [error, setError] = useState<string | null>(null)
@@ -70,11 +73,15 @@ export const MobileConnect = () => {
   const scaleFadeAnimation = `${scaleFade} 0.6s cubic-bezier(0.76, 0, 0.24, 1)`
   const hasWallet = Boolean(state.walletInfo?.deviceId)
   const history = useHistory()
+  const { isOpen, onClose, onOpen } = useDisclosure()
+  const [defaultRoute, setDefaultRoute] = useState<MobileWalletDialogRoutes>(
+    MobileWalletDialogRoutes.Saved,
+  )
 
-  const handleCreate = useCallback(() => {
-    dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-    create(KeyManager.Mobile)
-  }, [create, dispatch])
+  const handleOpenCreateWallet = useCallback(() => {
+    setDefaultRoute(MobileWalletDialogRoutes.Create)
+    onOpen()
+  }, [onOpen])
 
   const handleImport = useCallback(() => {
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
@@ -148,7 +155,7 @@ export const MobileConnect = () => {
             <BodyText>{translate('connectWalletPage.mobileWelcomeBody')}</BodyText>
           </Stack>
           <Stack maxWidth='80%' mx='auto' spacing={4} width='full'>
-            <Button colorScheme='blue' size='lg-multiline' onClick={handleCreate}>
+            <Button colorScheme='blue' size='lg-multiline' onClick={handleOpenCreateWallet}>
               {translate('connectWalletPage.createANewWallet')}
             </Button>
             <Button variant='outline' size='lg-multiline' onClick={handleImport}>
@@ -200,7 +207,15 @@ export const MobileConnect = () => {
         </BodyStack>
       </motion.div>
     )
-  }, [error, handleCreate, handleImport, handleToggleWallets, hideWallets, translate, wallets])
+  }, [
+    error,
+    handleImport,
+    handleOpenCreateWallet,
+    handleToggleWallets,
+    hideWallets,
+    translate,
+    wallets,
+  ])
 
   return (
     <Flex
@@ -300,6 +315,7 @@ export const MobileConnect = () => {
           </SlideTransitionY>
         )}
       </AnimatePresence>
+      <MobileWalletDialog isOpen={isOpen} onClose={onClose} defaultRoute={defaultRoute} />
     </Flex>
   )
 }


### PR DESCRIPTION
## Description
Mobile home create wallet should be using the new dialog mobile drawer

- Import is not included in this PR as it's not down already in the new drawer, an issue has been created

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8774

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go to the home page on mobile, create a new wallet, it should use the new drawer and working as expected
- Please be careful that the welcome modal is shown after creating a wallet
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/b97b9070-277d-4412-9ba4-68e923bc7597