### PR TITLE
feat: asset selection remember selected ChainId

### DIFF
--- a/src/components/Modals/TradeAssetSearch/TradeAssetSearchModal.tsx
+++ b/src/components/Modals/TradeAssetSearch/TradeAssetSearchModal.tsx
@@ -20,6 +20,8 @@ export type TradeAssetSearchModalProps = TradeAssetSearchProps & {
   onAssetClick: Required<TradeAssetSearchProps>['onAssetClick']
   assetFilterPredicate: (assetId: AssetId) => boolean
   chainIdFilterPredicate: (chainId: ChainId) => boolean
+  selectedChainId?: ChainId | 'All'
+  onSelectedChainIdChange?: (chainId: ChainId | 'All') => void
 }
 
 type AssetSearchModalBaseProps = TradeAssetSearchModalProps & {
@@ -27,6 +29,8 @@ type AssetSearchModalBaseProps = TradeAssetSearchModalProps & {
   close: () => void
   assetFilterPredicate: (assetId: AssetId) => boolean
   chainIdFilterPredicate: (chainId: ChainId) => boolean
+  selectedChainId?: ChainId | 'All'
+  onSelectedChainIdChange?: (chainId: ChainId | 'All') => void
 }
 
 export const TradeAssetSearchModalBase: FC<AssetSearchModalBaseProps> = ({
@@ -37,6 +41,8 @@ export const TradeAssetSearchModalBase: FC<AssetSearchModalBaseProps> = ({
   title = 'common.selectAsset',
   assetFilterPredicate,
   chainIdFilterPredicate,
+  selectedChainId,
+  onSelectedChainIdChange,
 }) => {
   const translate = useTranslate()
 
@@ -60,6 +66,8 @@ export const TradeAssetSearchModalBase: FC<AssetSearchModalBaseProps> = ({
         allowWalletUnsupportedAssets={allowWalletUnsupportedAssets}
         assetFilterPredicate={assetFilterPredicate}
         chainIdFilterPredicate={chainIdFilterPredicate}
+        selectedChainId={selectedChainId}
+        onSelectedChainIdChange={onSelectedChainIdChange}
       />
     </Dialog>
   )

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -32,6 +32,8 @@ export type LimitOrderBuyAssetProps = {
   onAccountIdChange: AccountDropdownProps['onChange']
   onSetBuyAsset: (asset: Asset) => void
   isLoading: boolean
+  selectedChainId?: ChainId | 'All'
+  onChainChange?: (chainId: ChainId | 'All') => void
 }
 
 export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
@@ -43,6 +45,8 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
     chainIdFilterPredicate,
     onAccountIdChange,
     onSetBuyAsset,
+    selectedChainId,
+    onChainChange,
   }) => {
     const translate = useTranslate()
     const buyAssetSearch = useModal('buyTradeAssetSearch')
@@ -58,8 +62,10 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         title: 'trade.tradeTo',
         assetFilterPredicate,
         chainIdFilterPredicate,
+        selectedChainId,
+        onSelectedChainIdChange: onChainChange,
       })
-    }, [assetFilterPredicate, buyAssetSearch, chainIdFilterPredicate, onSetBuyAsset])
+    }, [assetFilterPredicate, buyAssetSearch, chainIdFilterPredicate, onSetBuyAsset, selectedChainId, onChainChange])
 
     const tradeAssetSelect = useMemo(
       () => (

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -33,7 +33,7 @@ export type LimitOrderBuyAssetProps = {
   onSetBuyAsset: (asset: Asset) => void
   isLoading: boolean
   selectedChainId?: ChainId | 'All'
-  onChainChange?: (chainId: ChainId | 'All') => void
+  onSelectedChainIdChange?: (chainId: ChainId | 'All') => void
 }
 
 export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
@@ -46,7 +46,7 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
     onAccountIdChange,
     onSetBuyAsset,
     selectedChainId,
-    onChainChange,
+    onSelectedChainIdChange,
   }) => {
     const translate = useTranslate()
     const buyAssetSearch = useModal('buyTradeAssetSearch')
@@ -63,9 +63,16 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         assetFilterPredicate,
         chainIdFilterPredicate,
         selectedChainId,
-        onSelectedChainIdChange: onChainChange,
+        onSelectedChainIdChange,
       })
