### PR TITLE
fix: earn page redirect to rfox page if provider is rfox

### DIFF
--- a/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
+++ b/src/components/EarnDashboard/components/PositionDetails/StakingPositionsByProvider.tsx
@@ -24,6 +24,7 @@ import type {
   OpportunityId,
   StakingEarnOpportunityType,
 } from '@/state/slices/opportunitiesSlice/types'
+import { DefiProvider } from '@/state/slices/opportunitiesSlice/types'
 import { getUnderlyingAssetIdsBalances } from '@/state/slices/opportunitiesSlice/utils'
 import { getMetadataForProvider } from '@/state/slices/opportunitiesSlice/utils/getMetadataForProvider'
 import {
@@ -115,6 +116,10 @@ export const StakingPositionsByProvider: React.FC<StakingPositionsByProviderProp
         highestBalanceAccountAddress,
       } = opportunity
       const { assetReference, assetNamespace } = fromAssetId(assetId)
+
+      if (provider === DefiProvider.rFOX) {
+        return history.push('/rfox')
+      }
 
       if (!isConnected) {
         dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })


### PR DESCRIPTION
## Description

Previously, with the byProvider view, we were redirecting to the RFOX page on click on the opportunity, this part was missing on the byAsset view, added it!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8910

## Risk
Low

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go on the earn page
- Click on any RFOX opportunity/manage
- You should be redirected to the RFOX page
- Same on mobile
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/92a03d9b-cdcf-4b38-949d-3ceedf67186e