### PR TITLE
fix: discord url that does not expire

### DIFF
--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -372,7 +372,7 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
           <AlertIcon />
           <AlertDescription>
             {translate('lending.haltedAlert')}
-            <Link isExternal href='https://discord.gg/jhnWUxye' ml={1} color='text.link'>
+            <Link isExternal href='https://discord.gg/uhhZe9pCZj' ml={1} color='text.link'>
               {translate('lending.halterMoreDetails')}
             </Link>
           </AlertDescription>

--- a/src/pages/Lending/Pool/components/PoolInfo.tsx
+++ b/src/pages/Lending/Pool/components/PoolInfo.tsx
@@ -130,7 +130,7 @@ export const PoolInfo = ({ poolAssetId }: PoolInfoProps) => {
           <AlertIcon />
           <AlertDescription>
             {translate('lending.haltedAlert')}
-            <Link isExternal href='https://discord.gg/jhnWUxye' ml={1} color='text.link'>
+            <Link isExternal href='https://discord.gg/uhhZe9pCZj' ml={1} color='text.link'>
               {translate('lending.halterMoreDetails')}
             </Link>
           </AlertDescription>

--- a/src/pages/Lending/components/LendingHeader.tsx
+++ b/src/pages/Lending/components/LendingHeader.tsx
@@ -140,7 +140,7 @@ export const LendingHeader = () => {
               <AlertIcon />
               <AlertDescription>
                 {translate('lending.haltedAlert')}
-                <Link isExternal href='https://discord.gg/jhnWUxye' ml={1} color='text.link'>
+                <Link isExternal href='https://discord.gg/uhhZe9pCZj' ml={1} color='text.link'>
                   {translate('lending.halterMoreDetails')}
                 </Link>
               </AlertDescription>


### PR DESCRIPTION
## Description

A fast-follow to https://github.com/shapeshift/web/pull/8815, but this time we include a link that we know will never expire. The default is 7 days, this one is infinite:

<img width="459" alt="Screenshot 2025-02-13 at 16 05 57" src="https://github.com/user-attachments/assets/29a3a88b-0b5c-4933-9f26-ab084269c182" />

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/8814

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

URL should point to THORChain Devs Discord.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A