### PR TITLE
fix: convert manage accounts modal to mobile drawer

### DIFF
--- a/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
+++ b/src/components/Modals/ManageAccounts/ManageAccountsModal.tsx
@@ -1,24 +1,19 @@
-import {
-  Button,
-  Flex,
-  HStack,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  ModalOverlay,
-  Tag,
-  useDisclosure,
-  VStack,
-} from '@chakra-ui/react'
+import { Box, Button, Flex, HStack, Tag, useDisclosure, VStack } from '@chakra-ui/react'
 import type { ChainId } from '@shapeshiftoss/caip'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { LazyLoadAvatar } from 'components/LazyLoadAvatar'
 import { ManageAccountsDrawer } from 'components/ManageAccountsDrawer/ManageAccountsDrawer'
+import { Dialog } from 'components/Modal/components/Dialog'
+import { DialogBody } from 'components/Modal/components/DialogBody'
+import { DialogCloseButton } from 'components/Modal/components/DialogCloseButton'
+import { DialogFooter } from 'components/Modal/components/DialogFooter'
+import {
+  DialogHeader,
+  DialogHeaderMiddle,
+  DialogHeaderRight,
+} from 'components/Modal/components/DialogHeader'
 import { RawText } from 'components/Text'
 import { availableLedgerChainIds } from 'context/WalletProvider/Ledger/constants'
 import { useModal } from 'hooks/useModal/useModal'
@@ -33,6 +28,11 @@ import {
 import { useAppSelector } from 'state/store'
 
 const disabledProp = { opacity: 0.5, cursor: 'not-allowed', userSelect: 'none' }
+
+const chainListMaxHeight = {
+  base: '220px',
+  md: '400px',
+}
 
 const ConnectedChain = ({
   chainId,
@@ -110,67 +110,76 @@ export const ManageAccountsModal = () => {
 
   return (
     <>
-      <Modal
+      <Dialog
         isOpen={isOpen}
         onClose={close}
-        isCentered
-        size='md'
-        closeOnOverlayClick={!disableClose}
+        isDisablingPropagation={false}
+        isFullScreen={false}
+        height='auto'
       >
-        <ModalOverlay />
-        <ModalContent>
-          <ManageAccountsDrawer
-            isOpen={isDrawerOpen}
-            onClose={handleDrawerClose}
-            chainId={selectedChainId}
-          />
-          <ModalHeader textAlign='left' pt={14}>
-            <RawText as='h3' fontWeight='semibold'>
-              {translate('accountManagement.manageAccounts.title')}
-            </RawText>
-            <RawText color='text.subtle' fontSize='md' fontWeight='normal'>
-              {walletConnectedChainIdsSorted.length === 0
-                ? translate('accountManagement.manageAccounts.emptyList')
-                : translate('accountManagement.manageAccounts.description')}
-            </RawText>
-          </ModalHeader>
-          <ModalCloseButton position='absolute' top={3} right={3} isDisabled={disableClose} />
-          {walletConnectedChainIdsSorted.length > 0 && (
-            <ModalBody maxH='400px' overflowY='auto'>
+        <ManageAccountsDrawer
+          isOpen={isDrawerOpen}
+          onClose={handleDrawerClose}
+          chainId={selectedChainId}
+        />
+        <DialogHeader>
+          <DialogHeaderMiddle>
+            <Box minWidth='50px'>
+              <RawText as='h3' fontWeight='semibold' textAlign='center'>
+                {translate('accountManagement.manageAccounts.title')}
+              </RawText>
+            </Box>
+          </DialogHeaderMiddle>
+          <DialogHeaderRight>
+            <DialogCloseButton isDisabled={disableClose} />
+          </DialogHeaderRight>
+        </DialogHeader>
+
+        <VStack spacing={2} alignItems='flex-start' px={2} pb={4}>
+          <RawText color='text.subtle' fontSize='md' fontWeight='normal' textAlign='center'>
+            {walletConnectedChainIdsSorted.length === 0
+              ? translate('accountManagement.manageAccounts.emptyList')
+              : translate('accountManagement.manageAccounts.description')}
+          </RawText>
+        </VStack>
+
+        {walletConnectedChainIdsSorted.length > 0 && (
+          <DialogBody maxHeight={chainListMaxHeight}>
+            <Box mx={-4} px={4}>
               <VStack spacing={2} width='full'>
                 {connectedChains}
               </VStack>
-            </ModalBody>
-          )}
-          <ModalFooter justifyContent='center' pb={6}>
-            <VStack spacing={2} width='full'>
-              <Button
-                colorScheme='blue'
-                onClick={handleClickAddChain}
-                width='full'
-                size='lg'
-                isLoading={isDrawerOpen}
-                isDisabled={disableAddChain}
-                _disabled={disabledProp}
-              >
-                {walletConnectedChainIdsSorted.length === 0
-                  ? translate('accountManagement.manageAccounts.addChain')
-                  : translate('accountManagement.manageAccounts.addAnotherChain')}
-              </Button>
-              <Button
-                size='lg'
-                colorScheme='gray'
-                onClick={close}
-                // don't allow users to close the modal until at least one chain is connected
-                isDisabled={isDrawerOpen || disableClose}
-                width='full'
-              >
-                {translate('common.done')}
-              </Button>
-            </VStack>
-          </ModalFooter>
-        </ModalContent>
-      </Modal>
+            </Box>
+          </DialogBody>
+        )}
+
+        <DialogFooter>
+          <VStack spacing={2} width='full' py={2} pt={4}>
+            <Button
+              colorScheme='blue'
+              onClick={handleClickAddChain}
+              width='full'
+              size='lg'
+              isLoading={isDrawerOpen}
+              isDisabled={disableAddChain}
+              _disabled={disabledProp}
+            >
+              {walletConnectedChainIdsSorted.length === 0
+                ? translate('accountManagement.manageAccounts.addChain')
+                : translate('accountManagement.manageAccounts.addAnotherChain')}
+            </Button>
+            <Button
+              size='lg'
+              colorScheme='gray'
+              onClick={close}
+              isDisabled={isDrawerOpen || disableClose}
+              width='full'
+            >
+              {translate('common.done')}
+            </Button>
+          </VStack>
+        </DialogFooter>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
## Description

Converting the manage account modal to our drawer so it's more integrated and mobile friendly

I had to tweak a bit the design to make it look more like the actual version on desktop, but it should be almost similar!

And on mobile it should use the sliding drawer that feels super sweet

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8795

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Use the manage account drawer on desktop and see if you can use all the feature as before
- Use the manage account drawer on mobile app and see if it use the new mobile drawer sliding view, try to use te features as before

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/3b850861-8606-4ead-be85-dea12aa26994
<img width="423" alt="image" src="https://github.com/user-attachments/assets/4a3837ca-908a-401f-8974-82058110b047" />
