### PR TITLE
feat: no rate refresh spinner on unsupported swappers

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -347,13 +347,25 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
     }, [isLoading, quote, swapperName, toPercent, translate, userSlippagePercentageDecimal])
 
     const headerContent = useMemo(() => {
+      const hasUnsupportedChainError = errors.some(
+        error =>
+          error.error === SwapperTradeQuoteError.UnsupportedChain ||
+          error.error === SwapperTradeQuoteError.CrossChainNotSupported ||
+          error.error === SwapperTradeQuoteError.UnsupportedTradePair,
+      )
+
       return (
         <Flex gap={2} alignItems='center'>
           <Skeleton isLoaded={!isLoading}>{tag}</Skeleton>
-          <CountdownSpinner isLoading={isLoading || isRefetching} initialTimeMs={pollingInterval} />
+          {!hasUnsupportedChainError && (
+            <CountdownSpinner
+              isLoading={isLoading || isRefetching}
+              initialTimeMs={pollingInterval}
+            />
+          )}
         </Flex>
       )
-    }, [isLoading, isRefetching, pollingInterval, tag])
+    }, [isLoading, isRefetching, pollingInterval, tag, errors])
 
     const bodyContent = useMemo(() => {
       return quote ? (


### PR DESCRIPTION
## Description

Does what it says on the box, an unsupported swapper for a pair will never be, meaning it shouldn't be displaying refresh state.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8833

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Get into unsupported pair errored swappers (e.g ETH -> BTC or FOX -> BTC)
- Ensure there is no refresh countdown spinner 
- Get into a valid pair for the same swappers that were previously errored (e.g ETH -> FOX)
- Ensure those *do* display the spinner now

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/2f53eaef-4c9b-4f24-af8c-0a3ff12cd340


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":"develop"}
```
-->
