### PR TITLE
fix: modalType not set on native creation

### DIFF
--- a/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
+++ b/src/context/WalletProvider/NativeWallet/hooks/useNativeSuccess.ts
@@ -50,6 +50,10 @@ export const useNativeSuccess = ({ vault }: UseNativeSuccessPropTypes) => {
           type: WalletActions.SET_IS_CONNECTED,
           payload: true,
         })
+        dispatch({
+          type: WalletActions.SET_CONNECTOR_TYPE,
+          payload: { modalType: KeyManager.Native, isMipdProvider: false },
+        })
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
         localWallet.setLocalWallet({ type: KeyManager.Native, deviceId })
         localWallet.setLocalNativeWalletName(walletLabel)


### PR DESCRIPTION
## Description

Aligns `useNativeSuccess` with `useMobileSuccess`, which *does* set the modalType properly on creation:

https://github.com/shapeshift/web/blob/cadb5617f96f1ec7407b54b547d4c551929002aa/src/components/MobileWalletDialog/routes/CreateWallet/CreateSuccess.tsx#L71

This meant that the `modalType` right after creation would either be none (no previous wallet connected) or the one of the previously connected wallet, which could produce a bunch of small bugs,
including that one.
After rehydration however, and when the `modalType` was reconciliated, then things worked as they should and users were able to backup their wallet.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8879

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, this was a blatant bug.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Able to backup wallet after creation without refreshing the page.

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/1c2f07f1-c7ed-470f-9264-02e39bb7d24b


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
