### PR TITLE
feat: inverse rate when clicked

### DIFF
--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -3,7 +3,7 @@ import type { FlexProps } from '@chakra-ui/react'
 import { Box, Collapse, Flex, Skeleton, Stack, Tooltip, useDisclosure } from '@chakra-ui/react'
 import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import type { FC, PropsWithChildren } from 'react'
-import { useState, memo, useMemo } from 'react'
+import { memo, useMemo, useState } from 'react'
 import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 
@@ -49,7 +49,7 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
     const translate = useTranslate()
     const { isOpen, onToggle } = useDisclosure()
     const [useInverse, setUseInverse] = useState(false)
-    
+
     // Compute the inverse rate for toggling between display formats:
     const displayedRate = useMemo(() => {
       const computedRate = rate ? parseFloat(rate) : 0
@@ -137,7 +137,11 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
                               symbol={buyAssetSymbol}
                               suffix='='
                             />
-                            <Amount.Crypto fontSize='sm' value={displayedRate} symbol={sellAssetSymbol} />
+                            <Amount.Crypto
+                              fontSize='sm'
+                              value={displayedRate}
+                              symbol={sellAssetSymbol}
+                            />
                           </>
                         )}
                         {!isDisabled && <ArrowUpDownIcon />}

--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -4,7 +4,7 @@ import { Box, Collapse, Flex, Skeleton, Stack, Tooltip, useDisclosure } from '@c
 import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import { bnOrZero } from '@shapeshiftoss/utils'
 import type { FC, PropsWithChildren } from 'react'
