### PR TITLE
fix: ci after fee bump

### DIFF
--- a/src/lib/fees/model.test.ts
+++ b/src/lib/fees/model.test.ts
@@ -101,7 +101,7 @@ describe('calculateFees', () => {
       feeModel: 'SWAPPER',
       isSnapshotApiQueriesRejected,
     })
-    expect(feeBps.toNumber()).toEqual(35)
+    expect(feeBps.toNumber()).toEqual(45)
   })
 
   it('should discount fees by 50% holding at midpoint holding half max fox discount limit', () => {
@@ -116,7 +116,7 @@ describe('calculateFees', () => {
       feeModel: 'SWAPPER',
       isSnapshotApiQueriesRejected,
     })
-    expect(feeBps.toNumber()).toEqual(17)
+    expect(feeBps.toNumber()).toEqual(22)
     expect(foxDiscountPercent).toEqual(bn(50))
   })
 


### PR DESCRIPTION
## Description

Fixes CI after https://github.com/shapeshift/web/pull/8825.

## Issue (if applicable)

N/A

## Risk

> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

CI should pass.

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

N/A

## Screenshots (if applicable)

N/A