### PR TITLE
fix: create multiple native wallets in a row

### DIFF
--- a/src/context/WalletProvider/NativeWallet/components/NativeSuccess.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeSuccess.tsx
@@ -1,5 +1,6 @@
 import { Box, ModalBody, ModalHeader } from '@chakra-ui/react'
 import { useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 
 import { useNativeSuccess } from '../hooks/useNativeSuccess'
 import type { NativeSetupProps } from '../types'
@@ -11,9 +12,21 @@ export const NativeSuccess = ({ location }: NativeSetupProps) => {
   const queryClient = useQueryClient()
   const { isSuccessful } = useNativeSuccess({ vault: location.state.vault })
 
-  queryClient.invalidateQueries({
-    queryKey: reactQueries.common.hdwalletNativeVaultsList().queryKey,
-  })
+  useEffect(() => {
+    queryClient.invalidateQueries({
+      queryKey: reactQueries.common.hdwalletNativeVaultsList().queryKey,
+    })
+    queryClient.invalidateQueries({
+      queryKey: ['native-create-vault'],
+      exact: false,
+      refetchType: 'all',
+    })
+    queryClient.invalidateQueries({
+      queryKey: ['native-create-words'],
+      exact: false,
+      refetchType: 'all',
+    })
+  }, [queryClient])
 
   return (
     <>


### PR DESCRIPTION
## Description

Invalidate vault queries on success so any new creation flow won't use weird cache but new vault with new mnemonic

Only invalidate on success so if we get back using the routing, mnemonic and vault doesn't change

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8998

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Create a native wallet
- Try to create another one
- And try to create another one

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/31c13673-9033-4695-8f80-2b39e44426c5