### PR TITLE
feat: hop/swap progress improvements

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -65,11 +65,9 @@ export const ExpandableStepperSteps = ({
     swap: { state: swapTxState, sellTxHash },
   } = useSelectorWithArgs(selectHopExecutionMetadata, hopExecutionMetadataFilter)
 
+  const stepsLength = useMemo(() => activeTradeQuote?.steps.length ?? 1, [activeTradeQuote])
   // Ternary to satisfy TS, if we're here, we should have a trade quote already
-  const lastHopIndex = useMemo(
-    () => (activeTradeQuote ? activeTradeQuote.steps.length - 1 : 0),
-    [activeTradeQuote],
-  )
+  const lastHopIndex = useMemo(() => stepsLength - 1, [activeTradeQuote])
 
   // Introspects both hops to determine the holistic swap progress
   const firstHopProgress = useHopProgress(0, activeTradeId)
@@ -82,7 +80,7 @@ export const ExpandableStepperSteps = ({
 
     return bn(firstHopProgress.progress)
       .plus(lastHopProgress?.progress ?? 0)
-      .div(2)
+      .div(stepsLength)
       .toNumber()
   }, [firstHopProgress, lastHopProgress, isMultiHopTrade])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -78,7 +78,7 @@ export const ExpandableStepperSteps = ({
       .plus(lastHopProgress?.progress ?? 0)
       .div(2)
       .toNumber()
-  }, [firstHopProgress, lastHopProgress, activeTradeQuote?.steps])
+  }, [firstHopProgress, lastHopProgress, isMultiHopTrade])
 
   const swapProgressStatus = useMemo(() => {
     if (!firstHopProgress) return 'default'
@@ -89,7 +89,7 @@ export const ExpandableStepperSteps = ({
       return 'complete'
 
     return
-  }, [firstHopProgress, lastHopProgress, activeTradeQuote?.steps])
+  }, [firstHopProgress, lastHopProgress, isMultiHopTrade])
 
   // Set progress bar color based on status
   const colorScheme = useMemo(() => {
@@ -123,15 +123,21 @@ export const ExpandableStepperSteps = ({
   }, [confirmedTradeExecutionState, activeQuoteError, swapTxState])
 
   // Memoize selector arguments
-  const firstHopMetadataFilter = useMemo(() => ({
-    tradeId: activeTradeId ?? '',
-    hopIndex: 0,
-  }), [activeTradeId])
+  const firstHopMetadataFilter = useMemo(
+    () => ({
+      tradeId: activeTradeId ?? '',
+      hopIndex: 0,
+    }),
+    [activeTradeId],
+  )
 
-  const lastHopMetadataFilter = useMemo(() => ({
-    tradeId: activeTradeId ?? '',
-    hopIndex: 1,
-  }), [activeTradeId])
+  const lastHopMetadataFilter = useMemo(
+    () => ({
+      tradeId: activeTradeId ?? '',
+      hopIndex: 1,
+    }),
+    [activeTradeId],
+  )
 
   // Get metadata for both hops
   const firstHopMetadata = useSelectorWithArgs(selectHopExecutionMetadata, firstHopMetadataFilter)
@@ -142,7 +148,12 @@ export const ExpandableStepperSteps = ({
       return firstHopMetadata?.swap.message
     }
     return currentHopIndex === 0 ? firstHopMetadata?.swap.message : lastHopMetadata?.swap.message
-  }, [currentHopIndex, firstHopMetadata?.swap.message, lastHopMetadata?.swap.message, isMultiHopTrade])
+  }, [
+    currentHopIndex,
+    firstHopMetadata?.swap.message,
+    lastHopMetadata?.swap.message,
+    isMultiHopTrade,
+  ])
 
   const titleElement = useMemo(() => {
     if (!hopExecutionState) return null
@@ -166,13 +177,7 @@ export const ExpandableStepperSteps = ({
         </HStack>
       </Flex>
     )
-  }, [
-    hopExecutionState,
-    swapProgressValue,
-    swapperName,
-    colorScheme,
-    currentHopMessage,
-  ])
+  }, [hopExecutionState, swapProgressValue, swapperName, colorScheme, currentHopMessage])
 
   const estimatedCompletionTimeForStepMs: number = useMemo(() => {
     switch (currentTradeStep) {

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -65,9 +65,15 @@ export const ExpandableStepperSteps = ({
     swap: { state: swapTxState, sellTxHash },
   } = useSelectorWithArgs(selectHopExecutionMetadata, hopExecutionMetadataFilter)
 
+  // Ternary to satisfy TS, if we're here, we should have a trade quote already
+  const lastHopIndex = useMemo(
+    () => (activeTradeQuote ? activeTradeQuote.steps.length - 1 : 0),
+    [activeTradeQuote],
+  )
+
   // Introspects both hops to determine the holistic swap progress
   const firstHopProgress = useHopProgress(0, activeTradeId)
-  const lastHopProgress = useHopProgress(1, activeTradeId)
+  const lastHopProgress = useHopProgress(lastHopIndex, activeTradeId)
 
   const swapProgressValue = useMemo(() => {
     if (!firstHopProgress) return 0

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -67,7 +67,7 @@ export const ExpandableStepperSteps = ({
 
   const stepsLength = useMemo(() => activeTradeQuote?.steps.length ?? 1, [activeTradeQuote])
   // Ternary to satisfy TS, if we're here, we should have a trade quote already
-  const lastHopIndex = useMemo(() => stepsLength - 1, [activeTradeQuote])
+  const lastHopIndex = useMemo(() => stepsLength - 1, [stepsLength])
 
   // Introspects both hops to determine the holistic swap progress
   const firstHopProgress = useHopProgress(0, activeTradeId)
@@ -82,7 +82,7 @@ export const ExpandableStepperSteps = ({
       .plus(lastHopProgress?.progress ?? 0)
       .div(stepsLength)
       .toNumber()
-  }, [firstHopProgress, lastHopProgress, isMultiHopTrade])
+  }, [firstHopProgress, lastHopProgress, isMultiHopTrade, stepsLength])
 
   const swapProgressStatus = useMemo(() => {
     if (!firstHopProgress) return

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandableStepperSteps.tsx
@@ -81,7 +81,7 @@ export const ExpandableStepperSteps = ({
   }, [firstHopProgress, lastHopProgress, isMultiHopTrade])
 
   const swapProgressStatus = useMemo(() => {
-    if (!firstHopProgress) return 'default'
+    if (!firstHopProgress) return
     if (!isMultiHopTrade) return firstHopProgress.status
 
     if ([firstHopProgress.status, lastHopProgress?.status].includes('failed')) return 'failed'
@@ -91,11 +91,9 @@ export const ExpandableStepperSteps = ({
     return
   }, [firstHopProgress, lastHopProgress, isMultiHopTrade])
 
-  // Set progress bar color based on status
   const colorScheme = useMemo(() => {
     if (swapProgressStatus === 'complete') return 'green'
     if (swapProgressStatus === 'failed') return 'red'
-    return 'blue'
   }, [swapProgressStatus])
 
   const summaryStepIndicator = useMemo(() => {
@@ -122,7 +120,6 @@ export const ExpandableStepperSteps = ({
     }
   }, [confirmedTradeExecutionState, activeQuoteError, swapTxState])
 
-  // Memoize selector arguments
   const firstHopMetadataFilter = useMemo(
     () => ({
       tradeId: activeTradeId ?? '',
@@ -139,7 +136,6 @@ export const ExpandableStepperSteps = ({
     [activeTradeId],
   )
 
-  // Get metadata for both hops
   const firstHopMetadata = useSelectorWithArgs(selectHopExecutionMetadata, firstHopMetadataFilter)
   const lastHopMetadata = useSelectorWithArgs(selectHopExecutionMetadata, lastHopMetadataFilter)
 
@@ -158,7 +154,6 @@ export const ExpandableStepperSteps = ({
   const titleElement = useMemo(() => {
     if (!hopExecutionState) return null
 
-    // Fallback to summary translation if no message
     const stepSummaryTranslation = getHopExecutionStateSummaryStepTranslation(
       hopExecutionState,
       swapperName ?? '',
@@ -166,6 +161,7 @@ export const ExpandableStepperSteps = ({
 
     if (!stepSummaryTranslation && !currentHopMessage) return null
 
+    // Messaging always first for top-level swap status, but we may not have it/yet
     const displayText = currentHopMessage ?? stepSummaryTranslation
 
     return (

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -259,18 +259,11 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
   }, [swapperName, translate])
 
   const firstHopActionTitle = useMemo(() => {
-    const firstHopMessage = firstHopSwap.message
-    const firstHopStatus = firstHopSwap.state
-
     return (
       <VStack width='full' spacing={2} align='stretch'>
         <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
           <HStack>
-            <RawText>
-              {firstHopStatus === TransactionExecutionState.Pending && firstHopMessage
-                ? translate(firstHopMessage)
-                : firstHopActionTitleText}
-            </RawText>
+            <RawText>{firstHopActionTitleText}</RawText>
             {firstHopStreamingProgress && firstHopStreamingProgress.totalSwapCount > 0 && (
               <Tag
                 minWidth='auto'
@@ -322,12 +315,9 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     firstHopSellAccountId,
     firstHopStreamingProgress,
     firstHopSwap.buyTxHash,
-    firstHopSwap.message,
     firstHopSwap.sellTxHash,
-    firstHopSwap.state,
     swapperName,
     tradeQuoteFirstHop,
-    translate,
     firstHopProgress,
   ])
 
@@ -383,18 +373,11 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
   ])
 
   const lastHopActionTitle = useMemo(() => {
-    const lastHopMessage = lastHopSwap.message
-    const lastHopStatus = lastHopSwap.state
-
     return (
       <VStack width='full' spacing={2} align='stretch'>
         <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
           <HStack>
-            <RawText>
-              {lastHopStatus === TransactionExecutionState.Pending && lastHopMessage
-                ? translate(lastHopMessage)
-                : lastHopActionTitleText}
-            </RawText>
+            <RawText>{lastHopActionTitleText}</RawText>
             {secondHopStreamingProgress && secondHopStreamingProgress.totalSwapCount > 0 && (
               <Tag
                 minWidth='auto'
@@ -444,13 +427,10 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     lastHopActionTitleText,
     lastHopSellAccountId,
     lastHopSwap.buyTxHash,
-    lastHopSwap.message,
     lastHopSwap.sellTxHash,
-    lastHopSwap.state,
     secondHopStreamingProgress,
     swapperName,
     tradeQuoteSecondHop,
-    translate,
     lastHopProgress,
   ])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -4,7 +4,6 @@ import {
   Flex,
   HStack,
   Icon,
-  StepIndicator,
   Stepper,
   StepStatus,
   Tag,
@@ -202,23 +201,13 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
 
   const stepStatus = useMemo(
     () => (
-      <StepIndicator
-        className={undefined}
-        sx={undefined}
-        borderWidth={0}
-        height='auto'
-        justifyContent='stretch'
-        flexDir='column'
-        boxSize='16px'
-      >
-        <StepStatus
-          complete={completedStepIndicator}
-          incomplete={undefined}
-          active={
-            activeQuoteError || transactionExecutionStateError ? erroredStepIndicator : undefined
-          }
-        />
-      </StepIndicator>
+      <StepStatus
+        complete={completedStepIndicator}
+        incomplete={undefined}
+        active={
+          activeQuoteError || transactionExecutionStateError ? erroredStepIndicator : undefined
+        }
+      />
     ),
     [activeQuoteError, transactionExecutionStateError],
   )

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -258,7 +258,6 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
       lastHopProgress,
       lastHopSwap.sellTxHash,
       stepStatus,
-      erroredStepIndicator,
     ],
   )
 
@@ -385,7 +384,6 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     firstHopSwap.sellTxHash,
     swapperName,
     tradeQuoteFirstHop,
-    firstHopProgress,
   ])
 
   const lastHopAllowanceResetTitle = useMemo(() => {
@@ -485,7 +483,6 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     secondHopStreamingProgress,
     swapperName,
     tradeQuoteSecondHop,
-    lastHopProgress,
   ])
 
   return (

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -22,16 +22,14 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
   useEffect(() => {
     if (!hopExecutionMetadata?.swap.sellTxHash || hopIndex === undefined || !tradeId) return
 
-    if (hopExecutionMetadata.swap.sellTxHash) {
-      dispatch(
-        tradeQuoteSlice.actions.setHopProgress({
-          hopIndex,
-          tradeId,
-          progress: 50,
-          status: 'default',
-        }),
-      )
-    }
+    dispatch(
+      tradeQuoteSlice.actions.setHopProgress({
+        hopIndex,
+        tradeId,
+        progress: 50,
+        status: 'default',
+      }),
+    )
   }, [dispatch, hopIndex, tradeId, hopExecutionMetadata?.swap.sellTxHash])
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -32,7 +32,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         }),
       )
     }
-  }, [dispatch, hopIndex])
+  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata])
 
   useEffect(() => {
     if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
@@ -58,7 +58,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         }),
       )
     }
-  }, [dispatch, hopIndex, tradeId])
+  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata])
 
   const progress = useMemo(() => hopExecutionMetadata?.progress, [hopExecutionMetadata])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -1,0 +1,65 @@
+import { useEffect, useMemo } from 'react'
+import { selectHopExecutionMetadata } from 'state/slices/tradeQuoteSlice/selectors'
+import { tradeQuoteSlice } from 'state/slices/tradeQuoteSlice/tradeQuoteSlice'
+import { TransactionExecutionState } from 'state/slices/tradeQuoteSlice/types'
+import { useAppDispatch, useAppSelector } from 'state/store'
+
+export const useHopProgress = (hopIndex: number | undefined, tradeId: string | undefined) => {
+  const dispatch = useAppDispatch()
+
+  const hopExecutionMetadataFilter = useMemo(() => {
+    if (!tradeId || hopIndex === undefined) return
+
+    return { tradeId, hopIndex }
+  }, [hopIndex, tradeId])
+
+  const hopExecutionMetadata = useAppSelector(state =>
+    hopExecutionMetadataFilter
+      ? selectHopExecutionMetadata(state, hopExecutionMetadataFilter)
+      : undefined,
+  )
+
+  useEffect(() => {
+    if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
+
+    if (hopExecutionMetadata.swap.sellTxHash) {
+      dispatch(
+        tradeQuoteSlice.actions.setHopProgress({
+          hopIndex,
+          tradeId,
+          progress: 50,
+          status: 'default',
+        }),
+      )
+    }
+  }, [dispatch, hopIndex])
+
+  useEffect(() => {
+    if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
+
+    if (hopExecutionMetadata.swap.state === TransactionExecutionState.Complete) {
+      dispatch(
+        tradeQuoteSlice.actions.setHopProgress({
+          hopIndex,
+          tradeId,
+          progress: 100,
+          status: 'complete',
+        }),
+      )
+    } else if (hopExecutionMetadata.swap.state === TransactionExecutionState.Failed) {
+      dispatch(
+        tradeQuoteSlice.actions.setHopProgress({
+          hopIndex,
+          tradeId,
+          progress: 100,
+          status: 'failed',
+        }),
+      )
+    }
+  }, [dispatch, hopIndex, tradeId])
+
+  const progress = useMemo(() => hopExecutionMetadata?.progress, [hopExecutionMetadata])
+
+  return progress
+}
+

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -20,7 +20,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
   )
 
   useEffect(() => {
-    if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
+    if (!hopExecutionMetadata?.swap.sellTxHash || hopIndex === undefined || !tradeId) return
 
     if (hopExecutionMetadata.swap.sellTxHash) {
       dispatch(
@@ -35,7 +35,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
   }, [dispatch, hopIndex, tradeId, hopExecutionMetadata?.swap.sellTxHash])
 
   useEffect(() => {
-    if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
+    if (!hopExecutionMetadata?.swap.sellTxHash || hopIndex === undefined || !tradeId) return
 
     if (hopExecutionMetadata.swap.state === TransactionExecutionState.Failed) {
       dispatch(
@@ -58,7 +58,13 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         }),
       )
     }
-  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata?.swap.sellTxHash])
+  }, [
+    dispatch,
+    hopIndex,
+    tradeId,
+    hopExecutionMetadata?.swap.sellTxHash,
+    hopExecutionMetadata?.swap.state,
+  ])
 
   const progress = useMemo(() => hopExecutionMetadata?.progress, [hopExecutionMetadata])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -37,16 +37,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
   useEffect(() => {
     if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
 
-    if (hopExecutionMetadata.swap.state === TransactionExecutionState.Complete) {
-      dispatch(
-        tradeQuoteSlice.actions.setHopProgress({
-          hopIndex,
-          tradeId,
-          progress: 100,
-          status: 'complete',
-        }),
-      )
-    } else if (hopExecutionMetadata.swap.state === TransactionExecutionState.Failed) {
+    if (hopExecutionMetadata.swap.state === TransactionExecutionState.Failed) {
       dispatch(
         tradeQuoteSlice.actions.setHopProgress({
           hopIndex,
@@ -56,10 +47,20 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         }),
       )
     }
+
+    if (hopExecutionMetadata.swap.state === TransactionExecutionState.Complete) {
+      dispatch(
+        tradeQuoteSlice.actions.setHopProgress({
+          hopIndex,
+          tradeId,
+          progress: 100,
+          status: 'complete',
+        }),
+      )
+    }
   }, [dispatch, hopIndex, tradeId])
 
   const progress = useMemo(() => hopExecutionMetadata?.progress, [hopExecutionMetadata])
 
   return progress
 }
-

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -27,7 +27,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         hopIndex,
         tradeId,
         progress: 50,
-        status: 'default',
+        status: 'pending',
       }),
     )
   }, [dispatch, hopIndex, tradeId, hopExecutionMetadata?.swap.sellTxHash])

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useHopProgress.ts
@@ -32,7 +32,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         }),
       )
     }
