### PR TITLE
fix: useHasFocus

### DIFF
--- a/src/hooks/useHasFocus.tsx
+++ b/src/hooks/useHasFocus.tsx
@@ -1,16 +1,22 @@
 import { useEffect, useState } from 'react'
 
 export const useHasFocus = () => {
-  const [hasFocus, setHasFocus] = useState(document.hasFocus())
+  const [hasFocus, setHasFocus] = useState(true)
 
   useEffect(() => {
-    const handleFocus = () => {
-      setHasFocus(document.hasFocus())
-    }
+    const handleFocus = () => setHasFocus(true)
+    const handleBlur = () => setHasFocus(false)
+    const handleResume = () => setHasFocus(true)
 
     window.addEventListener('focus', handleFocus)
+    window.addEventListener('blur', handleBlur)
+    document.addEventListener('resume', handleResume) // Handle mobile app lifecycle events
 
-    return () => window.removeEventListener('focus', handleFocus)
+    return () => {
+      window.removeEventListener('focus', handleFocus)
+      window.removeEventListener('blur', handleBlur)
+      document.removeEventListener('resume', handleResume)
+    }
   }, [])
 
   return hasFocus

--- a/src/hooks/useHasFocus.tsx
+++ b/src/hooks/useHasFocus.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 
 export const useHasFocus = () => {
-  const [hasFocus, setHasFocus] = useState(true)
+  const [hasFocus, setHasFocus] = useState(document.hasFocus())
 
   useEffect(() => {
     const handleFocus = () => setHasFocus(true)


### PR DESCRIPTION
## Description

Fixes the `useHasFocus` hook to actually set on `blur`.
Also adds support for `resume` for mobile applications, ensuring the state is correctly updated when unlocking the phone etc.

## Issue (if applicable)

Inspired by https://github.com/shapeshift/web/issues/8731

## Risk

> High Risk PRs Require 2 approvals

Medium - risk that polling breaks and users can't get quotes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Swapper quotes.

## Testing

The easiest way to test this is to open the developer console. Navigate to the network tab and observe that whilst the developer pane is active we won't fetch quotes.

Then, click back into the app and we'll continue fetching (timer will reset, and we'll fetch a quote at the end).

Check mobile still works as expected - quotes poll, and resume polling on app re-open etc.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

N/A