-import { memo, useCallback, useMemo} from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 
@@ -56,7 +56,11 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
     // Compute the inverse rate for toggling between display formats:
     const inverseRate = useMemo(() => {
       const parsedRate = bnOrZero(rate)
-      return parsedRate.isZero() ? '0' : parsedRate.isPositive() ? bnOrZero(1).div(parsedRate).toFixed(8) : '0'
+      return parsedRate.isZero()
+        ? '0'
+        : parsedRate.isPositive()
+        ? bnOrZero(1).div(parsedRate).toFixed(8)
+        : '0'
     }, [rate])
 
     const handleClick = useCallback(() => {

--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -56,11 +56,8 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
     // Compute the inverse rate for toggling between display formats:
     const inverseRate = useMemo(() => {
       const parsedRate = bnOrZero(rate)
-      return parsedRate.isZero()
-        ? '0'
-        : parsedRate.isPositive()
-        ? bnOrZero(1).div(parsedRate).toFixed(8)
-        : '0'
+      if (parsedRate.isZero() || parsedRate.isNegative()) return '0'
+      return bnOrZero(1).div(parsedRate).toFixed(8)
     }, [rate])
 
     const handleClick = useCallback(() => {

--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -3,7 +3,7 @@ import type { FlexProps } from '@chakra-ui/react'
 import { Box, Collapse, Flex, Skeleton, Stack, Tooltip, useDisclosure } from '@chakra-ui/react'
 import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import type { FC, PropsWithChildren } from 'react'
-import { memo } from 'react'
+import { useState, memo, useMemo } from 'react'
 import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 
@@ -48,6 +48,13 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
   }) => {
     const translate = useTranslate()
     const { isOpen, onToggle } = useDisclosure()
+    const [useInverse, setUseInverse] = useState(false)
+    
+    // Compute the inverse rate for toggling between display formats:
+    const displayedRate = useMemo(() => {
+      const computedRate = rate ? parseFloat(rate) : 0
+      return computedRate !== 0 ? (1 / computedRate).toFixed(8) : '0'
+    }, [rate])
 
     switch (true) {
       case isLoading:
@@ -95,8 +102,11 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
                       display='flex'
                       alignItems='center'
                       gap={2}
-                      _hover={!isDisabled ? rateHover : undefined}
-                      onClick={onClick}
+                      _hover={rateHover}
+                      onClick={() => {
+                        setUseInverse(!useInverse)
+                        onClick && onClick()
+                      }}
                     >
                       <SwapperIcons swapperName={swapperName} swapSource={swapSource} />
                       <Stack
@@ -109,13 +119,27 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
                         borderColor='transparent'
                         alignItems='center'
                       >
-                        <Amount.Crypto
-                          fontSize='sm'
-                          value='1'
-                          symbol={sellAssetSymbol}
-                          suffix='='
-                        />
-                        <Amount.Crypto fontSize='sm' value={rate} symbol={buyAssetSymbol} />
+                        {!useInverse ? (
+                          <>
+                            <Amount.Crypto
+                              fontSize='sm'
+                              value='1'
+                              symbol={sellAssetSymbol}
+                              suffix='='
+                            />
+                            <Amount.Crypto fontSize='sm' value={rate} symbol={buyAssetSymbol} />
+                          </>
+                        ) : (
+                          <>
+                            <Amount.Crypto
+                              fontSize='sm'
+                              value='1'
+                              symbol={buyAssetSymbol}
+                              suffix='='
+                            />
+                            <Amount.Crypto fontSize='sm' value={displayedRate} symbol={sellAssetSymbol} />
+                          </>
+                        )}
                         {!isDisabled && <ArrowUpDownIcon />}
                       </Stack>
                     </Row.Value>

--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -2,6 +2,7 @@ import { ArrowUpDownIcon, ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icon
 import type { FlexProps } from '@chakra-ui/react'
 import { Box, Collapse, Flex, Skeleton, Stack, Tooltip, useDisclosure } from '@chakra-ui/react'
 import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
+import { bnOrZero } from '@shapeshiftoss/utils'
 import type { FC, PropsWithChildren } from 'react'
 import { memo, useCallback, useMemo} from 'react'
 import { FaGasPump } from 'react-icons/fa'
@@ -32,6 +33,7 @@ const rowHover = { bg: 'background.surface.raised.base' }
 const rateHover = {
   cursor: 'pointer',
   '.rate': { borderColor: 'text.link' },
+  userSelect: 'none',
 }
 
 export const RateGasRow: FC<RateGasRowProps> = memo(
@@ -53,8 +55,8 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
 
     // Compute the inverse rate for toggling between display formats:
     const inverseRate = useMemo(() => {
-      const parsedRate = rate ? parseFloat(rate) : 0
-      return parsedRate === 0 ? '0' : (1 / parsedRate).toFixed(8)
+      const parsedRate = bnOrZero(rate)
+      return parsedRate.isZero() ? '0' : parsedRate.isPositive() ? bnOrZero(1).div(parsedRate).toFixed(8) : '0'
     }, [rate])
 
     const handleClick = useCallback(() => {

--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -3,7 +3,7 @@ import type { FlexProps } from '@chakra-ui/react'
 import { Box, Collapse, Flex, Skeleton, Stack, Tooltip, useDisclosure } from '@chakra-ui/react'
 import type { SwapperName, SwapSource } from '@shapeshiftoss/swapper'
 import type { FC, PropsWithChildren } from 'react'
-import { memo, useMemo, useState } from 'react'
+import { memo, useCallback, useMemo} from 'react'
 import { FaGasPump } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 
@@ -13,6 +13,7 @@ import { Amount } from '@/components/Amount/Amount'
 import { HelperTooltip } from '@/components/HelperTooltip/HelperTooltip'
 import { Row } from '@/components/Row/Row'
 import { Text } from '@/components/Text'
+import { useToggle } from '@/hooks/useToggle/useToggle'
 
 type RateGasRowProps = {
   buyAssetSymbol: string
@@ -48,13 +49,18 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
   }) => {
     const translate = useTranslate()
     const { isOpen, onToggle } = useDisclosure()
-    const [useInverse, setUseInverse] = useState(false)
+    const [useInverse, toggleUseInverse] = useToggle(false)
 
     // Compute the inverse rate for toggling between display formats:
-    const displayedRate = useMemo(() => {
-      const computedRate = rate ? parseFloat(rate) : 0
-      return computedRate !== 0 ? (1 / computedRate).toFixed(8) : '0'
+    const inverseRate = useMemo(() => {
+      const parsedRate = rate ? parseFloat(rate) : 0
+      return parsedRate === 0 ? '0' : (1 / parsedRate).toFixed(8)
     }, [rate])
+
+    const handleClick = useCallback(() => {
+      toggleUseInverse()
+      onClick && onClick()
+    }, [toggleUseInverse, onClick])
 
     switch (true) {
       case isLoading:
@@ -103,10 +109,7 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
                       alignItems='center'
                       gap={2}
                       _hover={rateHover}
-                      onClick={() => {
-                        setUseInverse(!useInverse)
-                        onClick && onClick()
-                      }}
+                      onClick={handleClick}
                     >
                       <SwapperIcons swapperName={swapperName} swapSource={swapSource} />
                       <Stack
@@ -139,7 +142,7 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
                             />
                             <Amount.Crypto
                               fontSize='sm'
-                              value={displayedRate}
+                              value={inverseRate}
                               symbol={sellAssetSymbol}
                             />
                           </>


### PR DESCRIPTION
## Description

It is an industry standard for swappers to be able to inverse a quoted rate to switch the denomination back and forth between basecoin and quotecoin.

For example by default, when I am trading USDC -> FOX, the app displays: 1 USDC = XXX FOX. This is not very helpful, as almost all exchanges will default to denominating a rate in terms of fiat. I need a calculator to actually see the fiat rate that I get.

Clicking on the rate should swap the perspective and show 1 FOX = XXX USDC, which is the human readable form of the quote.

## Issue (if applicable)

closes #9001

## Risk
Low

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots
![rate_toggle](https://github.com/user-attachments/assets/46d7245d-9d8a-456c-8d02-9bc6e7d9a172)