-    }, [assetFilterPredicate, buyAssetSearch, chainIdFilterPredicate, onSetBuyAsset, selectedChainId, onChainChange])
+    }, [
+      assetFilterPredicate,
+      buyAssetSearch,
+      chainIdFilterPredicate,
+      onSetBuyAsset,
+      selectedChainId,
+      onSelectedChainIdChange,
+    ])
 
     const tradeAssetSelect = useMemo(
       () => (

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -55,10 +55,10 @@ import {
   selectIsInputtingFiatSellAmount,
   selectLimitPrice,
   selectLimitPriceMode,
+  selectSelectedBuyAssetChainId,
+  selectSelectedSellAssetChainId,
   selectSellAccountId,
   selectSellAssetBalanceCryptoBaseUnit,
-  selectSelectedSellAssetChainId,
-  selectSelectedBuyAssetChainId,
 } from '@/state/slices/limitOrderInputSlice/selectors'
 import { calcLimitPriceBuyAsset } from '@/state/slices/limitOrderSlice/helpers'
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
@@ -416,7 +416,7 @@ export const LimitOrderInput = ({
         assetFilterPredicate={sellAssetFilterPredicate}
         chainIdFilterPredicate={chainIdFilterPredicate}
         selectedSellAssetChainId={selectedSellAssetChainId}
-        onSellAssetChainChange={setSelectedSellAssetChainId}
+        onSellAssetChainIdChange={setSelectedSellAssetChainId}
       >
         <Stack>
           <LimitOrderBuyAsset
@@ -429,7 +429,7 @@ export const LimitOrderInput = ({
             assetFilterPredicate={buyAssetFilterPredicate}
             chainIdFilterPredicate={chainIdFilterPredicate}
             selectedChainId={selectedBuyAssetChainId}
-            onChainChange={setSelectedBuyAssetChainId}
+            onSelectedChainIdChange={setSelectedBuyAssetChainId}
           />
           <Divider />
           <LimitOrderConfig

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -57,6 +57,8 @@ import {
   selectLimitPriceMode,
   selectSellAccountId,
   selectSellAssetBalanceCryptoBaseUnit,
+  selectSelectedSellAssetChainId,
+  selectSelectedBuyAssetChainId,
 } from '@/state/slices/limitOrderInputSlice/selectors'
 import { calcLimitPriceBuyAsset } from '@/state/slices/limitOrderSlice/helpers'
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
@@ -116,6 +118,8 @@ export const LimitOrderInput = ({
   const limitPriceMode = useAppSelector(selectLimitPriceMode)
   const sellAssetUsdRate = useAppSelector(state => selectUsdRateByAssetId(state, sellAsset.assetId))
   const buyAssetUsdRate = useAppSelector(state => selectUsdRateByAssetId(state, buyAsset.assetId))
+  const selectedSellAssetChainId = useAppSelector(selectSelectedSellAssetChainId)
+  const selectedBuyAssetChainId = useAppSelector(selectSelectedBuyAssetChainId)
 
   const {
     switchAssets,
@@ -126,6 +130,8 @@ export const LimitOrderInput = ({
     setLimitPrice,
     setIsInputtingFiatSellAmount,
     setSellAmountCryptoPrecision,
+    setSelectedSellAssetChainId,
+    setSelectedBuyAssetChainId,
   } = useActions(limitOrderInput.actions)
   const { setActiveQuote, setLimitOrderInitialized } = useActions(limitOrderSlice.actions)
   const { isFetching: isAccountsMetadataLoading } = useAccountsFetchQuery()
@@ -409,6 +415,8 @@ export const LimitOrderInput = ({
         setSellAccountId={setSellAccountId}
         assetFilterPredicate={sellAssetFilterPredicate}
         chainIdFilterPredicate={chainIdFilterPredicate}
+        selectedSellAssetChainId={selectedSellAssetChainId}
+        onSellAssetChainChange={setSelectedSellAssetChainId}
       >
         <Stack>
           <LimitOrderBuyAsset
@@ -420,6 +428,8 @@ export const LimitOrderInput = ({
             onSetBuyAsset={setBuyAsset}
             assetFilterPredicate={buyAssetFilterPredicate}
             chainIdFilterPredicate={chainIdFilterPredicate}
+            selectedChainId={selectedBuyAssetChainId}
+            onChainChange={setSelectedBuyAssetChainId}
           />
           <Divider />
           <LimitOrderConfig
@@ -451,6 +461,10 @@ export const LimitOrderInput = ({
     setBuyAsset,
     buyAssetFilterPredicate,
     marketPriceBuyAsset,
+    selectedBuyAssetChainId,
+    setSelectedBuyAssetChainId,
+    selectedSellAssetChainId,
+    setSelectedSellAssetChainId,
   ])
 
   const affiliateFeeAfterDiscountUserCurrency = useMemo(() => {

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputBody.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputBody.tsx
@@ -45,7 +45,7 @@ type SharedTradeInputBodyProps = {
   setSellAsset: (asset: Asset) => void
   setSellAccountId: (accountId: AccountId) => void
   selectedSellAssetChainId?: ChainId | 'All'
-  onSellAssetChainChange?: (chainId: ChainId | 'All') => void
+  onSellAssetChainIdChange?: (chainId: ChainId | 'All') => void
 }
 
 export const SharedTradeInputBody = ({
@@ -65,7 +65,7 @@ export const SharedTradeInputBody = ({
   setSellAsset,
   setSellAccountId,
   selectedSellAssetChainId,
-  onSellAssetChainChange,
+  onSellAssetChainIdChange,
 }: SharedTradeInputBodyProps) => {
   const translate = useTranslate()
 
@@ -121,7 +121,7 @@ export const SharedTradeInputBody = ({
       assetFilterPredicate,
       chainIdFilterPredicate,
       selectedChainId: selectedSellAssetChainId,
-      onSelectedChainIdChange: onSellAssetChainChange,
+      onSelectedChainIdChange: onSellAssetChainIdChange,
     })
   }, [
     assetFilterPredicate,
@@ -129,7 +129,7 @@ export const SharedTradeInputBody = ({
     sellAssetSearch,
     setSellAsset,
     selectedSellAssetChainId,
-    onSellAssetChainChange,
+    onSellAssetChainIdChange,
   ])
 
   const sellTradeAssetSelect = useMemo(

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputBody.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputBody.tsx
@@ -44,6 +44,8 @@ type SharedTradeInputBodyProps = {
   onChangeSellAmountCryptoPrecision: (sellAmountCryptoPrecision: string) => void
   setSellAsset: (asset: Asset) => void
   setSellAccountId: (accountId: AccountId) => void
+  selectedSellAssetChainId?: ChainId | 'All'
+  onSellAssetChainChange?: (chainId: ChainId | 'All') => void
 }
 
 export const SharedTradeInputBody = ({
@@ -62,6 +64,8 @@ export const SharedTradeInputBody = ({
   onChangeSellAmountCryptoPrecision,
   setSellAsset,
   setSellAccountId,
+  selectedSellAssetChainId,
+  onSellAssetChainChange,
 }: SharedTradeInputBodyProps) => {
   const translate = useTranslate()
 
@@ -116,8 +120,17 @@ export const SharedTradeInputBody = ({
       title: 'trade.tradeFrom',
       assetFilterPredicate,
       chainIdFilterPredicate,
+      selectedChainId: selectedSellAssetChainId,
+      onSelectedChainIdChange: onSellAssetChainChange,
     })
-  }, [assetFilterPredicate, chainIdFilterPredicate, sellAssetSearch, setSellAsset])
+  }, [
+    assetFilterPredicate,
+    chainIdFilterPredicate,
+    sellAssetSearch,
+    setSellAsset,
+    selectedSellAssetChainId,
+    onSellAssetChainChange,
+  ])
 
   const sellTradeAssetSelect = useMemo(
     () => (

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -52,6 +52,8 @@ import {
   selectInputSellAmountUserCurrency,
   selectInputSellAsset,
   selectIsInputtingFiatSellAmount,
+  selectSelectedSellAssetChainId,
+  selectSelectedBuyAssetChainId,
 } from '@/state/slices/tradeInputSlice/selectors'
 import { tradeInput } from '@/state/slices/tradeInputSlice/tradeInputSlice'
 import {
@@ -125,6 +127,8 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
   const isUnsafeQuote = useAppSelector(selectIsUnsafeActiveQuote)
   const sellAsset = useAppSelector(selectInputSellAsset)
   const buyAsset = useAppSelector(selectInputBuyAsset)
+  const selectedSellAssetChainId = useAppSelector(selectSelectedSellAssetChainId)
+  const selectedBuyAssetChainId = useAppSelector(selectSelectedBuyAssetChainId)
   const activeQuote = useAppSelector(selectActiveQuote)
   const isAnyAccountMetadataLoadedForChainIdFilter = useMemo(
     () => ({ chainId: sellAsset.chainId }),
@@ -371,14 +375,33 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     [isSolanaSwapperEnabled],
   )
 
+  const setSelectedBuyAssetChainId = useCallback(
+    (chainId: ChainId | 'All') => dispatch(tradeInput.actions.setSelectedBuyAssetChainId(chainId)),
+    [dispatch],
+  )
+
   const handleBuyAssetClick = useCallback(() => {
     buyAssetSearch.open({
       onAssetClick: setBuyAsset,
       title: 'trade.tradeTo',
       assetFilterPredicate,
       chainIdFilterPredicate,
+      selectedChainId: selectedBuyAssetChainId,
+      onSelectedChainIdChange: setSelectedBuyAssetChainId,
     })
-  }, [assetFilterPredicate, buyAssetSearch, chainIdFilterPredicate, setBuyAsset])
+  }, [
+    assetFilterPredicate,
+    buyAssetSearch,
+    chainIdFilterPredicate,
+    setBuyAsset,
+    selectedBuyAssetChainId,
+    setSelectedBuyAssetChainId,
+  ])
+
+  const setSelectedSellAssetChainId = useCallback(
+    (chainId: ChainId | 'All') => dispatch(tradeInput.actions.setSelectedSellAssetChainId(chainId)),
+    [dispatch],
+  )
 
   const buyTradeAssetSelect = useMemo(
     () => (
@@ -417,6 +440,8 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
         onChangeSellAmountCryptoPrecision={handleChangeSellAmountCryptoPrecision}
         assetFilterPredicate={assetFilterPredicate}
         chainIdFilterPredicate={chainIdFilterPredicate}
+        selectedSellAssetChainId={selectedSellAssetChainId}
+        onSellAssetChainChange={setSelectedSellAssetChainId}
       >
         <TradeAssetInput
           // Disable account selection when user set a manual receive address
@@ -467,6 +492,8 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
     setBuyAssetAccountId,
     setSellAsset,
     setSellAssetAccountId,
+    selectedSellAssetChainId,
+    setSelectedSellAssetChainId,
   ])
 
   const footerContent = useMemo(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -52,8 +52,8 @@ import {
   selectInputSellAmountUserCurrency,
   selectInputSellAsset,
   selectIsInputtingFiatSellAmount,
-  selectSelectedSellAssetChainId,
   selectSelectedBuyAssetChainId,
+  selectSelectedSellAssetChainId,
 } from '@/state/slices/tradeInputSlice/selectors'
 import { tradeInput } from '@/state/slices/tradeInputSlice/tradeInputSlice'
 import {
@@ -441,7 +441,7 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
         assetFilterPredicate={assetFilterPredicate}
         chainIdFilterPredicate={chainIdFilterPredicate}
         selectedSellAssetChainId={selectedSellAssetChainId}
-        onSellAssetChainChange={setSelectedSellAssetChainId}
+        onSellAssetChainIdChange={setSelectedSellAssetChainId}
       >
         <TradeAssetInput
           // Disable account selection when user set a manual receive address

--- a/src/components/TradeAssetSearch/TradeAssetSearch.tsx
+++ b/src/components/TradeAssetSearch/TradeAssetSearch.tsx
@@ -49,6 +49,8 @@ export type TradeAssetSearchProps = {
   allowWalletUnsupportedAssets?: boolean
   assetFilterPredicate?: (assetId: AssetId) => boolean
   chainIdFilterPredicate?: (chainId: ChainId) => boolean
+  selectedChainId?: ChainId | 'All'
+  onSelectedChainIdChange?: (chainId: ChainId | 'All') => void
 }
 export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
   onAssetClick,
@@ -56,12 +58,14 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
   allowWalletUnsupportedAssets,
   assetFilterPredicate,
   chainIdFilterPredicate,
+  selectedChainId = 'All',
+  onSelectedChainIdChange,
 }) => {
   const { walletInfo } = useWallet().state
   const hasWallet = useMemo(() => Boolean(walletInfo?.deviceId), [walletInfo?.deviceId])
   const translate = useTranslate()
   const history = useHistory()
-  const [activeChainId, setActiveChainId] = useState<ChainId | 'All'>('All')
+  const [activeChainId, setActiveChainId] = useState<ChainId | 'All'>(selectedChainId)
   const [assetToImport, setAssetToImport] = useState<Asset | undefined>(undefined)
   const [shouldShowWarningAcknowledgement, setShouldShowWarningAcknowledgement] = useState(false)
 
@@ -108,6 +112,14 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
   )
 
   const handleSubmit = useCallback((e: FormEvent<unknown>) => e.preventDefault(), [])
+
+  const handleSelectedChainIdChange = useCallback(
+    (chainId: ChainId | 'All') => {
+      setActiveChainId(chainId)
+      onSelectedChainIdChange?.(chainId)
+    },
+    [onSelectedChainIdChange],
+  )
 
   const popularAssets = useMemo(() => {
     const unfilteredPopularAssets = popularAssetsByChainId?.[activeChainId] ?? []
@@ -239,7 +251,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
             chainIds={chainIds}
             isActiveChainIdSupported={true}
             isDisabled={false}
-            onMenuOptionClick={setActiveChainId}
+            onMenuOptionClick={handleSelectedChainIdChange}
             buttonProps={buttonProps}
             disableTooltip
           />

--- a/src/state/slices/common/tradeInputBase/createTradeInputBaseSelectors.ts
+++ b/src/state/slices/common/tradeInputBase/createTradeInputBaseSelectors.ts
@@ -47,6 +47,16 @@ export const createTradeInputBaseSelectors = <T extends TradeInputBaseState>(
     tradeInput => tradeInput.sellAsset,
   )
 
+  const selectSelectedSellAssetChainId = createSelector(
+    selectBaseSlice,
+    tradeInput => tradeInput.selectedSellAssetChainId,
+  )
+
+  const selectSelectedBuyAssetChainId = createSelector(
+    selectBaseSlice,
+    tradeInput => tradeInput.selectedBuyAssetChainId,
+  )
+
   const selectInputSellAssetUsdRate = createSelector(
     selectInputSellAsset,
     selectMarketDataUsd,
@@ -235,5 +245,7 @@ export const createTradeInputBaseSelectors = <T extends TradeInputBaseState>(
     selectIsInputtingFiatSellAmount,
     selectHasUserEnteredAmount,
     selectInputSellAmountCryptoPrecision,
+    selectSelectedSellAssetChainId,
+    selectSelectedBuyAssetChainId,
   }
 }

--- a/src/state/slices/common/tradeInputBase/createTradeInputBaseSlice.ts
+++ b/src/state/slices/common/tradeInputBase/createTradeInputBaseSlice.ts
@@ -1,6 +1,6 @@
 import type { Draft, PayloadAction } from '@reduxjs/toolkit'
 import { createSlice } from '@reduxjs/toolkit'
-import type { AccountId } from '@shapeshiftoss/caip'
+import type { AccountId, ChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 
 import { bnOrZero } from '@/lib/bignumber/bignumber'
@@ -16,6 +16,8 @@ export interface TradeInputBaseState {
   isManualReceiveAddressValidating: boolean
   isManualReceiveAddressEditing: boolean
   isManualReceiveAddressValid: boolean | undefined
+  selectedSellAssetChainId: ChainId | 'All'
+  selectedBuyAssetChainId: ChainId | 'All'
 }
 
 const getBaseReducers = <T extends TradeInputBaseState>(initialState: T) => ({
@@ -85,6 +87,11 @@ const getBaseReducers = <T extends TradeInputBaseState>(initialState: T) => ({
     state.sellAccountId = state.buyAccountId
     state.buyAccountId = sellAssetAccountId
 
+    // Also switch the selected chain IDs
+    const selectedSellAssetChainId = state.selectedSellAssetChainId
+    state.selectedSellAssetChainId = state.selectedBuyAssetChainId
+    state.selectedBuyAssetChainId = selectedSellAssetChainId
+
     state.manualReceiveAddress = undefined
   },
   setManualReceiveAddress: (state: Draft<T>, action: PayloadAction<string | undefined>) => {
@@ -101,6 +108,12 @@ const getBaseReducers = <T extends TradeInputBaseState>(initialState: T) => ({
   },
   setIsInputtingFiatSellAmount: (state: Draft<T>, action: PayloadAction<boolean>) => {
     state.isInputtingFiatSellAmount = action.payload
+  },
+  setSelectedSellAssetChainId: (state: Draft<T>, action: PayloadAction<ChainId | 'All'>) => {
+    state.selectedSellAssetChainId = action.payload
+  },
+  setSelectedBuyAssetChainId: (state: Draft<T>, action: PayloadAction<ChainId | 'All'>) => {
+    state.selectedBuyAssetChainId = action.payload
   },
 })
 

--- a/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
+++ b/src/state/slices/limitOrderInputSlice/limitOrderInputSlice.ts
@@ -33,6 +33,8 @@ const initialState: LimitOrderInputState = {
   isManualReceiveAddressValidating: false,
   isManualReceiveAddressValid: undefined,
   isManualReceiveAddressEditing: false,
+  selectedSellAssetChainId: 'All',
+  selectedBuyAssetChainId: 'All',
   limitPriceDirection: PriceDirection.BuyAssetDenomination,
   limitPrice: {
     [PriceDirection.BuyAssetDenomination]: '0',

--- a/src/state/slices/limitOrderInputSlice/selectors.ts
+++ b/src/state/slices/limitOrderInputSlice/selectors.ts
@@ -23,6 +23,8 @@ export const {
   selectIsInputtingFiatSellAmount,
   selectHasUserEnteredAmount,
   selectInputSellAmountCryptoPrecision,
+  selectSelectedSellAssetChainId,
+  selectSelectedBuyAssetChainId,
   ...privateSelectors
 } = createTradeInputBaseSelectors<LimitOrderInputState>('limitOrderInput')
 

--- a/src/state/slices/tradeInputSlice/selectors.ts
+++ b/src/state/slices/tradeInputSlice/selectors.ts
@@ -33,6 +33,8 @@ export const {
   selectIsInputtingFiatSellAmount,
   selectHasUserEnteredAmount,
   selectInputSellAmountCryptoPrecision,
+  selectSelectedSellAssetChainId,
+  selectSelectedBuyAssetChainId,
   // We don't want to export some of the selectors so we can give them more specific names
   ...privateSelectors
 } = createTradeInputBaseSelectors<TradeInputState>('tradeInput')

--- a/src/state/slices/tradeInputSlice/tradeInputSlice.ts
+++ b/src/state/slices/tradeInputSlice/tradeInputSlice.ts
@@ -26,6 +26,8 @@ const initialState: TradeInputState = {
   isManualReceiveAddressValid: undefined,
   isManualReceiveAddressEditing: false,
   slippagePreferencePercentage: undefined,
+  selectedSellAssetChainId: 'All',
+  selectedBuyAssetChainId: 'All',
 }
 
 export const tradeInput = createTradeInputBaseSlice({

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -246,6 +246,8 @@ export const mockStore: ReduxState = {
     isManualReceiveAddressEditing: false,
     isManualReceiveAddressValid: undefined,
     slippagePreferencePercentage: undefined,
+    selectedBuyAssetChainId: 'All',
+    selectedSellAssetChainId: 'All',
   },
   limitOrderInput: {
     buyAsset: defaultAsset,
@@ -265,6 +267,8 @@ export const mockStore: ReduxState = {
     limitPriceMode: LimitPriceMode.Market,
     expiry: ExpiryOption.SevenDays,
     limitPriceDirection: PriceDirection.BuyAssetDenomination,
+    selectedBuyAssetChainId: 'All',
+    selectedSellAssetChainId: 'All',
   },
   tradeQuoteSlice: {
     activeQuoteMeta: undefined,


### PR DESCRIPTION
## Description

Precisely what it says on the box. Remembers the selected ChainId on a granular level:

- All instances (e.g limit and spot) have their own ChainId memory 
- Buy and sell AssetIds have independant ChainId memory

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8834

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Play around with asset chain selection in spot and limit and ensure the selected chain is consistently remembered on selection

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

### Limit 

https://jam.dev/c/28d0ba53-7b82-4392-90c2-c5cb79c0560e

### Spot 

https://jam.dev/c/c5e7d075-c756-42f6-9091-f082586c18b2


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
