### PR TITLE
fix: selectIsLoading swappers should select loading swappers

### DIFF
--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -657,18 +657,18 @@ export const selectIsTradeQuoteRequestAborted = createSelector(
 )
 
 export const selectLoadingSwappers = createSelector(
-  selectIsSwapperResponseAvailable,
   selectIsTradeQuoteApiQueryPending,
   selectTradeQuoteDisplayCache,
-  (isSwapperQuoteAvailable, isTradeQuoteApiQueryPending, tradeQuoteDisplayCache) => {
-    return Object.entries(isSwapperQuoteAvailable)
-      .filter(
-        ([swapperName, isQuoteAvailable]) =>
-          // only include swappers that are still fetching data
-          (!isQuoteAvailable || isTradeQuoteApiQueryPending[swapperName as SwapperName]) &&
-          // filter out entries that already have data - these have been loaded and are refetching
-          !tradeQuoteDisplayCache.some(quoteData => quoteData.swapperName === swapperName),
-      )
+  (isTradeQuoteApiQueryPending, tradeQuoteDisplayCache) => {
+    return Object.entries(isTradeQuoteApiQueryPending)
+      .filter(([swapperName, isPending]) => {
+        // filter out entries that already have data - these have been loaded and are refetching
+        const hasDisplayCache = tradeQuoteDisplayCache.some(
+          quoteData => quoteData.swapperName === swapperName,
+        )
+
+        return isPending && !hasDisplayCache
+      })
       .map(([swapperName, _isQuoteAvailable]) => swapperName)
   },
 )


### PR DESCRIPTION
## Description

What it says on the box, literally. There was a bug in the selector that was reacting on data presence or lack thereof, which would not work on refresh and would consider quotes to be loading when they in fact aren't.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8738

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get a quote for e.g ETH -> BTC
- Notice there are no loading swappers that shouldn't which are perma-loading (i.e unsupported ones for this pair which aren't actually loading)
- Wait for the auto-refresh 
- Note there *still* aren't any perma-loading


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/65aec27f-b8d8-4537-9053-56c91603188e


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
