### PR TITLE
fix: improve release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -103,11 +103,17 @@ type GetCommitMessagesReturn = {
 }
 type GetCommitMessages = (branch: GetCommitMessagesArgs) => Promise<GetCommitMessagesReturn>
 const getCommits: GetCommitMessages = async branch => {
+  // Get the last release tag
+  const latestTag = await getLatestSemverTag()
+
+  // If we have a last release tag, base the diff on that
+  const range = latestTag ? `${latestTag}..origin/${branch}` : `origin/main..origin/${branch}`
+
   const { all, total } = await git().log([
     '--oneline',
     '--first-parent',
     '--pretty=format:%s', // no hash, just conventional commit style
-    `origin/main..origin/${branch}`,
+    range,
   ])
 
   const messages = all.map(({ hash }) => hash)

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -119,7 +119,6 @@ const assertCommitsToRelease = (total: number) => {
 }
 
 const doRegularRelease = async () => {
-  await fetch()
   const { messages, total } = await getCommits('develop')
   assertCommitsToRelease(total)
   await inquireProceedWithCommits(messages, 'create')
@@ -224,7 +223,6 @@ const createRelease = async () => {
 }
 
 const mergeRelease = async () => {
-  await fetch()
   const { messages, total } = await getCommits('release')
   assertCommitsToRelease(total)
   await inquireProceedWithCommits(messages, 'merge')

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -266,6 +266,7 @@ const main = async () => {
   await assertIsCleanRepo()
   await assertGhInstalled()
   await assertGhAuth()
+  await fetch()
   ;(await isReleaseInProgress()) ? await mergeRelease() : await createRelease()
 }
 


### PR DESCRIPTION
## Description

Makes 2 quality of life fixes to the release script:

1. Fetches _before_ we invoke `isReleaseInProgress`. If your local git state isn't up to date we can end up in a place where the script thinks it needs to create a new release, but one already exists
2. Creates the release diff using the range of commits _since the last release tag_. The fixes the issue of us creating a release containing commits/PRs that were hotfixed in the previous release (caused by different commit hashes in the cherry-picked hot-fix).

## Issue (if applicable)

N/A - QOL

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Release script only.

## Testing

### Engineering

Sanity check that the `yarn release` still does what we expect it to!

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

No testing needed here.

## Screenshots (if applicable)

N/A