### PR TITLE
chore: change default buy asset to btc

### DIFF
--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -1,5 +1,5 @@
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
+import { btcAssetId, ethAssetId } from '@shapeshiftoss/caip'
 import { localAssetData } from 'lib/asset-service'
 
 import { defaultAsset } from '../assetsSlice/assetsSlice'
@@ -14,7 +14,7 @@ export type TradeInputState = {
 } & TradeInputBaseState
 
 const initialState: TradeInputState = {
-  buyAsset: localAssetData[foxAssetId] ?? defaultAsset,
+  buyAsset: localAssetData[btcAssetId] ?? defaultAsset,
   sellAsset: localAssetData[ethAssetId] ?? defaultAsset,
   sellAccountId: undefined,
   buyAccountId: undefined,


### PR DESCRIPTION
## Description

Updates the default buy asset to BTC (replacing FOX).

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8801

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

On initial load the default asset pair should be ETH to BTC.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

<img width="394" alt="Screenshot 2025-02-14 at 08 50 16" src="https://github.com/user-attachments/assets/fe84cc38-c6a6-4f37-a04e-ea804f1c4202" />