### PR TITLE
fix: portals one-click defi assets

### DIFF
--- a/src/lib/portals/utils.ts
+++ b/src/lib/portals/utils.ts
@@ -4,7 +4,7 @@ import type { Asset } from '@shapeshiftoss/types'
 import { createThrottle, isSome } from '@shapeshiftoss/utils'
 import axios from 'axios'
 import qs from 'qs'
-import { getAddress, isAddressEqual, zeroAddress } from 'viem'
+import { getAddress, isAddress, isAddressEqual, zeroAddress } from 'viem'
 
 import { CHAIN_ID_TO_PORTALS_NETWORK } from './constants'
 import type {
@@ -99,7 +99,7 @@ export const fetchPortalsTokens = async ({
 
     const pageTokens = pageResponse.data.tokens.filter(
       // Filter out native assets as 0x0 tokens, or problems
-      ({ address }) => !isAddressEqual(getAddress(address), zeroAddress),
+      ({ address }) => isAddress(address) && !isAddressEqual(getAddress(address), zeroAddress),
     )
 
     const newTokens = accTokens.concat(pageTokens)


### PR DESCRIPTION
## Description

Not sure what's happening here:

```
host-console-events.js:1 InvalidAddressError: Address "0x16344277b69bd724a92b9e06ba40f0ec5512bd8b6290b63862db757a8a94ba33" is invalid.

- Address must be a hex value of 20 bytes (40 hex characters).
- Address must match its checksum counterpart.
```

As the one addy which throws this seems to be correct according to https://app.uniswap.org/explore/pools/base/0x16344277b69bd724a92b9e06ba40f0ec5512bd8b6290b63862db757a8a94ba33), but is apparently not a valid ETH address for all checksum intents and purposes,
and is not visible on basescan either.

Either way, this fixes it!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9022

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- One-click DeFi assets are happy again

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->

<img width="1113" alt="Screenshot 2025-03-14 at 01 49 12" src="https://github.com/user-attachments/assets/fb4a5309-a8a9-49b3-ab54-1dd699307a14" />

