### PR TITLE
fix: confusing quote un/select behaviour

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -172,7 +172,7 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
     const handleQuoteSelection = useCallback(() => {
       dispatch(tradeQuoteSlice.actions.setActiveQuote(quoteData))
       onBack && onBack()
-    }, [dispatch, isActive, onBack, quoteData])
+    }, [dispatch, onBack, quoteData])
 
     const feeAsset = useAppSelector(state =>
       selectFeeAssetByChainId(state, sellAsset.chainId ?? ''),

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -170,14 +170,9 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
     )
 
     const handleQuoteSelection = useCallback(() => {
-      if (!isActive) {
-        dispatch(tradeQuoteSlice.actions.setActiveQuote(quoteData))
-        onBack && onBack()
-      } else if (!isBest) {
-        // don't allow un-selecting of best quote as it gets re-selected in this case
-        dispatch(tradeQuoteSlice.actions.setActiveQuote(undefined))
-      }
-    }, [dispatch, isActive, isBest, onBack, quoteData])
+      dispatch(tradeQuoteSlice.actions.setActiveQuote(quoteData))
+      onBack && onBack()
+    }, [dispatch, isActive, onBack, quoteData])
 
     const feeAsset = useAppSelector(state =>
       selectFeeAssetByChainId(state, sellAsset.chainId ?? ''),


### PR DESCRIPTION
## Description

Allows users to click the selected quote as many times as they want without the second click reverting the selection back to active
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8841

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go bananas clicking around in quotes 
- Clicking on a quote should always select it, or keep it selected if selected, no weird unselection

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/ab6be634-112e-46cb-883e-aeb21e566bf1


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
