### PR TITLE
chore: Update Fee Model to increase Max_Fee_BPS to 69

### DIFF
--- a/src/lib/fees/parameters/swapper.ts
+++ b/src/lib/fees/parameters/swapper.ts
@@ -1,6 +1,6 @@
 import type { FeeCurveParameters } from './types'
 
-const FEE_CURVE_MAX_FEE_BPS = 49 // basis points
+const FEE_CURVE_MAX_FEE_BPS = 69 // basis points
 const FEE_CURVE_MIN_FEE_BPS = 20 // basis points
 const FEE_CURVE_NO_FEE_THRESHOLD_USD = 1_000 // usd
 const FEE_CURVE_FOX_MAX_DISCOUNT_THRESHOLD = 500_000 // fox


### PR DESCRIPTION
## Description

Changing max_fee_bps to 69 as per DFC vote 99: https://discord.com/channels/554694662431178782/920449863408287855/1331381886248812607

## Issue (if applicable)

no issue

## Risk

> High Risk PRs Require 2 approvals

low-risk but needs testing.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
needs testing
spin up wallet without any fox. makes sure fees are accurate. 

### Engineering

halp?

### Operations

when ready, test fees please

## Screenshots (if applicable)
no screenshots