### PR TITLE
fix: allow claim routing from both inside and outside of swapper

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -17,6 +17,7 @@ import { HashRouter } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
 import { WagmiProvider } from 'wagmi'
 
+import { MultiHopTradeProvider } from './components/MultiHopTrade/context/MultiHopTradeContext'
 import { ScrollToTop } from './Routes/ScrollToTop'
 
 import { ChatwootWidget } from '@/components/ChatWoot'
@@ -95,7 +96,9 @@ export function AppProviders({ children }: ProvidersProps) {
                                         <FoxEthProvider>
                                           <DefiManagerProvider>
                                             <RFOXProvider>
-                                              <FoxPageProvider>{children}</FoxPageProvider>
+                                              <MultiHopTradeProvider>
+                                                <FoxPageProvider>{children}</FoxPageProvider>
+                                              </MultiHopTradeProvider>
                                             </RFOXProvider>
                                           </DefiManagerProvider>
                                         </FoxEthProvider>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,6 +1,6 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { MemoryRouter, Route, Switch, useHistory, useLocation, useParams } from 'react-router-dom'
 
@@ -15,8 +15,8 @@ import { MultiHopTradeProvider } from './context/MultiHopTradeContext'
 import { useGetTradeRates } from './hooks/useGetTradeQuotes/useGetTradeRates'
 import { TradeRoutePaths } from './types'
 
-import { fromBaseUnit } from '@/lib/math'
 import { registerClaimTabClickHandler } from '@/hooks/useBridgeClaimNotification/useBridgeClaimNotification'
+import { fromBaseUnit } from '@/lib/math'
 import { selectAssetById } from '@/state/slices/assetsSlice/selectors'
 import {
   selectInputBuyAsset,
@@ -173,12 +173,11 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
     )
   }, [location.pathname])
 
-  // Register the claim tab click handler
   useEffect(() => {
     const handleClaimTabClick = () => {
       history.push(TradeRoutePaths.Claim)
     }
-    
+
     registerClaimTabClickHandler(handleClaimTabClick)
   }, [history])
 
