### PR TITLE
fix: disable thorchain affiliate fees

### DIFF
--- a/packages/swapper/src/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/utils/getQuote/getQuote.ts
@@ -113,12 +113,14 @@ export const getQuote = async (
   const { sellAsset, sellAmountCryptoBaseUnit, affiliateBps } = input
 
   // don't apply an affiliate fee if it's below the outbound fee for the inbound pool
-  const thresholdedAffiliateBps = await getThresholdedAffiliateBps({
+  // @ts-ignore - temporary fix for THORChain affiliate fee bug
+  const _thresholdedAffiliateBps = await getThresholdedAffiliateBps({
     sellAsset,
     sellAmountCryptoBaseUnit,
     affiliateBps,
     config: deps.config,
   })
 
-  return _getQuote({ ...input, affiliateBps: thresholdedAffiliateBps }, deps)
+  // TODO: Change me back to thresholdedAffiliateBps once the THORChain affiliate fee bug is fixed
+  return _getQuote({ ...input, affiliateBps: '0' }, deps)
 }


### PR DESCRIPTION
## Description

A temporary fix to alleviate the issues with the THORName affiliate transfer.
We are disabling affiliate fees from THORChain until this is resolved to allow trades via THORChain to go through again.

## Issue (if applicable)

N/A - active prod issue.

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

THORChain trades.

## Testing

Trades over $1k (that would normally attract a fee) on THORChain should be free.

<img width="397" alt="Screenshot 2025-03-11 at 19 14 40" src="https://github.com/user-attachments/assets/28e95fa8-fa45-4699-8822-b3b930da0961" />

### Engineering

☝️

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

☝️

## Screenshots (if applicable)

See above.