### PR TITLE
fix: close on click outside mobile drawer

### DIFF
--- a/src/components/Layout/Header/NavBar/MobileNavBar.tsx
+++ b/src/components/Layout/Header/NavBar/MobileNavBar.tsx
@@ -222,7 +222,7 @@ export const MobileNavBar = memo(() => {
           />
         </Flex>
       </SimpleGrid>
-      <Dialog isOpen={isOpen} onClose={onClose} height='auto'>
+      <Dialog isOpen={isOpen} onClose={onClose} height='auto' isDisablingPropagation={false}>
         <DialogHeader />
         <DialogBody
           pb='calc(env(safe-area-inset-bottom) + 2rem)'

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -122,9 +122,10 @@ const DialogWindow: React.FC<DialogProps> = ({
               position='fixed'
               inset={0}
               zIndex='var(--chakra-zIndices-modal)'
+              onClick={onClose}
             />
           ) : null}
-          {isDisablingPropagation ? <CustomDrawerOverlay /> : null}
+          {isDisablingPropagation ? <CustomDrawerOverlay onClick={onClose} /> : null}
           <CustomDrawerContent style={contentStyle}>{children}</CustomDrawerContent>
         </Drawer.Portal>
       </Drawer.Root>


### PR DESCRIPTION
## Description

Clicking outside the mobile drawer was not closing the drawer, fixed it by adding a click event on both overlays!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8713

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Open mobile drawer (on mobile app for example)
- Click outside of the drawer, it should close
- Use any thing inside, it should not close the drawer if it's not supposed to close it

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/d6993882-a87c-4b84-9c24-acce8c2fd640