### PR TITLE
feat: mobile and desktop wallet menu actions improvements

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -59,6 +59,7 @@
     "pairing": "Pairing",
     "connectWalletToGetStartedWith": "Connect a wallet to get started with %{feature}",
     "connectedWallet": "Connected Wallet",
+    "walletActions": "Wallet Actions",
     "connectedWalletSettings": "Wallet Settings",
     "noWallet": "No Wallet Connected",
     "seeAll": "See All",
@@ -324,7 +325,7 @@
   "connectWallet": {
     "menu": {
       "triggerButton": "Connect Wallet",
-      "switchWallet": "Switch Wallet Provider",
+      "switchWallet": "Switch Wallet",
       "disconnect": "Disconnect",
       "disconnected": "(Disconnected)",
       "connecting": "Connecting..."
@@ -1869,6 +1870,9 @@
         "mobileBody": "Enter the new nickname of your wallet.",
         "button": "Next",
         "confirmDelete": "Are you sure you want to delete the nickname of this wallet?"
+      },
+      "delete": {
+        "header": "Delete your wallet"
       },
       "legacy": {
         "deprecatedWarning": "ShapeShift Log In is being Deprecated",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1866,7 +1866,7 @@
       "rename": {
         "header": "Rename my wallet",
         "walletName": "New nickname for your wallet",
-        "body": "Enter the new nickname of your wallet and your password to decrypt your wallet.",
+        "body": "Enter the new nickname of your wallet and your password to decrypt %{name}.",
         "mobileBody": "Enter the new nickname of your wallet.",
         "button": "Next",
         "confirmDelete": "Are you sure you want to delete the nickname of this wallet?",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1869,10 +1869,14 @@
         "body": "Enter the new nickname of your wallet and your password to decrypt your wallet.",
         "mobileBody": "Enter the new nickname of your wallet.",
         "button": "Next",
-        "confirmDelete": "Are you sure you want to delete the nickname of this wallet?"
+        "confirmDelete": "Are you sure you want to delete the nickname of this wallet?",
+        "success": "Wallet renamed successfully"
       },
       "delete": {
-        "header": "Delete your wallet"
+        "header": "Delete your wallet",
+        "body": "Enter your password to delete %{name}.",
+        "confirmDelete": "Confirm",
+        "success": "Wallet deleted successfully"
       },
       "legacy": {
         "deprecatedWarning": "ShapeShift Log In is being Deprecated",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1870,7 +1870,10 @@
         "mobileBody": "Enter the new nickname of your wallet.",
         "button": "Next",
         "confirmDelete": "Are you sure you want to delete the nickname of this wallet?",
-        "success": "Wallet renamed successfully"
+        "success": "Wallet renamed successfully",
+        "error": {
+          "empty": "Wallet name cannot be empty"
+        }
       },
       "delete": {
         "header": "Delete your wallet",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1864,7 +1864,7 @@
         "button": "Next"
       },
       "rename": {
-        "header": "Rename your wallet",
+        "header": "Rename my wallet",
         "walletName": "New nickname for your wallet",
         "body": "Enter the new nickname of your wallet and your password to decrypt your wallet.",
         "mobileBody": "Enter the new nickname of your wallet.",
@@ -1876,7 +1876,7 @@
         }
       },
       "delete": {
-        "header": "Delete your wallet",
+        "header": "Delete my wallet",
         "body": "Enter your password to delete %{name}.",
         "confirmDelete": "Confirm",
         "success": "Wallet deleted successfully"

--- a/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
+++ b/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
@@ -5,7 +5,10 @@ import { useTranslate } from 'react-polyglot'
 
 import { ManageAccountsMenuItem } from '@/components/Layout/Header/NavBar/ManageAccountsMenuItem'
 import { Text } from '@/components/Text'
+import { WalletActions } from '@/context/WalletProvider/actions'
+import { NativeWalletRoutes } from '@/context/WalletProvider/types'
 import { useModal } from '@/hooks/useModal/useModal'
+import { useWallet } from '@/hooks/useWallet/useWallet'
 
 const downloadIcon = <TbDownload />
 const editIcon = <TbEdit />
@@ -18,6 +21,7 @@ type NativeMenuProps = {
 export const NativeMenu: React.FC<NativeMenuProps> = ({ onClose }) => {
   const backupNativePassphrase = useModal('backupNativePassphrase')
   const translate = useTranslate()
+  const { dispatch } = useWallet()
 
   const handleBackupMenuItemClick = useCallback(() => {
     onClose && onClose()
@@ -25,12 +29,26 @@ export const NativeMenu: React.FC<NativeMenuProps> = ({ onClose }) => {
   }, [backupNativePassphrase, onClose])
 
   const handleRenameClick = useCallback(() => {
+    dispatch({
+      type: WalletActions.SET_INITIAL_ROUTE,
+      payload: NativeWalletRoutes.Rename,
+    })
+
+    dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+
     onClose && onClose()
-  }, [onClose])
+  }, [dispatch, onClose])
 
   const handleDeleteClick = useCallback(() => {
+    dispatch({
+      type: WalletActions.SET_INITIAL_ROUTE,
+      payload: NativeWalletRoutes.Delete,
+    })
+
+    dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
+
     onClose && onClose()
-  }, [onClose])
+  }, [dispatch, onClose])
 
   return (
     <>

--- a/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
+++ b/src/components/Layout/Header/NavBar/Native/NativeMenu.tsx
@@ -1,36 +1,67 @@
-import { ChevronRightIcon } from '@chakra-ui/icons'
 import { Button, MenuDivider, MenuItem } from '@chakra-ui/react'
 import React, { useCallback } from 'react'
+import { TbDownload, TbEdit, TbTrash } from 'react-icons/tb'
+import { useTranslate } from 'react-polyglot'
 
 import { ManageAccountsMenuItem } from '@/components/Layout/Header/NavBar/ManageAccountsMenuItem'
 import { Text } from '@/components/Text'
 import { useModal } from '@/hooks/useModal/useModal'
 
-const chevronRightIcon = <ChevronRightIcon />
+const downloadIcon = <TbDownload />
+const editIcon = <TbEdit />
+const deleteIcon = <TbTrash />
+
 type NativeMenuProps = {
   onClose?: () => void
 }
 
 export const NativeMenu: React.FC<NativeMenuProps> = ({ onClose }) => {
   const backupNativePassphrase = useModal('backupNativePassphrase')
+  const translate = useTranslate()
 
   const handleBackupMenuItemClick = useCallback(() => {
     onClose && onClose()
     backupNativePassphrase.open({})
   }, [backupNativePassphrase, onClose])
 
+  const handleRenameClick = useCallback(() => {
+    onClose && onClose()
+  }, [onClose])
+
+  const handleDeleteClick = useCallback(() => {
+    onClose && onClose()
+  }, [onClose])
+
   return (
     <>
-      <MenuDivider />
       <ManageAccountsMenuItem onClose={onClose} />
       <MenuItem
         as={Button}
         variant='ghost'
-        justifyContent='space-between'
-        rightIcon={chevronRightIcon}
+        justifyContent='flex-start'
+        leftIcon={downloadIcon}
         onClick={handleBackupMenuItemClick}
       >
         <Text translation='modals.shapeShift.backupPassphrase.menuItem' />
+      </MenuItem>
+      <MenuDivider />
+      <MenuItem
+        as={Button}
+        variant='ghost'
+        justifyContent='flex-start'
+        leftIcon={editIcon}
+        onClick={handleRenameClick}
+      >
+        {translate('walletProvider.shapeShift.rename.header')}
+      </MenuItem>
+      <MenuItem
+        as={Button}
+        variant='ghost'
+        justifyContent='flex-start'
+        leftIcon={deleteIcon}
+        onClick={handleDeleteClick}
+      >
+        {translate('walletProvider.shapeShift.delete.header')}
       </MenuItem>
     </>
   )

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -76,6 +76,8 @@ const ConnectedMenu = memo(
               {translate('connectWallet.menu.connecting')}
             </MenuItem>
           )}
+        </MenuGroup>
+        <MenuGroup title={translate('common.walletActions')} color='text.subtle'>
           {ConnectMenuComponent && <ConnectMenuComponent onClose={onClose} />}
           <MenuDivider />
           <MenuItem icon={repeatIcon} onClick={onSwitchProvider}>

--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -77,6 +77,7 @@ const ConnectedMenu = memo(
             </MenuItem>
           )}
         </MenuGroup>
+        <MenuDivider />
         <MenuGroup title={translate('common.walletActions')} color='text.subtle'>
           {ConnectMenuComponent && <ConnectMenuComponent onClose={onClose} />}
           <MenuDivider />

--- a/src/context/WalletProvider/Ledger/components/LedgerMenu.tsx
+++ b/src/context/WalletProvider/Ledger/components/LedgerMenu.tsx
@@ -1,4 +1,4 @@
-import { MenuDivider, MenuItem } from '@chakra-ui/react'
+import { MenuItem } from '@chakra-ui/react'
 import React, { useCallback, useEffect, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 
@@ -55,7 +55,6 @@ export const LedgerMenu: React.FC<LedgerMenuProps> = ({ onClose }) => {
 
   return (
     <>
-      <MenuDivider />
       <ManageAccountsMenuItem onClose={onClose} />
       {/* TODO: Remove the below menu item once the new flow is added, and before the feature flag is enabled */}
       {(!isAccountManagementEnabled || !isLedgerAccountManagementEnabled) && (

--- a/src/context/WalletProvider/MetaMask/components/MetaMaskMenu.tsx
+++ b/src/context/WalletProvider/MetaMask/components/MetaMaskMenu.tsx
@@ -1,4 +1,4 @@
-import { MenuDivider, MenuItem, Skeleton, Tag } from '@chakra-ui/react'
+import { MenuItem, Skeleton, Tag } from '@chakra-ui/react'
 import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 
@@ -52,7 +52,6 @@ export const MetaMaskMenu: React.FC<MetaMaskMenuProps> = ({ onClose }) => {
 
   return isMetaMask ? (
     <>
-      <MenuDivider />
       {isSnapInstalled && isCorrectVersion && <ManageAccountsMenuItem onClose={onClose} />}
       <MenuItem
         justifyContent='space-between'

--- a/src/context/WalletProvider/NewWalletViews/routes/NativeRoutes.tsx
+++ b/src/context/WalletProvider/NewWalletViews/routes/NativeRoutes.tsx
@@ -9,6 +9,8 @@ import { NativePassword } from '../../NativeWallet/components/NativePassword'
 import { NativeSuccess } from '../../NativeWallet/components/NativeSuccess'
 import { NativeTestPhrase } from '../../NativeWallet/components/NativeTestPhrase'
 import type { NativeSetupProps } from '../../NativeWallet/types'
+import { NativeDelete } from '../wallets/native/NativeDelete'
+import { NativeRename } from '../wallets/native/NativeRename'
 import { NativeStart } from '../wallets/native/NativeStart'
 
 import { NativeWalletRoutes } from '@/context/WalletProvider/types'
@@ -52,6 +54,20 @@ export const NativeRoutes = () => (
       // we need to pass an arg here, so we need an anonymous function wrapper
       // eslint-disable-next-line react-memo/require-usememo
       render={routeProps => <NativePassword {...(routeProps as NativeSetupProps)} />}
+    />
+    <Route
+      exact
+      path={NativeWalletRoutes.Rename}
+      // we need to pass an arg here, so we need an anonymous function wrapper
+      // eslint-disable-next-line react-memo/require-usememo
+      render={() => <NativeRename />}
+    />
+    <Route
+      exact
+      path={NativeWalletRoutes.Delete}
+      // we need to pass an arg here, so we need an anonymous function wrapper
+      // eslint-disable-next-line react-memo/require-usememo
+      render={() => <NativeDelete />}
     />
     <Route exact path={NativeWalletRoutes.EnterPassword}>
       <EnterPassword />

--- a/src/context/WalletProvider/NewWalletViews/wallets/native/NativeDelete.tsx
+++ b/src/context/WalletProvider/NewWalletViews/wallets/native/NativeDelete.tsx
@@ -1,0 +1,146 @@
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  ModalBody,
+  ModalHeader,
+  useToast,
+  useUnmountEffect,
+} from '@chakra-ui/react'
+import type { InterpolationOptions } from 'node-polyglot'
+import { useCallback, useMemo, useState } from 'react'
+import type { FieldValues } from 'react-hook-form'
+import { useForm } from 'react-hook-form'
+import { FaEye, FaEyeSlash } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
+
+import { Text } from '@/components/Text'
+import { WalletActions } from '@/context/WalletProvider/actions'
+import { createRevocableWallet } from '@/context/WalletProvider/MobileWallet/RevocableWallet'
+import { useWallet } from '@/hooks/useWallet/useWallet'
+
+export const NativeDelete = () => {
+  const translate = useTranslate()
+  const [showPw, setShowPw] = useState<boolean>(false)
+  const toast = useToast()
+  const { state, dispatch } = useWallet()
+  const [revocableWallet, setRevocableWallet] = useState(
+    createRevocableWallet({
+      id: state.walletInfo?.deviceId,
+      label: state.walletInfo?.meta?.label,
+    }),
+  )
+
+  useUnmountEffect(() => {
+    revocableWallet?.revoke()
+    setRevocableWallet(
+      createRevocableWallet({
+        id: state.walletInfo?.deviceId,
+        label: state.walletInfo?.name,
+      }),
+    )
+  }, [])
+
+  const {
+    setError,
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting },
+  } = useForm<{ password: string }>({ mode: 'onChange' })
+
+  const handleShowClick = useCallback(() => setShowPw(!showPw), [showPw])
+
+  const onSubmit = useCallback(
+    async (values: FieldValues) => {
+      try {
+        const Vault = await import('@shapeshiftoss/hdwallet-native-vault').then(m => m.Vault)
+        // Verify password is correct by attempting to open the vault
+        await Vault.open(revocableWallet.id, values.password)
+
+        if (!revocableWallet.id) {
+          throw new Error('Wallet ID is undefined')
+        }
+
+        // If we get here, the password was correct - proceed with deletion
+        await Vault.delete(revocableWallet.id)
+
+        dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+        dispatch({ type: WalletActions.RESET_STATE })
+
+        toast({
+          title: translate('walletProvider.shapeShift.delete.success'),
+          status: 'success',
+          duration: 5000,
+          isClosable: true,
+        })
+      } catch (e) {
+        console.error(e)
+        setError('password', {
+          type: 'manual',
+          message: translate('modals.shapeShift.password.error.invalid'),
+        })
+      }
+    },
+    [dispatch, revocableWallet.id, setError, toast, translate],
+  )
+
+  const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
+
+  const passwordInputProps = useMemo(
+    () =>
+      register('password', {
+        required: translate('modals.shapeShift.password.error.required'),
+        minLength: {
+          value: 8,
+          message: translate('modals.shapeShift.password.error.length', { length: 8 }),
+        },
+      }),
+    [register, translate],
+  )
+
+  const walletTranslations: [string, number | InterpolationOptions] = useMemo(() => {
+    return ['walletProvider.shapeShift.delete.body', { name: state.walletInfo?.meta?.label }]
+  }, [state.walletInfo?.meta?.label])
+
+  return (
+    <>
+      <ModalHeader>
+        <Text translation={'walletProvider.shapeShift.delete.header'} />
+      </ModalHeader>
+      <ModalBody>
+        <Text mb={6} color='text.subtle' translation={walletTranslations} />
+        <form onSubmit={handleFormSubmit}>
+          <FormControl mb={6} isInvalid={Boolean(errors.password)}>
+            <InputGroup size='lg' variant='filled'>
+              <Input
+                {...passwordInputProps}
+                pr='4.5rem'
+                type={showPw ? 'text' : 'password'}
+                placeholder={translate('modals.shapeShift.password.placeholder')}
+                autoComplete={'password'}
+                id='password'
+              />
+              <InputRightElement>
+                <IconButton
+                  aria-label={translate(`modals.shapeShift.password.${showPw ? 'hide' : 'show'}`)}
+                  h='1.75rem'
+                  size='sm'
+                  onClick={handleShowClick}
+                  icon={!showPw ? <FaEye /> : <FaEyeSlash />}
+                />
+              </InputRightElement>
+            </InputGroup>
+            <FormErrorMessage>{errors?.password?.message}</FormErrorMessage>
+          </FormControl>
+          <Button colorScheme='red' size='lg' width='full' type='submit' isLoading={isSubmitting}>
+            <Text translation={'walletProvider.shapeShift.delete.confirmDelete'} />
+          </Button>
+        </form>
+      </ModalBody>
+    </>
+  )
+}

--- a/src/context/WalletProvider/NewWalletViews/wallets/native/NativeDelete.tsx
+++ b/src/context/WalletProvider/NewWalletViews/wallets/native/NativeDelete.tsx
@@ -14,7 +14,7 @@ import {
 import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useMemo, useState } from 'react'
 import type { FieldValues } from 'react-hook-form'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { FaEye, FaEyeSlash } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 
@@ -22,6 +22,8 @@ import { Text } from '@/components/Text'
 import { WalletActions } from '@/context/WalletProvider/actions'
 import { createRevocableWallet } from '@/context/WalletProvider/MobileWallet/RevocableWallet'
 import { useWallet } from '@/hooks/useWallet/useWallet'
+
+const MIN_PASSWORD_LENGTH = 8
 
 export const NativeDelete = () => {
   const translate = useTranslate()
@@ -46,11 +48,14 @@ export const NativeDelete = () => {
   }, [])
 
   const {
+    control,
     setError,
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
   } = useForm<{ password: string }>({ mode: 'onChange' })
+
+  const password = useWatch({ control, name: 'password' })
 
   const handleShowClick = useCallback(() => setShowPw(!showPw), [showPw])
 
@@ -95,8 +100,10 @@ export const NativeDelete = () => {
       register('password', {
         required: translate('modals.shapeShift.password.error.required'),
         minLength: {
-          value: 8,
-          message: translate('modals.shapeShift.password.error.length', { length: 8 }),
+          value: MIN_PASSWORD_LENGTH,
+          message: translate('modals.shapeShift.password.error.length', {
+            length: MIN_PASSWORD_LENGTH,
+          }),
         },
       }),
     [register, translate],
@@ -136,7 +143,14 @@ export const NativeDelete = () => {
             </InputGroup>
             <FormErrorMessage>{errors?.password?.message}</FormErrorMessage>
           </FormControl>
-          <Button colorScheme='red' size='lg' width='full' type='submit' isLoading={isSubmitting}>
+          <Button
+            colorScheme='red'
+            size='lg'
+            width='full'
+            type='submit'
+            isDisabled={isSubmitting || password?.length < MIN_PASSWORD_LENGTH}
+            isLoading={isSubmitting}
+          >
             <Text translation={'walletProvider.shapeShift.delete.confirmDelete'} />
           </Button>
         </form>

--- a/src/context/WalletProvider/NewWalletViews/wallets/native/NativeRename.tsx
+++ b/src/context/WalletProvider/NewWalletViews/wallets/native/NativeRename.tsx
@@ -1,0 +1,171 @@
+import {
+  Button,
+  FormControl,
+  FormErrorMessage,
+  IconButton,
+  Input,
+  InputGroup,
+  InputRightElement,
+  ModalBody,
+  ModalHeader,
+  useToast,
+  useUnmountEffect,
+} from '@chakra-ui/react'
+import { useCallback, useMemo, useState } from 'react'
+import type { FieldValues } from 'react-hook-form'
+import { useForm } from 'react-hook-form'
+import { FaEye, FaEyeSlash } from 'react-icons/fa'
+import { useTranslate } from 'react-polyglot'
+
+import { Text } from '@/components/Text'
+import { WalletActions } from '@/context/WalletProvider/actions'
+import { createRevocableWallet } from '@/context/WalletProvider/MobileWallet/RevocableWallet'
+import type { NativeWalletValues } from '@/context/WalletProvider/NativeWallet/types'
+import { useWallet } from '@/hooks/useWallet/useWallet'
+
+export const NativeRename = () => {
+  const translate = useTranslate()
+  const [showPw, setShowPw] = useState<boolean>(false)
+  const { state, dispatch } = useWallet()
+  const [revocableWallet, setRevocableWallet] = useState(
+    createRevocableWallet({
+      id: state.walletInfo?.deviceId,
+      label: state.walletInfo?.name,
+    }),
+  )
+  const toast = useToast()
+
+  useUnmountEffect(() => {
+    revocableWallet?.revoke()
+    setRevocableWallet(
+      createRevocableWallet({
+        id: state.walletInfo?.deviceId,
+        label: state.walletInfo?.name,
+      }),
+    )
+  }, [])
+
+  const {
+    setError,
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting },
+  } = useForm<NativeWalletValues>({ mode: 'onChange', shouldUnregister: true })
+
+  const handleShowClick = useCallback(() => setShowPw(!showPw), [showPw])
+  const onSubmit = useCallback(
+    async (values: FieldValues) => {
+      try {
+        const Vault = await import('@shapeshiftoss/hdwallet-native-vault').then(m => m.Vault)
+        const vault = await Vault.open(revocableWallet.id, values.password)
+        if (values.name.length === 0) {
+          const result = window.confirm(translate('walletProvider.shapeShift.rename.confirmDelete'))
+          if (result) {
+            vault.meta.delete('name')
+            await vault.save()
+            dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+            dispatch({ type: WalletActions.SET_WALLET_LABEL, payload: '' })
+          }
+        } else {
+          vault.meta.set('name', values.name)
+          await vault.save()
+          dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
+          dispatch({ type: WalletActions.SET_WALLET_LABEL, payload: values.name })
+        }
+
+        toast({
+          title: translate('walletProvider.shapeShift.rename.success'),
+          status: 'success',
+          duration: 5000,
+          isClosable: true,
+        })
+      } catch (e) {
+        console.error(e)
+        setError('password', {
+          type: 'manual',
+          message: translate('modals.shapeShift.password.error.invalid'),
+        })
+      }
+    },
+    [dispatch, revocableWallet.id, setError, toast, translate],
+  )
+
+  const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
+
+  const nameInputProps = useMemo(
+    () =>
+      register('name', {
+        maxLength: {
+          value: 64,
+          message: translate('modals.shapeShift.password.error.maxLength', { length: 64 }),
+        },
+      }),
+    [register, translate],
+  )
+
+  const passwordInputProps = useMemo(
+    () =>
+      register('password', {
+        required: translate('modals.shapeShift.password.error.required'),
+        minLength: {
+          value: 8,
+          message: translate('modals.shapeShift.password.error.length', { length: 8 }),
+        },
+      }),
+    [register, translate],
+  )
+  return (
+    <>
+      <ModalHeader>
+        <Text translation={'walletProvider.shapeShift.rename.header'} />
+      </ModalHeader>
+      <ModalBody>
+        <Text mb={6} color='text.subtle' translation={'walletProvider.shapeShift.rename.body'} />
+        <form onSubmit={handleFormSubmit}>
+          <FormControl mb={6} isInvalid={Boolean(errors.name)}>
+            <Input
+              {...nameInputProps}
+              size='lg'
+              variant='filled'
+              id='name'
+              placeholder={translate('walletProvider.shapeShift.rename.walletName')}
+            />
+            <FormErrorMessage>{errors?.name?.message}</FormErrorMessage>
+          </FormControl>
+          <FormControl mb={6} isInvalid={Boolean(errors.password)}>
+            <InputGroup size='lg' variant='filled'>
+              <Input
+                {...passwordInputProps}
+                pr='4.5rem'
+                type={showPw ? 'text' : 'password'}
+                placeholder={translate('modals.shapeShift.password.placeholder')}
+                autoComplete={'password'}
+                id='password'
+              />
+              <InputRightElement>
+                <IconButton
+                  aria-label={translate(`modals.shapeShift.password.${showPw ? 'hide' : 'show'}`)}
+                  h='1.75rem'
+                  size='sm'
+                  onClick={handleShowClick}
+                  icon={!showPw ? <FaEye /> : <FaEyeSlash />}
+                />
+              </InputRightElement>
+            </InputGroup>
+            <FormErrorMessage>{errors?.password?.message}</FormErrorMessage>
+          </FormControl>
+          <Button
+            colorScheme='blue'
+            size='lg'
+            width='full'
+            type='submit'
+            isLoading={isSubmitting}
+            isDisabled={Boolean(errors.name)}
+          >
+            <Text translation={'walletProvider.shapeShift.rename.button'} />
+          </Button>
+        </form>
+      </ModalBody>
+    </>
+  )
+}

--- a/src/context/WalletProvider/NewWalletViews/wallets/native/NativeRename.tsx
+++ b/src/context/WalletProvider/NewWalletViews/wallets/native/NativeRename.tsx
@@ -11,6 +11,7 @@ import {
   useToast,
   useUnmountEffect,
 } from '@chakra-ui/react'
+import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useMemo, useState } from 'react'
 import type { FieldValues } from 'react-hook-form'
 import { useForm } from 'react-hook-form'
@@ -114,13 +115,18 @@ export const NativeRename = () => {
       }),
     [register, translate],
   )
+
+  const walletTranslations: [string, number | InterpolationOptions] = useMemo(() => {
+    return ['walletProvider.shapeShift.rename.body', { name: state.walletInfo?.meta?.label }]
+  }, [state.walletInfo?.meta?.label])
+
   return (
     <>
       <ModalHeader>
         <Text translation={'walletProvider.shapeShift.rename.header'} />
       </ModalHeader>
       <ModalBody>
-        <Text mb={6} color='text.subtle' translation={'walletProvider.shapeShift.rename.body'} />
+        <Text mb={6} color='text.subtle' translation={walletTranslations} />
         <form onSubmit={handleFormSubmit}>
           <FormControl mb={6} isInvalid={Boolean(errors.name)}>
             <Input

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -162,6 +162,16 @@ const reducer = (state: InitialState, action: ActionTypes): InitialState => {
           },
         },
       }
+    case WalletActions.SET_WALLET_LABEL:
+      if (!state.walletInfo) return state
+
+      return {
+        ...state,
+        walletInfo: {
+          ...state.walletInfo,
+          meta: { ...state.walletInfo?.meta, label: action.payload },
+        },
+      }
     case WalletActions.SET_WCV2_PROVIDER:
       return { ...state, wcV2Provider: action.payload }
     case WalletActions.SET_IS_CONNECTED:

--- a/src/context/WalletProvider/actions.ts
+++ b/src/context/WalletProvider/actions.ts
@@ -8,6 +8,7 @@ import type { DeviceState, InitialState, WalletInfo } from './WalletProvider'
 export enum WalletActions {
   SET_ADAPTERS = 'SET_ADAPTERS',
   SET_WALLET = 'SET_WALLET',
+  SET_WALLET_LABEL = 'SET_WALLET_LABEL',
   SET_CONNECTOR_TYPE = 'SET_CONNECTOR_TYPE',
   SET_INITIAL_ROUTE = 'SET_INITIAL_ROUTE',
   SET_IS_CONNECTED = 'SET_IS_CONNECTED',
@@ -40,6 +41,10 @@ export type ActionTypes =
         wallet: HDWallet | null
         connectedType: KeyManager
       }
+    }
+  | {
+      type: WalletActions.SET_WALLET_LABEL
+      payload: string
     }
   | {
       type: WalletActions.SET_IS_CONNECTED

--- a/src/context/WalletProvider/types.ts
+++ b/src/context/WalletProvider/types.ts
@@ -27,6 +27,7 @@ export enum NativeWalletRoutes {
   Load = '/native/load',
   Password = '/native/password',
   Rename = '/native/rename',
+  Delete = '/native/delete',
   ImportSelect = '/native/import-select',
   ImportSeed = '/native/import-seed',
   ImportKeystore = '/native/import-keystore',


### PR DESCRIPTION
## Description
- Renamed Switch Wallet Provider to Switch Wallet
- Removed the chevron right in favor of a backup icon like on mobile
- Added Rename and delete buttons with icons
- Split between 2 groups and added a "Wallet action" header
- Added 2 new screens to the wallet modal so we can rename or delete the current wallet 

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8832

## Risk
Low (was not existing before)
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Import multiple native wallets
- Try to rename them
- Try to delete them

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/a687a144-40dc-477b-b28b-ffeb4615bae6)
https://jam.dev/c/e176c3c4-324a-4f75-a316-4f134ac9fe58