### PR TITLE
fix: missing rewardId

### DIFF
--- a/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/LpPositionsByProvider.tsx
@@ -3,6 +3,7 @@ import { Button, Flex, Stack } from '@chakra-ui/react'
 import { Tag } from '@chakra-ui/tag'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
+import type { DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import qs from 'qs'
 import { useCallback, useMemo } from 'react'
@@ -76,6 +77,10 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
       } = opportunity
       const { assetReference, assetNamespace } = fromAssetId(assetId)
 
+      if (!contractAddress || !rewardAddress) {
+        return
+      }
+
       if (opportunity.isReadOnly) {
         const url = getMetadataForProvider(opportunity.provider)?.url
         url && window.open(url, '_blank')
@@ -96,19 +101,21 @@ export const LpPositionsByProvider: React.FC<LpPositionsByProviderProps> = ({ id
         assets,
       )
 
+      const queryParams: DefiQueryParams = {
+        type,
+        provider,
+        chainId,
+        contractAddress,
+        assetNamespace,
+        assetReference,
+        highestBalanceAccountAddress,
+        rewardId: rewardAddress,
+        modal: action ? action : 'overview',
+      }
+
       history.push({
         pathname: location.pathname,
-        search: qs.stringify({
-          type,
-          provider,
-          chainId,
-          contractAddress,
-          assetNamespace,
-          assetReference,
-          highestBalanceAccountAddress,
-          rewardId: rewardAddress,
-          modal: action ? action : 'overview',
-        }),
+        search: qs.stringify(queryParams),
         state: { background: location },
       })
     },

--- a/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
@@ -4,6 +4,7 @@ import { Tag } from '@chakra-ui/tag'
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
 import type { Asset, MarketData } from '@shapeshiftoss/types'
+import type { DefiQueryParams } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import { DefiAction } from 'features/defi/contexts/DefiManagerProvider/DefiCommon'
 import qs from 'qs'
 import { useCallback, useMemo } from 'react'
@@ -120,6 +121,10 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
         return
       }
 
+      if (!contractAddress || !rewardAddress) {
+        return
+      }
+
       trackOpportunityEvent(
         MixPanelEvent.ClickOpportunity,
         {
@@ -129,19 +134,21 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
         assets,
       )
 
+      const queryParams: DefiQueryParams = {
+        type,
+        provider,
+        chainId,
+        contractAddress,
+        assetNamespace,
+        assetReference,
+        highestBalanceAccountAddress,
+        rewardId: rewardAddress,
+        modal: action,
+      }
+
       history.push({
         pathname: location.pathname,
-        search: qs.stringify({
-          type,
-          provider,
-          chainId,
-          contractAddress,
-          assetNamespace,
-          assetReference,
-          highestBalanceAccountAddress,
-          rewardId: rewardAddress,
-          modal: action,
-        }),
+        search: qs.stringify(queryParams),
         state: { background: location },
       })
     },
@@ -298,7 +305,7 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
 
           return (
             <Flex justifyContent='flex-end' width='full'>
-              {translation && (
+              {translation && row.original.rewardAddress && (
                 <Button
                   variant='ghost'
                   size='sm'


### PR DESCRIPTION
## Description

Adds typing to the query params of the routes in position details, which exposes the actual issue: `rewardAddress` (and `contractAddress`) is not guaranteed to be defined.

Guard against that so we don't crash:

<img width="528" alt="Screenshot 2025-02-21 at 14 31 56" src="https://github.com/user-attachments/assets/64b95dcf-ab90-477f-adca-01169459f10c" />

Side note, we should be typing all of these stringified query params, but the DeFi section is already a mess of duplicate spaghetti and it's probably best to just burn it all.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8910

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Interaction with "Each" positions.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

This branch, no "Manage" button:

<img width="852" alt="Screenshot 2025-02-21 at 14 20 59" src="https://github.com/user-attachments/assets/9a26ee53-3e0c-4523-b206-c856bc0280a1" />

Production, manage button of death:

<img width="830" alt="Screenshot 2025-02-21 at 14 31 04" src="https://github.com/user-attachments/assets/f843a5ed-b08a-4464-998f-26a551f597d2" />