-  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata])
+  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata?.swap.sellTxHash])
 
   useEffect(() => {
     if (!hopExecutionMetadata || hopIndex === undefined || !tradeId) return
@@ -58,7 +58,7 @@ export const useHopProgress = (hopIndex: number | undefined, tradeId: string | u
         }),
       )
     }
-  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata])
+  }, [dispatch, hopIndex, tradeId, hopExecutionMetadata?.swap.sellTxHash])
 
   const progress = useMemo(() => hopExecutionMetadata?.progress, [hopExecutionMetadata])
 

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -1,7 +1,7 @@
 import { TradeQuoteError } from '@shapeshiftoss/swapper'
 import { TradeQuoteValidationError } from 'state/apis/swapper/types'
 
-import type { TradeQuoteSliceState } from './types'
+import type { HopExecutionMetadata, TradeQuoteSliceState } from './types'
 import { HopExecutionState, TradeExecutionState, TransactionExecutionState } from './types'
 
 export const initialApprovalExecutionState = {
@@ -13,18 +13,33 @@ export const initialTransactionState = {
   state: TransactionExecutionState.AwaitingConfirmation,
 }
 
-const initialHopState = {
+const initialHopExecutionState: HopExecutionMetadata = {
   state: HopExecutionState.Pending,
-  allowanceReset: initialApprovalExecutionState,
-  allowanceApproval: initialApprovalExecutionState,
-  permit2: initialTransactionState,
-  swap: initialTransactionState,
+  allowanceReset: {
+    state: TransactionExecutionState.AwaitingConfirmation,
+    isInitiallyRequired: undefined,
+  },
+  allowanceApproval: {
+    state: TransactionExecutionState.AwaitingConfirmation,
+    isInitiallyRequired: undefined,
+  },
+  permit2: {
+    state: TransactionExecutionState.AwaitingConfirmation,
+    isRequired: false,
+  },
+  swap: {
+    state: TransactionExecutionState.AwaitingConfirmation,
+  },
+  progress: {
+    progress: 0,
+    status: 'default',
+  },
 }
 
 export const initialTradeExecutionState = {
   state: TradeExecutionState.Initializing,
-  firstHop: initialHopState,
-  secondHop: initialHopState,
+  firstHop: initialHopExecutionState,
+  secondHop: initialHopExecutionState,
 }
 
 export const initialState: TradeQuoteSliceState = {

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -16,7 +16,7 @@ export const initialTransactionState = {
 const initialProgressState = {
   progress: 0,
   status: 'default',
-}
+} as const
 
 const initialHopState = {
   state: HopExecutionState.Pending,

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -13,7 +13,7 @@ export const initialTransactionState = {
   state: TransactionExecutionState.AwaitingConfirmation,
 }
 
-const initialHopExecutionState: HopExecutionMetadata = {
+const initialHopState: HopExecutionMetadata = {
   state: HopExecutionState.Pending,
   allowanceReset: {
     state: TransactionExecutionState.AwaitingConfirmation,
@@ -38,8 +38,8 @@ const initialHopExecutionState: HopExecutionMetadata = {
 
 export const initialTradeExecutionState = {
   state: TradeExecutionState.Initializing,
-  firstHop: initialHopExecutionState,
-  secondHop: initialHopExecutionState,
+  firstHop: initialHopState,
+  secondHop: initialHopState,
 }
 
 export const initialState: TradeQuoteSliceState = {

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -15,7 +15,7 @@ export const initialTransactionState = {
 
 const initialProgressState = {
   progress: 0,
-  status: 'default',
+  status: 'pending',
 } as const
 
 const initialHopState = {

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -1,7 +1,7 @@
 import { TradeQuoteError } from '@shapeshiftoss/swapper'
 import { TradeQuoteValidationError } from 'state/apis/swapper/types'
 
-import type { HopExecutionMetadata, TradeQuoteSliceState } from './types'
+import type { TradeQuoteSliceState } from './types'
 import { HopExecutionState, TradeExecutionState, TransactionExecutionState } from './types'
 
 export const initialApprovalExecutionState = {
@@ -13,27 +13,18 @@ export const initialTransactionState = {
   state: TransactionExecutionState.AwaitingConfirmation,
 }
 
-const initialHopState: HopExecutionMetadata = {
+const initialProgressState = {
+  progress: 0,
+  status: 'default',
+}
+
+const initialHopState = {
   state: HopExecutionState.Pending,
-  allowanceReset: {
-    state: TransactionExecutionState.AwaitingConfirmation,
-    isInitiallyRequired: undefined,
-  },
-  allowanceApproval: {
-    state: TransactionExecutionState.AwaitingConfirmation,
-    isInitiallyRequired: undefined,
-  },
-  permit2: {
-    state: TransactionExecutionState.AwaitingConfirmation,
-    isRequired: false,
-  },
-  swap: {
-    state: TransactionExecutionState.AwaitingConfirmation,
-  },
-  progress: {
-    progress: 0,
-    status: 'default',
-  },
+  allowanceReset: initialApprovalExecutionState,
+  allowanceApproval: initialApprovalExecutionState,
+  permit2: initialTransactionState,
+  swap: initialTransactionState,
+  progress: initialProgressState,
 }
 
 export const initialTradeExecutionState = {

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -6,7 +6,7 @@ import type { InterpolationOptions } from 'node-polyglot'
 import type { ApiQuote } from 'state/apis/swapper/types'
 
 import { initialState, initialTradeExecutionState } from './constants'
-import type { StreamingSwapMetadata, TradeExecutionMetadata } from './types'
+import type { HopProgress, StreamingSwapMetadata, TradeExecutionMetadata } from './types'
 import {
   AllowanceKey,
   HopExecutionState,
@@ -448,6 +448,25 @@ export const tradeQuoteSlice = createSlice({
       const errorQuotes = sortQuotes(allQuotes.filter(({ errors }) => errors.length > 0))
 
       state.tradeQuoteDisplayCache = happyQuotes.concat(errorQuotes)
+    },
+    setHopProgress: (
+      state,
+      action: PayloadAction<{
+        hopIndex: number
+        tradeId: string
+        progress: number
+        status: HopProgress['status']
+      }>,
+    ) => {
+      const { hopIndex, tradeId, progress, status } = action.payload
+      const hopKey = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
+
+      if (!state.tradeExecution[tradeId]) return
+
+      state.tradeExecution[tradeId][hopKey].progress = {
+        progress,
+        status,
+      }
     },
   },
 })

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -75,6 +75,11 @@ export type SwapExecutionMetadata = {
   message?: string | [string, InterpolationOptions]
 }
 
+export type HopProgress = {
+  progress: number // 0, 50, or 100
+  status: 'default' | 'complete' | 'failed'
+}
+
 export type HopExecutionMetadata = {
   state: HopExecutionState
   allowanceReset: ApprovalExecutionMetadata
@@ -83,6 +88,7 @@ export type HopExecutionMetadata = {
     permit2Signature?: string
   }
   swap: SwapExecutionMetadata
+  progress: HopProgress
 }
 
 export type TradeExecutionMetadata = {

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -76,8 +76,9 @@ export type SwapExecutionMetadata = {
 }
 
 export type HopProgress = {
-  progress: number // 0, 50, or 100
-  status: 'default' | 'complete' | 'failed'
+  // i.e as an int from 0 to 100
+  progress: number
+  status: 'pending' | 'complete' | 'failed'
 }
 
 export type HopExecutionMetadata = {


### PR DESCRIPTION
## Description

What this PR does:

- Brings in the notion of less dumb progress, currently heuristics-based
  - a sell Tx contributes to 50% of a hop completion 
  - an effective complete state for a hop is 100% (as the hop is... well, conplete?)
  - Swaps consist of hops, and the holistic progress is the sum of both hops divided by 2 
- Wires up said notion 
  - in the holistic progress bar 
  - in each step, using circular progress with the current progress of a given hop 
- Removes the status messaging from the current hop and move it up top to the top-level swap view, so hops always reflect their name and don't flash status updates 

What this PR does not:

- bringing a best-effort parsing of different substeps to percent progress for a given hop for Li.Fi, THOR, Chainflip

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- only partially tackles #8575 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium given the amount of code touched, realistically low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Single-hop swaps look sane and so do their progress given the heuristics above
- Multi-hop swaps look sane and so do their progress given the heuristics above

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Single Hop

https://jam.dev/c/bb48ce6d-7838-47b5-9710-ac612f7e2da6

- Multi-Hop

https://jam.dev/c/519301fb-6c73-46ee-ac00-8500c536da08
https://jam.dev/c/ec036ec8-9b20-4902-bc0e-fc72d8573bcc



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
