### PR TITLE
fix: markets LP assets fetching

### DIFF
--- a/src/lib/portals/utils.ts
+++ b/src/lib/portals/utils.ts
@@ -25,6 +25,7 @@ export const fetchPortalsTokens = async ({
   chainIds,
   page = 0,
   accTokens = [],
+  minApy,
   sortBy,
   sortDirection,
   limit = 250,
@@ -32,6 +33,7 @@ export const fetchPortalsTokens = async ({
   chainIds: ChainId[] | undefined
   page?: number
   accTokens?: TokenInfo[]
+  minApy?: string
   sortBy?:
     | 'key'
     | 'decimals'
@@ -81,6 +83,7 @@ export const fetchPortalsTokens = async ({
       page: page.toString(),
       sortBy,
       sortDirection,
+      minApy,
     }
 
     await throttle()

--- a/src/pages/Markets/components/LpGrid.tsx
+++ b/src/pages/Markets/components/LpGrid.tsx
@@ -47,6 +47,7 @@ export const LpGrid: React.FC<{
     enabled: inView,
     sortBy,
     orderBy,
+    minApy: '1',
   })
 
   const filteredAssetIds = useMemo(
@@ -139,6 +140,9 @@ export const OneClickDefiAssets: React.FC<{
   const { ref, inView } = useInView()
   const { data: portalsAssets, isLoading: isPortalsAssetsLoading } = usePortalsAssetsQuery({
     chainIds: selectedChainId ? [selectedChainId] : undefined,
+    sortBy,
+    orderBy,
+    minApy: '1',
     enabled: inView,
   })
 

--- a/src/pages/Markets/hooks/usePortalsAssetsQuery.ts
+++ b/src/pages/Markets/hooks/usePortalsAssetsQuery.ts
@@ -22,11 +22,13 @@ export const usePortalsAssetsQuery = ({
   chainIds,
   sortBy,
   orderBy,
+  minApy,
 }: {
   enabled: boolean
   chainIds: ChainId[] | undefined
   sortBy?: SortOptionsKeys
   orderBy?: OrderDirection
+  minApy?: string
 }) => {
   const dispatch = useAppDispatch()
   const assets = useAppSelector(selectAssets)
@@ -38,7 +40,7 @@ export const usePortalsAssetsQuery = ({
   })
 
   return useQuery({
-    queryKey: ['portalsAssets', { chainIds, orderBy, sortBy }],
+    queryKey: ['portalsAssets', { chainIds, orderBy, sortBy, minApy }],
     queryFn:
       enabled && portalsPlatformsData
         ? () =>
@@ -46,6 +48,7 @@ export const usePortalsAssetsQuery = ({
               limit: 10,
               chainIds,
               sortBy: sortBy === SortOptionsKeys.Volume ? 'volumeUsd1d' : 'apy',
+              minApy,
               sortDirection:
                 orderBy === OrderDirection.Ascending && sortBy !== SortOptionsKeys.MarketCap
                   ? 'asc'


### PR DESCRIPTION
## Description

Aligns data-fetching between parents and children so that they leverage the same query, and ultimately same assets set.
While at that, ensures the "one-click DeFi" actually does fetch DeFi assets only (which was required after implementing the above) by enforcing a minApy in queryparams.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8763

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- One-click DeFi assets section looks sane
- Sorting still works for both volume and APY
- APY is *actually* present (or N/A for some when sorting by ascending)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