@@ -228,7 +227,10 @@ const TradeRoutesContent = memo(
             <Route key={`${TradeRoutePaths.Claim}/select`} path={`${TradeRoutePaths.Claim}/select`}>
               <Claim />
             </Route>
-            <Route key={`${TradeRoutePaths.Claim}/confirm`} path={`${TradeRoutePaths.Claim}/confirm`}>
+            <Route
+              key={`${TradeRoutePaths.Claim}/confirm`}
+              path={`${TradeRoutePaths.Claim}/confirm`}
+            >
               <Claim />
             </Route>
             <Route key={`${TradeRoutePaths.Claim}/status`} path={`${TradeRoutePaths.Claim}/status`}>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -239,20 +239,33 @@ const TradeRoutesContent = memo(
             <Route key={TradeRoutePaths.LimitOrder} path={TradeRoutePaths.LimitOrder}>
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>
-            <Route key={`${TradeRoutePaths.LimitOrder}/input`} path={`${TradeRoutePaths.LimitOrder}/input`}>
+            <Route
+              key={`${TradeRoutePaths.LimitOrder}/input`}
+              path={`${TradeRoutePaths.LimitOrder}/input`}
+            >
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>
-            <Route key={`${TradeRoutePaths.LimitOrder}/confirm`} path={`${TradeRoutePaths.LimitOrder}/confirm`}>
+            <Route
+              key={`${TradeRoutePaths.LimitOrder}/confirm`}
+              path={`${TradeRoutePaths.LimitOrder}/confirm`}
+            >
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>
-            <Route key={`${TradeRoutePaths.LimitOrder}/allowance-approval`} path={`${TradeRoutePaths.LimitOrder}/allowance-approval`}>
+            <Route
+              key={`${TradeRoutePaths.LimitOrder}/allowance-approval`}
+              path={`${TradeRoutePaths.LimitOrder}/allowance-approval`}
+            >
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>
-            <Route key={`${TradeRoutePaths.LimitOrder}/place-order`} path={`${TradeRoutePaths.LimitOrder}/place-order`}>
+            <Route
+              key={`${TradeRoutePaths.LimitOrder}/place-order`}
+              path={`${TradeRoutePaths.LimitOrder}/place-order`}
+            >
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>
-            <Route key={`${TradeRoutePaths.LimitOrder}/orders`} path={`${TradeRoutePaths.LimitOrder}/orders`}
-            
+            <Route
+              key={`${TradeRoutePaths.LimitOrder}/orders`}
+              path={`${TradeRoutePaths.LimitOrder}/orders`}
             >
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -1,5 +1,4 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { assertUnreachable } from '@shapeshiftoss/utils'
 import { AnimatePresence } from 'framer-motion'
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
@@ -12,10 +11,12 @@ import { TradeConfirm } from './components/TradeConfirm/TradeConfirm'
 import { Claim } from './components/TradeInput/components/Claim/Claim'
 import { TradeInput } from './components/TradeInput/TradeInput'
 import { VerifyAddresses } from './components/VerifyAddresses/VerifyAddresses'
+import { MultiHopTradeProvider } from './context/MultiHopTradeContext'
 import { useGetTradeRates } from './hooks/useGetTradeQuotes/useGetTradeRates'
-import { TradeInputTab, TradeRoutePaths } from './types'
+import { TradeRoutePaths } from './types'
 
 import { fromBaseUnit } from '@/lib/math'
+import { registerClaimTabClickHandler } from '@/hooks/useBridgeClaimNotification/useBridgeClaimNotification'
 import { selectAssetById } from '@/state/slices/assetsSlice/selectors'
 import {
   selectInputBuyAsset,
@@ -147,7 +148,9 @@ export const MultiHopTrade = memo(
     return (
       <FormProvider {...methods}>
         <MemoryRouter initialEntries={TradeRouteEntries} initialIndex={initialIndex}>
-          <TradeRoutes isCompact={isCompact} />
+          <MultiHopTradeProvider>
+            <TradeRoutes isCompact={isCompact} />
+          </MultiHopTradeProvider>
         </MemoryRouter>
       </FormProvider>
     )
@@ -159,9 +162,8 @@ type TradeRoutesProps = {
 }
 
 const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
-  const history = useHistory()
   const location = useLocation()
-
+  const history = useHistory()
   const tradeInputRef = useRef<HTMLDivElement | null>(null)
 
   const shouldUseTradeRates = useMemo(() => {
@@ -171,66 +173,77 @@ const TradeRoutes = memo(({ isCompact }: TradeRoutesProps) => {
     )
   }, [location.pathname])
 
-  const handleChangeTab = useCallback(
-    (newTab: TradeInputTab) => {
-      switch (newTab) {
-        case TradeInputTab.Trade:
-          history.push(TradeRoutePaths.Input)
-          break
-        case TradeInputTab.LimitOrder:
-          history.push(TradeRoutePaths.LimitOrder)
-          break
-        case TradeInputTab.Claim:
-          history.push(TradeRoutePaths.Claim)
-          break
-        default:
-          assertUnreachable(newTab)
-      }
-    },
-    [history],
-  )
+  // Register the claim tab click handler
+  useEffect(() => {
+    const handleClaimTabClick = () => {
+      history.push(TradeRoutePaths.Claim)
+    }
+    
+    registerClaimTabClickHandler(handleClaimTabClick)
+  }, [history])
 
   return (
-    <>
-      <AnimatePresence mode='wait' initial={false}>
-        <Switch location={location}>
-          <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
-            <TradeInput
-              isCompact={isCompact}
-              tradeInputRef={tradeInputRef}
-              onChangeTab={handleChangeTab}
-            />
-          </Route>
-          <Route key={TradeRoutePaths.Confirm} path={TradeRoutePaths.Confirm}>
-            <TradeConfirm />
-          </Route>
-          <Route key={TradeRoutePaths.VerifyAddresses} path={TradeRoutePaths.VerifyAddresses}>
-            <VerifyAddresses />
-          </Route>
-          <Route key={TradeRoutePaths.QuoteList} path={TradeRoutePaths.QuoteList}>
-            <SlideTransitionRoute
-              height={tradeInputRef.current?.offsetHeight ?? '500px'}
-              width={tradeInputRef.current?.offsetWidth ?? 'full'}
-              component={QuoteList}
-              parentRoute={TradeRoutePaths.Input}
-            />
-          </Route>
-          <Route key={TradeRoutePaths.Claim} path={TradeRoutePaths.Claim}>
-            <Claim onChangeTab={handleChangeTab} />
-          </Route>
-          <Route key={TradeRoutePaths.LimitOrder} path={TradeRoutePaths.LimitOrder}>
-            <LimitOrder
-              isCompact={isCompact}
-              tradeInputRef={tradeInputRef}
-              onChangeTab={handleChangeTab}
-            />
-          </Route>
-        </Switch>
-      </AnimatePresence>
-      {/* Stop polling for quotes by unmounting the hook. This prevents trade execution getting */}
-      {/* corrupted from state being mutated during trade execution. */}
-      {/* TODO: move the hook into a react-query or similar and pass a flag  */}
-      {shouldUseTradeRates ? <GetTradeRates /> : null}
-    </>
+    <TradeRoutesContent
+      isCompact={isCompact}
+      tradeInputRef={tradeInputRef}
+      shouldUseTradeRates={shouldUseTradeRates}
+    />
   )
 })
+
+type TradeRoutesContentProps = {
+  isCompact?: boolean
+  tradeInputRef: React.RefObject<HTMLDivElement>
+  shouldUseTradeRates: boolean
+}
+
+const TradeRoutesContent = memo(
+  ({ isCompact, tradeInputRef, shouldUseTradeRates }: TradeRoutesContentProps) => {
+    const location = useLocation()
+
+    return (
+      <>
+        <AnimatePresence mode='wait' initial={false}>
+          <Switch location={location}>
+            <Route key={TradeRoutePaths.Input} path={TradeRoutePaths.Input}>
+              <TradeInput isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
+            <Route key={TradeRoutePaths.Confirm} path={TradeRoutePaths.Confirm}>
+              <TradeConfirm />
+            </Route>
+            <Route key={TradeRoutePaths.VerifyAddresses} path={TradeRoutePaths.VerifyAddresses}>
+              <VerifyAddresses />
+            </Route>
+            <Route key={TradeRoutePaths.QuoteList} path={TradeRoutePaths.QuoteList}>
+              <SlideTransitionRoute
+                height={tradeInputRef.current?.offsetHeight ?? '500px'}
+                width={tradeInputRef.current?.offsetWidth ?? 'full'}
+                component={QuoteList}
+                parentRoute={TradeRoutePaths.Input}
+              />
+            </Route>
+            <Route key={TradeRoutePaths.Claim} path={TradeRoutePaths.Claim}>
+              <Claim />
+            </Route>
+            <Route key={`${TradeRoutePaths.Claim}/select`} path={`${TradeRoutePaths.Claim}/select`}>
+              <Claim />
+            </Route>
+            <Route key={`${TradeRoutePaths.Claim}/confirm`} path={`${TradeRoutePaths.Claim}/confirm`}>
+              <Claim />
+            </Route>
+            <Route key={`${TradeRoutePaths.Claim}/status`} path={`${TradeRoutePaths.Claim}/status`}>
+              <Claim />
+            </Route>
+            <Route key={TradeRoutePaths.LimitOrder} path={TradeRoutePaths.LimitOrder}>
+              <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
+          </Switch>
+        </AnimatePresence>
+        {/* Stop polling for quotes by unmounting the hook. This prevents trade execution getting */}
+        {/* corrupted from state being mutated during trade execution. */}
+        {/* TODO: move the hook into a react-query or similar and pass a flag  */}
+        {shouldUseTradeRates ? <GetTradeRates /> : null}
+      </>
+    )
+  },
+)

--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -239,6 +239,23 @@ const TradeRoutesContent = memo(
             <Route key={TradeRoutePaths.LimitOrder} path={TradeRoutePaths.LimitOrder}>
               <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
             </Route>
+            <Route key={`${TradeRoutePaths.LimitOrder}/input`} path={`${TradeRoutePaths.LimitOrder}/input`}>
+              <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
+            <Route key={`${TradeRoutePaths.LimitOrder}/confirm`} path={`${TradeRoutePaths.LimitOrder}/confirm`}>
+              <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
+            <Route key={`${TradeRoutePaths.LimitOrder}/allowance-approval`} path={`${TradeRoutePaths.LimitOrder}/allowance-approval`}>
+              <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
+            <Route key={`${TradeRoutePaths.LimitOrder}/place-order`} path={`${TradeRoutePaths.LimitOrder}/place-order`}>
+              <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
+            <Route key={`${TradeRoutePaths.LimitOrder}/orders`} path={`${TradeRoutePaths.LimitOrder}/orders`}
+            
+            >
+              <LimitOrder isCompact={isCompact} tradeInputRef={tradeInputRef} />
+            </Route>
           </Switch>
         </AnimatePresence>
         {/* Stop polling for quotes by unmounting the hook. This prevents trade execution getting */}

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -2,7 +2,6 @@ import { Flex } from '@chakra-ui/react'
 import { useCallback, useEffect, useRef } from 'react'
 import { MemoryRouter, Route, Switch, useHistory, useLocation } from 'react-router-dom'
 
-import { useMultiHopTradeContext } from '../../context/MultiHopTradeContext'
 import { LimitOrderConfirm as LimitOrderShared } from '../LimitOrderV2/LimitOrderConfirm'
 import { SlideTransitionRoute } from '../SlideTransitionRoute'
 import { AllowanceApproval } from './components/AllowanceApproval'
@@ -31,23 +30,9 @@ export const LimitOrder = ({ isCompact, tradeInputRef }: LimitOrderProps) => {
   const location = useLocation()
   const isNewLimitFlowEnabled = useFeatureFlag('NewLimitFlow')
   const memoryRouterHistoryRef = useRef<any>(null)
-  const { activeTab } = useMultiHopTradeContext()
-
-  // Navigate the MemoryRouter to the Input route when the active tab changes to LimitOrder
-  useEffect(() => {
-    if (memoryRouterHistoryRef.current && activeTab === 'limitOrder') {
-      // Navigate to the Input route in the MemoryRouter
-      memoryRouterHistoryRef.current.push(LimitOrderRoutePaths.Input)
-    }
-  }, [activeTab])
 
   const renderLimitOrderInput = useCallback(() => {
-    return (
-      <LimitOrderInput
-        isCompact={isCompact}
-        tradeInputRef={tradeInputRef}
-      />
-    )
+    return <LimitOrderInput isCompact={isCompact} tradeInputRef={tradeInputRef} />
   }, [isCompact, tradeInputRef])
 
   const renderLimitOrderConfirm = useCallback(() => {
@@ -69,12 +54,12 @@ export const LimitOrder = ({ isCompact, tradeInputRef }: LimitOrderProps) => {
   // This component will be rendered inside the MemoryRouter
   const LimitOrderContent = () => {
     const history = useHistory()
-    
+
     // Store the history object in the ref so we can access it from outside
     useEffect(() => {
       memoryRouterHistoryRef.current = history
     }, [history])
-    
+
     return (
       <Switch location={location}>
         <Flex flex={1} width='full' justifyContent='center'>

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrderInput.tsx
@@ -1,0 +1,4 @@
+import { LimitOrderInput as ActualLimitOrderInput } from './components/LimitOrderInput'
+
+// Re-export the component
+export const LimitOrderInput = ActualLimitOrderInput 

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrderInput.tsx
@@ -1,4 +1,0 @@
-import { LimitOrderInput as ActualLimitOrderInput } from './components/LimitOrderInput'
-
-// Re-export the component
-export const LimitOrderInput = ActualLimitOrderInput 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -80,10 +80,7 @@ type LimitOrderInputProps = {
   isCompact?: boolean
 }
 
-export const LimitOrderInput = ({
-  isCompact,
-  tradeInputRef,
-}: LimitOrderInputProps) => {
+export const LimitOrderInput = ({ isCompact, tradeInputRef }: LimitOrderInputProps) => {
   const {
     dispatch: walletDispatch,
     state: { isConnected },

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -78,13 +78,11 @@ import { breakpoints } from '@/theme/theme'
 type LimitOrderInputProps = {
   tradeInputRef: React.MutableRefObject<HTMLDivElement | null>
   isCompact?: boolean
-  onChangeTab: (newTab: TradeInputTab) => void
 }
 
 export const LimitOrderInput = ({
   isCompact,
   tradeInputRef,
-  onChangeTab,
 }: LimitOrderInputProps) => {
   const {
     dispatch: walletDispatch,
@@ -588,7 +586,6 @@ export const LimitOrderInput = ({
         tradeInputRef={tradeInputRef}
         tradeInputTab={TradeInputTab.LimitOrder}
         onSubmit={handleTradeQuoteConfirm}
-        onChangeTab={onChangeTab}
       />
     </>
   )

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -60,9 +60,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
             as='form'
             onSubmit={onSubmit}
           >
-            <SharedTradeInputHeader
-              rightContent={headerRightContent}
-            />
+            <SharedTradeInputHeader rightContent={headerRightContent} />
             {bodyContent}
             {footerContent}
           </Card>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -26,7 +26,6 @@ type SharedTradeInputProps = {
   shouldOpenSideComponent: boolean
   tradeInputRef: React.RefObject<HTMLDivElement>
   tradeInputTab: TradeInputTab
-  onChangeTab: (newTab: TradeInputTab) => void
   onSubmit: (e: FormEvent<unknown>) => void
 }
 
@@ -37,10 +36,8 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   isLoading,
   SideComponent,
   shouldOpenSideComponent,
-  tradeInputTab,
   tradeInputRef,
   footerContent,
-  onChangeTab,
   onSubmit,
 }) => {
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
@@ -64,9 +61,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
             onSubmit={onSubmit}
           >
             <SharedTradeInputHeader
-              initialTab={tradeInputTab}
               rightContent={headerRightContent}
-              onChangeTab={onChangeTab}
             />
             {bodyContent}
             {footerContent}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
@@ -13,9 +13,7 @@ type SharedTradeInputHeaderProps = {
   rightContent?: JSX.Element
 }
 
-export const SharedTradeInputHeader = ({
-  rightContent,
-}: SharedTradeInputHeaderProps) => {
+export const SharedTradeInputHeader = ({ rightContent }: SharedTradeInputHeaderProps) => {
   const translate = useTranslate()
   const { activeTab, handleChangeTab } = useMultiHopTradeContext()
 
@@ -45,7 +43,6 @@ export const SharedTradeInputHeader = ({
             color={activeTab !== TradeInputTab.Trade ? 'text.subtle' : undefined}
             onClick={handleClickTrade}
             cursor={activeTab !== TradeInputTab.Trade ? 'pointer' : undefined}
-            data-testid="trade-tab"
           >
             {translate('navBar.trade')}
           </Heading>
@@ -56,7 +53,6 @@ export const SharedTradeInputHeader = ({
               color={activeTab !== TradeInputTab.LimitOrder ? 'text.subtle' : undefined}
               onClick={handleClickLimitOrder}
               cursor={activeTab !== TradeInputTab.LimitOrder ? 'pointer' : undefined}
-              data-testid="limitOrder-tab"
             >
               {translate('limitOrder.heading')}
             </Heading>
@@ -68,7 +64,6 @@ export const SharedTradeInputHeader = ({
               color={activeTab !== TradeInputTab.Claim ? 'text.subtle' : undefined}
               onClick={handleClickClaim}
               cursor={activeTab !== TradeInputTab.Claim ? 'pointer' : undefined}
-              data-testid="claim-tab"
             >
               {translate('bridge.claim')}
             </Heading>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
@@ -1,7 +1,8 @@
 import { CardHeader, Flex, Heading } from '@chakra-ui/react'
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import { useTranslate } from 'react-polyglot'
 
+import { useMultiHopTradeContext } from '../../context/MultiHopTradeContext'
 import { TradeInputTab } from '../../types'
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
@@ -9,30 +10,18 @@ import { selectWalletId } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
 type SharedTradeInputHeaderProps = {
-  initialTab: TradeInputTab
   rightContent?: JSX.Element
-  onChangeTab: (newTab: TradeInputTab) => void
 }
 
 export const SharedTradeInputHeader = ({
-  initialTab,
   rightContent,
-  onChangeTab,
 }: SharedTradeInputHeaderProps) => {
   const translate = useTranslate()
-  const [selectedTab, setSelectedTab] = useState<TradeInputTab>(initialTab)
+  const { activeTab, handleChangeTab } = useMultiHopTradeContext()
 
   const enableBridgeClaims = useFeatureFlag('ArbitrumBridgeClaims')
   const enableLimitOrders = useFeatureFlag('LimitOrders')
   const walletId = useAppSelector(selectWalletId)
-
-  const handleChangeTab = useCallback(
-    (newTab: TradeInputTab) => {
-      setSelectedTab(newTab)
-      onChangeTab(newTab)
-    },
-    [onChangeTab],
-  )
 
   const handleClickTrade = useCallback(() => {
     handleChangeTab(TradeInputTab.Trade)
@@ -53,9 +42,10 @@ export const SharedTradeInputHeader = ({
           <Heading
             as='h5'
             fontSize='md'
-            color={selectedTab !== TradeInputTab.Trade ? 'text.subtle' : undefined}
+            color={activeTab !== TradeInputTab.Trade ? 'text.subtle' : undefined}
             onClick={handleClickTrade}
-            cursor={selectedTab !== TradeInputTab.Trade ? 'pointer' : undefined}
+            cursor={activeTab !== TradeInputTab.Trade ? 'pointer' : undefined}
+            data-testid="trade-tab"
           >
             {translate('navBar.trade')}
           </Heading>
@@ -63,9 +53,10 @@ export const SharedTradeInputHeader = ({
             <Heading
               as='h5'
               fontSize='md'
-              color={selectedTab !== TradeInputTab.LimitOrder ? 'text.subtle' : undefined}
+              color={activeTab !== TradeInputTab.LimitOrder ? 'text.subtle' : undefined}
               onClick={handleClickLimitOrder}
-              cursor={selectedTab !== TradeInputTab.LimitOrder ? 'pointer' : undefined}
+              cursor={activeTab !== TradeInputTab.LimitOrder ? 'pointer' : undefined}
+              data-testid="limitOrder-tab"
             >
               {translate('limitOrder.heading')}
             </Heading>
@@ -74,9 +65,10 @@ export const SharedTradeInputHeader = ({
             <Heading
               as='h5'
               fontSize='md'
-              color={selectedTab !== TradeInputTab.Claim ? 'text.subtle' : undefined}
+              color={activeTab !== TradeInputTab.Claim ? 'text.subtle' : undefined}
               onClick={handleClickClaim}
-              cursor={selectedTab !== TradeInputTab.Claim ? 'pointer' : undefined}
+              cursor={activeTab !== TradeInputTab.Claim ? 'pointer' : undefined}
+              data-testid="claim-tab"
             >
               {translate('bridge.claim')}
             </Heading>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
@@ -15,7 +15,7 @@ type SharedTradeInputHeaderProps = {
 
 export const SharedTradeInputHeader = ({ rightContent }: SharedTradeInputHeaderProps) => {
   const translate = useTranslate()
-  const { activeTab, handleChangeTab } = useMultiHopTradeContext()
+  const { selectedTab, handleChangeTab } = useMultiHopTradeContext()
 
   const enableBridgeClaims = useFeatureFlag('ArbitrumBridgeClaims')
   const enableLimitOrders = useFeatureFlag('LimitOrders')
@@ -40,9 +40,9 @@ export const SharedTradeInputHeader = ({ rightContent }: SharedTradeInputHeaderP
           <Heading
             as='h5'
             fontSize='md'
-            color={activeTab !== TradeInputTab.Trade ? 'text.subtle' : undefined}
+            color={selectedTab !== TradeInputTab.Trade ? 'text.subtle' : undefined}
             onClick={handleClickTrade}
-            cursor={activeTab !== TradeInputTab.Trade ? 'pointer' : undefined}
+            cursor={selectedTab !== TradeInputTab.Trade ? 'pointer' : undefined}
           >
             {translate('navBar.trade')}
           </Heading>
@@ -50,9 +50,9 @@ export const SharedTradeInputHeader = ({ rightContent }: SharedTradeInputHeaderP
             <Heading
               as='h5'
               fontSize='md'
-              color={activeTab !== TradeInputTab.LimitOrder ? 'text.subtle' : undefined}
+              color={selectedTab !== TradeInputTab.LimitOrder ? 'text.subtle' : undefined}
               onClick={handleClickLimitOrder}
-              cursor={activeTab !== TradeInputTab.LimitOrder ? 'pointer' : undefined}
+              cursor={selectedTab !== TradeInputTab.LimitOrder ? 'pointer' : undefined}
             >
               {translate('limitOrder.heading')}
             </Heading>
@@ -61,9 +61,9 @@ export const SharedTradeInputHeader = ({ rightContent }: SharedTradeInputHeaderP
             <Heading
               as='h5'
               fontSize='md'
-              color={activeTab !== TradeInputTab.Claim ? 'text.subtle' : undefined}
+              color={selectedTab !== TradeInputTab.Claim ? 'text.subtle' : undefined}
               onClick={handleClickClaim}
-              cursor={activeTab !== TradeInputTab.Claim ? 'pointer' : undefined}
+              cursor={selectedTab !== TradeInputTab.Claim ? 'pointer' : undefined}
             >
               {translate('bridge.claim')}
             </Heading>

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -82,10 +82,9 @@ const STREAM_ACKNOWLEDGEMENT_MINIMUM_TIME_THRESHOLD = 1_000 * 60 * 5
 type TradeInputProps = {
   tradeInputRef: React.MutableRefObject<HTMLDivElement | null>
   isCompact?: boolean
-  onChangeTab: (newTab: TradeInputTab) => void
 }
 
-export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInputProps) => {
+export const TradeInput = ({ isCompact, tradeInputRef }: TradeInputProps) => {
   const {
     dispatch: walletDispatch,
     state: { isConnected, wallet },
@@ -551,7 +550,6 @@ export const TradeInput = ({ isCompact, tradeInputRef, onChangeTab }: TradeInput
         tradeInputRef={tradeInputRef}
         tradeInputTab={TradeInputTab.Trade}
         onSubmit={handleTradeQuoteConfirm}
-        onChangeTab={onChangeTab}
       />
     </>
   )

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
@@ -18,9 +18,7 @@ export const Claim = () => {
   const [claimTxHash, setClaimTxHash] = useState<string | undefined>()
   const [claimTxStatus, setClaimTxStatus] = useState<TxStatus | undefined>()
 
-  // Redirect to the Select route when the component mounts
   useEffect(() => {
-    // Only redirect if we're exactly on the /trade/claim route
     if (location.pathname === '/trade/claim') {
       history.replace(ClaimRoutePaths.Select)
     }
@@ -60,18 +58,9 @@ export const Claim = () => {
     <Card flex={1} width='full' maxWidth='500px'>
       <SharedTradeInputHeader />
       <Switch location={location}>
-        <Route
-          path={ClaimRoutePaths.Select}
-          render={renderClaimSelect}
-        />
-        <Route
-          path={ClaimRoutePaths.Confirm}
-          render={renderClaimConfirm}
-        />
-        <Route
-          path={ClaimRoutePaths.Status}
-          render={renderClaimStatus}
-        />
+        <Route path={ClaimRoutePaths.Select} render={renderClaimSelect} />
+        <Route path={ClaimRoutePaths.Confirm} render={renderClaimConfirm} />
+        <Route path={ClaimRoutePaths.Status} render={renderClaimStatus} />
       </Switch>
     </Card>
   )

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@chakra-ui/react'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useState } from 'react'
-import { MemoryRouter, Route, Switch, useLocation } from 'react-router-dom'
+import { useCallback, useEffect, useState } from 'react'
+import { Route, Switch, useHistory, useLocation } from 'react-router-dom'
 
 import { SharedTradeInputHeader } from '../../../SharedTradeInput/SharedTradeInputHeader'
 import { ClaimConfirm } from './ClaimConfirm'
@@ -10,16 +10,21 @@ import { ClaimStatus } from './ClaimStatus'
 import type { ClaimDetails } from './hooks/useArbitrumClaimsByStatus'
 import { ClaimRoutePaths } from './types'
 
-import { TradeInputTab } from '@/components/MultiHopTrade/types'
-
-const ClaimRouteEntries = [ClaimRoutePaths.Select, ClaimRoutePaths.Confirm, ClaimRoutePaths.Status]
-
-export const Claim = ({ onChangeTab }: { onChangeTab: (newTab: TradeInputTab) => void }) => {
+export const Claim = () => {
   const location = useLocation()
+  const history = useHistory()
 
   const [activeClaim, setActiveClaim] = useState<ClaimDetails | undefined>()
   const [claimTxHash, setClaimTxHash] = useState<string | undefined>()
   const [claimTxStatus, setClaimTxStatus] = useState<TxStatus | undefined>()
+
+  // Redirect to the Select route when the component mounts
+  useEffect(() => {
+    // Only redirect if we're exactly on the /trade/claim route
+    if (location.pathname === '/trade/claim') {
+      history.replace(ClaimRoutePaths.Select)
+    }
+  }, [history, location.pathname])
 
   const renderClaimSelect = useCallback(() => {
     return <ClaimSelect setActiveClaim={setActiveClaim} />
@@ -52,27 +57,22 @@ export const Claim = ({ onChangeTab }: { onChangeTab: (newTab: TradeInputTab) =>
   }, [activeClaim, claimTxHash, claimTxStatus])
 
   return (
-    <MemoryRouter initialEntries={ClaimRouteEntries} initialIndex={0}>
+    <Card flex={1} width='full' maxWidth='500px'>
+      <SharedTradeInputHeader />
       <Switch location={location}>
-        <Card flex={1} width='full' maxWidth='500px'>
-          <SharedTradeInputHeader initialTab={TradeInputTab.Claim} onChangeTab={onChangeTab} />
-          <Route
-            key={ClaimRoutePaths.Select}
-            path={ClaimRoutePaths.Select}
-            render={renderClaimSelect}
-          />
-          <Route
-            key={ClaimRoutePaths.Confirm}
-            path={ClaimRoutePaths.Confirm}
-            render={renderClaimConfirm}
-          />
-          <Route
-            key={ClaimRoutePaths.Status}
-            path={ClaimRoutePaths.Status}
-            render={renderClaimStatus}
-          />
-        </Card>
+        <Route
+          path={ClaimRoutePaths.Select}
+          render={renderClaimSelect}
+        />
+        <Route
+          path={ClaimRoutePaths.Confirm}
+          render={renderClaimConfirm}
+        />
+        <Route
+          path={ClaimRoutePaths.Status}
+          render={renderClaimStatus}
+        />
       </Switch>
-    </MemoryRouter>
+    </Card>
   )
 }

--- a/src/components/MultiHopTrade/context/MultiHopTradeContext.tsx
+++ b/src/components/MultiHopTrade/context/MultiHopTradeContext.tsx
@@ -5,23 +5,18 @@ import { TradeInputTab, TradeRoutePaths } from '../types'
 
 import { assertUnreachable } from '@/lib/utils'
 
-// Define action types
-type MultiHopTradeAction =
-  | { type: 'SET_ACTIVE_TAB'; payload: TradeInputTab }
+type MultiHopTradeAction = { type: 'SET_ACTIVE_TAB'; payload: TradeInputTab }
 
-// Define the state type
 type MultiHopTradeState = {
-  activeTab: TradeInputTab
+  selectedTab: TradeInputTab
 }
 
-// Define the context type
 type MultiHopTradeContextType = MultiHopTradeState & {
   handleChangeTab: (newTab: TradeInputTab) => void
 }
 
-// Create the initial state
 const initialState: MultiHopTradeState = {
-  activeTab: TradeInputTab.Trade
+  selectedTab: TradeInputTab.Trade,
 }
 
 // Create the reducer function
@@ -33,7 +28,7 @@ export const multiHopTradeReducer = (
     case 'SET_ACTIVE_TAB':
       return {
         ...state,
-        activeTab: action.payload
+        selectedTab: action.payload,
       }
     default:
       return state
@@ -68,7 +63,7 @@ export const MultiHopTradeProvider: React.FC<React.PropsWithChildren> = ({ child
     (newTab: TradeInputTab) => {
       // Update the active tab state
       dispatch({ type: 'SET_ACTIVE_TAB', payload: newTab })
-      
+
       // Navigate to the corresponding route
       switch (newTab) {
         case TradeInputTab.Trade:
@@ -84,12 +79,12 @@ export const MultiHopTradeProvider: React.FC<React.PropsWithChildren> = ({ child
           assertUnreachable(newTab)
       }
     },
-    [history]
+    [history],
   )
 
   const value = {
     ...state,
-    handleChangeTab
+    handleChangeTab,
   }
 
   return <MultiHopTradeContext.Provider value={value}>{children}</MultiHopTradeContext.Provider>

--- a/src/components/MultiHopTrade/context/MultiHopTradeContext.tsx
+++ b/src/components/MultiHopTrade/context/MultiHopTradeContext.tsx
@@ -1,0 +1,104 @@
+import { createContext, useCallback, useContext, useEffect, useReducer } from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
+
+import { TradeInputTab, TradeRoutePaths } from '../types'
+
+import { assertUnreachable } from '@/lib/utils'
+
+// Define action types
+type MultiHopTradeAction =
+  | { type: 'SET_ACTIVE_TAB'; payload: TradeInputTab }
+
+// Define the state type
+type MultiHopTradeState = {
+  activeTab: TradeInputTab
+}
+
+// Define the context type
+type MultiHopTradeContextType = MultiHopTradeState & {
+  handleChangeTab: (newTab: TradeInputTab) => void
+}
+
+// Create the initial state
+const initialState: MultiHopTradeState = {
+  activeTab: TradeInputTab.Trade
+}
+
+// Create the reducer function
+export const multiHopTradeReducer = (
+  state: MultiHopTradeState,
+  action: MultiHopTradeAction,
+): MultiHopTradeState => {
+  switch (action.type) {
+    case 'SET_ACTIVE_TAB':
+      return {
+        ...state,
+        activeTab: action.payload
+      }
+    default:
+      return state
+  }
+}
+
+// Create the context
+const MultiHopTradeContext = createContext<MultiHopTradeContextType | undefined>(undefined)
+
+export const MultiHopTradeProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const history = useHistory()
+  const location = useLocation()
+  const [state, dispatch] = useReducer(multiHopTradeReducer, initialState)
+
+  // Sync the active tab with the current route
+  useEffect(() => {
+    if (location.pathname === TradeRoutePaths.Claim) {
+      dispatch({ type: 'SET_ACTIVE_TAB', payload: TradeInputTab.Claim })
+    } else if (location.pathname === TradeRoutePaths.LimitOrder) {
+      dispatch({ type: 'SET_ACTIVE_TAB', payload: TradeInputTab.LimitOrder })
+    } else if (
+      location.pathname === TradeRoutePaths.Input ||
+      location.pathname === TradeRoutePaths.Confirm ||
+      location.pathname === TradeRoutePaths.VerifyAddresses ||
+      location.pathname === TradeRoutePaths.QuoteList
+    ) {
+      dispatch({ type: 'SET_ACTIVE_TAB', payload: TradeInputTab.Trade })
+    }
+  }, [location.pathname])
+
+  const handleChangeTab = useCallback(
+    (newTab: TradeInputTab) => {
+      // Update the active tab state
+      dispatch({ type: 'SET_ACTIVE_TAB', payload: newTab })
+      
+      // Navigate to the corresponding route
+      switch (newTab) {
+        case TradeInputTab.Trade:
+          history.push(TradeRoutePaths.Input)
+          break
+        case TradeInputTab.LimitOrder:
+          history.push(TradeRoutePaths.LimitOrder)
+          break
+        case TradeInputTab.Claim:
+          history.push(TradeRoutePaths.Claim)
+          break
+        default:
+          assertUnreachable(newTab)
+      }
+    },
+    [history]
+  )
+
+  const value = {
+    ...state,
+    handleChangeTab
+  }
+
+  return <MultiHopTradeContext.Provider value={value}>{children}</MultiHopTradeContext.Provider>
+}
+
+export const useMultiHopTradeContext = () => {
+  const context = useContext(MultiHopTradeContext)
+  if (context === undefined) {
+    throw new Error('useMultiHopTradeContext must be used within MultiHopTradeProvider')
+  }
+  return context
+}

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -83,10 +83,7 @@ export const useBridgeClaimNotification = () => {
       render: ({ onClose }) => {
         const handleCtaClick = () => {
           handleClaimTabClick?.()
-
-          if (multiHopTradeContext) {
-            multiHopTradeContext.handleChangeTab(TradeInputTab.Claim)
-          }
+          multiHopTradeContext?.handleChangeTab(TradeInputTab.Claim)
 
           onClose()
         }

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -25,8 +25,9 @@ const flexGap = { base: 2, md: 3 }
 const flexDir: ResponsiveValue<Property.FlexDirection> = { base: 'column', md: 'row' }
 const flexAlignItems = { base: 'flex-start', md: 'center' }
 
-// Create a global function to handle the claim tab click
-// This will be called from the toast
+// Create a "global" (as in, a singleton that will be instantiated when swapper mounts) function to handle the claim tab click from swapper
+// This will be called from the toast, so that it works from within swapper
+// It's high time we stop the memory router madness and just use global routing or something else, this is getting out of hand
 let handleClaimTabClick: (() => void) | null = null
 
 export const registerClaimTabClickHandler = (handler: () => void) => {

--- a/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
+++ b/src/hooks/useBridgeClaimNotification/useBridgeClaimNotification.tsx
@@ -18,7 +18,7 @@ import { useHistory } from 'react-router-dom'
 import { IconCircle } from '@/components/IconCircle'
 import { useArbitrumClaimsByStatus } from '@/components/MultiHopTrade/components/TradeInput/components/Claim/hooks/useArbitrumClaimsByStatus'
 import { useMultiHopTradeContext } from '@/components/MultiHopTrade/context/MultiHopTradeContext'
-import { TradeInputTab, TradeRoutePaths } from '@/components/MultiHopTrade/types'
+import { TradeInputTab } from '@/components/MultiHopTrade/types'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 
 const flexGap = { base: 2, md: 3 }
@@ -27,16 +27,10 @@ const flexAlignItems = { base: 'flex-start', md: 'center' }
 
 // Create a global function to handle the claim tab click
 // This will be called from the toast
-let handleClaimTabClickGlobal: (() => void) | null = null
+let handleClaimTabClick: (() => void) | null = null
 
 export const registerClaimTabClickHandler = (handler: () => void) => {
-  handleClaimTabClickGlobal = handler
-}
-
-export const triggerClaimTabClick = () => {
-  if (handleClaimTabClickGlobal) {
-    handleClaimTabClickGlobal()
-  }
+  handleClaimTabClick = handler
 }
 
 export const useBridgeClaimNotification = () => {
@@ -87,21 +81,12 @@ export const useBridgeClaimNotification = () => {
     const _toastIdRef = toast({
       render: ({ onClose }) => {
         const handleCtaClick = () => {
-          // Try multiple approaches to ensure the tab changes
-          
-          // 1. Use the global handler if available
-          if (handleClaimTabClickGlobal) {
-            handleClaimTabClickGlobal()
-          }
-          
-          // 2. Use the context if available
+          handleClaimTabClick?.()
+
           if (multiHopTradeContext) {
             multiHopTradeContext.handleChangeTab(TradeInputTab.Claim)
           }
-          
-          // 3. Use the history as a fallback
-          history.push(TradeRoutePaths.Claim)
-          
+
           onClose()
         }
 


### PR DESCRIPTION
## Description

Monday going the Monday way, or when "let's pick this simple button click fix in-between reviews" becomes a gargantuous refactor.

The tl;dr of this is we're dealing with three kinds of routing in swapper:
- an outer routing (`/trade`)
- an inner routing (e.g `/trade/claim`, or `/claim` for oversimplification purposes)
- an active tab context

While the two latter work well regardless of whether or not you're in the context of swapper, the two latter absolutely don't and will product unpredictable results.
Yes, the bug does happen while we're in the context of trade route, which is unintuitive, but it actually makes sense, as the toast will try to leverage an inner swapper routing from outside, whereas 
doing the same button click from somewhere else will actually do a fully outter routing, which will *then* be picked up from inside swapper context.

Fixed by:

- Moving the relevant Trade context to a context file with a reducer for singleton-y purposes
- Removing the `onChangeTab()` event-handling logic in consumers. Routing is now made by *only* pushing a route, which is then handled in a single source of truth in the context
- Registering the click event handler from outside of the context
- Wrapping both `<AppProviders />` and `<MultiHopTrade />` with said context

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8940

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium - refactors swapper routing so we can properly route

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

See Jam:

- Arbitrum claims toast click should work regardless of whether you're already in swapper or not
- Swapper tabs routing should still work
- Swapper routing should still work e2e (perform a quick smoke test)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/b8ad4987-a7a3-495b-8565-ec03f00fd75c


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
