### PR TITLE
feat: blazingly fast follow

### DIFF
--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -73,11 +73,13 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
   const pubkey = useMemo(() => fromAccountId(accountId).account, [accountId])
   const isUtxoAccount = useMemo(() => isUtxoAccountId(accountId), [accountId])
 
-  const { data: account, isFetching: isAccountFetching } = useQuery({
+  const { data: account } = useQuery({
     ...accountManagement.getAccount(accountId),
     staleTime: Infinity,
     // Never garbage collect me, I'm a special snowflake
     gcTime: Infinity,
+    // Yes, we do refetch on mount despite having an Infinity stale time. Stale then fresh FTW.
+    refetchOnMount: 'always',
   })
 
   const assetBalanceCryptoPrecision = useMemo(() => {
@@ -97,11 +99,7 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
         </InlineCopyButton>
       </Td>
       <Td textAlign='right'>
-        {isAccountFetching ? (
-          <Skeleton height='24px' width='100%' />
-        ) : (
-          <Amount.Crypto value={assetBalanceCryptoPrecision} symbol={asset.symbol} />
-        )}
+        <Amount.Crypto value={assetBalanceCryptoPrecision} symbol={asset.symbol} />
       </Td>
     </>
   )

--- a/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
+++ b/src/components/ManageAccountsDrawer/components/ImportAccounts.tsx
@@ -18,7 +18,7 @@ import type { Asset } from '@shapeshiftoss/types'
 import { useInfiniteQuery, useQueries, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { accountManagement, GET_ACCOUNT_STALE_TIME } from 'react-queries/queries/accountManagement'
+import { accountManagement } from 'react-queries/queries/accountManagement'
 import { Amount } from 'components/Amount/Amount'
 import { InlineCopyButton } from 'components/InlineCopyButton'
 import { RawText } from 'components/Text'
@@ -75,7 +75,7 @@ const TableRowAccount = forwardRef<TableRowAccountProps, 'div'>(({ asset, accoun
 
   const { data: account, isFetching: isAccountFetching } = useQuery({
     ...accountManagement.getAccount(accountId),
-    staleTime: GET_ACCOUNT_STALE_TIME,
+    staleTime: Infinity,
     // Never garbage collect me, I'm a special snowflake
     gcTime: Infinity,
   })
@@ -368,7 +368,7 @@ export const ImportAccounts = ({ chainId, onClose, isOpen }: ImportAccountsProps
         // "Fetch" the query leveraging the existing cached data
         const account = await queryClient.fetchQuery({
           ...accountManagement.getAccount(accountId),
-          staleTime: GET_ACCOUNT_STALE_TIME,
+          staleTime: Infinity,
           // Never garbage collect me, I'm a special snowflake
           gcTime: Infinity,
         })

--- a/src/components/ManageAccountsDrawer/helpers.ts
+++ b/src/components/ManageAccountsDrawer/helpers.ts
@@ -1,7 +1,7 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { matchSorter } from 'match-sorter'
-import { accountManagement, GET_ACCOUNT_STALE_TIME } from 'react-queries/queries/accountManagement'
+import { accountManagement } from 'react-queries/queries/accountManagement'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { queryClient } from 'context/QueryClientProvider/queryClient'
 import { deriveAccountIdsAndMetadata } from 'lib/account/account'
@@ -45,7 +45,7 @@ export const getAccountIdsWithActivityAndMetadata = async (
     Object.entries(accountIdsAndMetadata).map(async ([accountId, accountMetadata]) => {
       const account = await queryClient.fetchQuery({
         ...accountManagement.getAccount(accountId),
-        staleTime: GET_ACCOUNT_STALE_TIME,
+        staleTime: Infinity,
         // Never garbage collect me, I'm a special snowflake
         gcTime: Infinity,
       })

--- a/src/react-queries/queries/accountManagement.ts
+++ b/src/react-queries/queries/accountManagement.ts
@@ -3,8 +3,6 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { assertGetChainAdapter } from 'lib/utils'
 
-export const GET_ACCOUNT_STALE_TIME = 5 * 60 * 1000 // 5 minutes
-
 export const accountManagement = createQueryKeys('accountManagement', {
   getAccount: (accountId: AccountId) => ({
     queryKey: ['getAccount', accountId],

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -6,7 +6,7 @@ import type { AccountMetadataById } from '@shapeshiftoss/types'
 import cloneDeep from 'lodash/cloneDeep'
 import merge from 'lodash/merge'
 import uniq from 'lodash/uniq'
-import { accountManagement, GET_ACCOUNT_STALE_TIME } from 'react-queries/queries/accountManagement'
+import { accountManagement } from 'react-queries/queries/accountManagement'
 import { PURGE } from 'redux-persist'
 import { getChainAdapterManager } from 'context/PluginProvider/chainAdapterSingleton'
 import { queryClient } from 'context/QueryClientProvider/queryClient'
@@ -186,7 +186,7 @@ export const portfolioApi = createApi({
           const portfolioAccounts = {
             [pubkey]: await queryClient.fetchQuery({
               ...accountManagement.getAccount(accountId),
-              staleTime: GET_ACCOUNT_STALE_TIME,
+              staleTime: Infinity,
               // Never garbage collect me, I'm a special snowflake
               gcTime: Infinity,
             }),

--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -182,7 +182,13 @@ export const portfolioApi = createApi({
         try {
           const adapter = chainAdapters.get(chainId)
           if (!adapter) throw new Error(`no adapter for ${chainId} not available`)
-          // "Fetch" the query leveraging the existing cached data
+          // We want the query to be Infinity staleTime and gcTime for later use, but we also want it to always refetch
+          // This is consumed by TransactionProvider and failure to do so means portfolio will *not* be updated
+          await queryClient.invalidateQueries({
+            queryKey: accountManagement.getAccount(accountId).queryKey,
+            refetchType: 'all',
+            exact: true,
+          })
           const portfolioAccounts = {
             [pubkey]: await queryClient.fetchQuery({
               ...accountManagement.getAccount(accountId),


### PR DESCRIPTION
## Description

A blazingly fast follow on a [blazingly fast PR](https://github.com/shapeshift/web/pull/8862).
This improves things twofolds:

1. Removes the 5mn staleTime for the getAccount() query. Why have your cake, if you can have your cake *and* eat it? This means that regardless of how long the app was opened, the insta-display of already loaded accounts will work
2. While at it, fixes a bug that's guaranteed to be present in the previous PR, where Txs (either inbound or outbound) in `<TransactionsProvider />` will *not* trigger an account refetch, hence not trigger balances update. 
   In the previous version, this'd happen if you were to send within 5mn of opening the app (previous staleTime for the query), and in this PR, would now happen *anytime* because of the infinity.
   Same thing here, allows us to have our cake and eat it, by invalidating before we `fetchQuery()`. This means that we'll always fetch on `portfolio.endpoints.getAccount()` *but* will also cache said query infinitely for later use.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, actually a bugfix included

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Open the Import Accounts drawer for a given chain, preferrably a stable one (e.g Arbitrum One)
- Notice the balance for accounts there
- Do any Txs to/from any account of your choosing on and ensure balances are updated in the app
- Reopen the Import Accounts drawer and ensure balance is also updated there :tada:


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/0035e679-1023-41f5-9d2b-e080061f6ca3


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
