### PR TITLE
feat: single tx list in the notification drawer

### DIFF
--- a/src/components/Layout/Header/TxWindow/TxWindow.tsx
+++ b/src/components/Layout/Header/TxWindow/TxWindow.tsx
@@ -1,4 +1,3 @@
-import type { TabProps } from '@chakra-ui/react'
 import {
   Box,
   Circle,
@@ -10,11 +9,6 @@ import {
   Flex,
   IconButton,
   Select,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
 } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import React, { memo, useCallback, useMemo, useState } from 'react'
@@ -28,27 +22,17 @@ import { selectIsAnyTxHistoryApiQueryPending, selectTxIdsByFilter } from '@/stat
 import { useAppSelector } from '@/state/store'
 
 const paddingProp = { base: 4, md: 6 }
-const selectedProp = { color: 'text.base' }
-const hoverProp = { cursor: 'pointer' }
 
-const CustomTab: React.FC<TabProps> = props => (
-  <Tab
-    px={0}
-    fontWeight='medium'
-    color='text.subtle'
-    cursor='pointer'
-    _selected={selectedProp}
-    _hover={hoverProp}
-    {...props}
-  />
-)
 type TxsByStatusProps = {
-  txStatus: TxStatus
+  txStatus: TxStatus | 'all'
   limit: string
 }
 export const TxsByStatus: React.FC<TxsByStatusProps> = ({ txStatus, limit }) => {
   const translate = useTranslate()
-  const filter = useMemo(() => ({ txStatus }), [txStatus])
+  const filter = useMemo(
+    () => ({ txStatus: txStatus === 'all' ? undefined : txStatus }),
+    [txStatus],
+  )
   const txIds = useAppSelector(state => selectTxIdsByFilter(state, filter))
   const isAnyTxHistoryApiQueryPending = useAppSelector(selectIsAnyTxHistoryApiQueryPending)
   const limitTxIds = useMemo(() => {
@@ -110,63 +94,49 @@ export const TxWindow = memo(() => {
       </Box>
       <Drawer isOpen={isOpen} onClose={handleClose} size='sm'>
         <DrawerOverlay backdropBlur='10px' />
-        <DrawerContent
-          minHeight='100vh'
-          maxHeight='100vh'
-          overflow='auto'
-          paddingTop='env(safe-area-inset-top)'
-        >
-          <DrawerCloseButton top='calc(var(--chakra-space-2) + env(safe-area-inset-top))' />
-          <DrawerHeader px={paddingProp} display='flex' alignItems='center' gap={2}>
-            <TxHistoryIcon color='text.subtle' />
-            {translate('navBar.transactions')}
-          </DrawerHeader>
-          <Tabs variant='unstyled' isLazy>
-            <Flex
-              gap={4}
-              justifyContent='space-between'
-              px={paddingProp}
-              bg='background.surface.overlay.base'
-              position='sticky'
-              top={0}
-              py={2}
-              zIndex='banner'
-            >
-              <TabList gap={4}>
-                <CustomTab>{translate('transactionRow.pending')}</CustomTab>
-                <CustomTab>{translate('transactionRow.confirmed')}</CustomTab>
-                <CustomTab>{translate('transactionRow.failed')}</CustomTab>
-              </TabList>
-              <Flex alignItems='center' gap={2}>
-                <RawText fontSize='sm' color='text.subtle'>
-                  {translate('common.show')}
-                </RawText>
-                <Select
-                  size='sm'
-                  variant='filled'
-                  value={limit}
-                  onChange={handleSetLimit}
-                  borderRadius='lg'
-                  fontWeight='medium'
-                >
-                  <option value='25'>25</option>
-                  <option value='50'>50</option>
-                  <option value='100'>100</option>
-                </Select>
-              </Flex>
+
+        <DrawerContent minHeight='100vh' maxHeight='100vh' paddingTop='env(safe-area-inset-top)'>
+          <DrawerCloseButton top='calc(18px + env(safe-area-inset-top))' />
+          <DrawerHeader
+            px={paddingProp}
+            display='flex'
+            alignItems='center'
+            gap={2}
+            justifyContent='space-between'
+          >
+            <Flex alignItems='center' gap={2}>
+              <TxHistoryIcon color='text.subtle' />
+              {translate('navBar.transactions')}
             </Flex>
-            <TabPanels>
-              <TabPanel px={0}>
-                <TxsByStatus txStatus={TxStatus.Pending} limit={limit} />
-              </TabPanel>
-              <TabPanel px={0}>
-                <TxsByStatus txStatus={TxStatus.Confirmed} limit={limit} />
-              </TabPanel>
-              <TabPanel px={0}>
-                <TxsByStatus txStatus={TxStatus.Failed} limit={limit} />
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
+
+            <Flex alignItems='center' gap={2} me={8}>
+              <RawText fontSize='sm' color='text.subtle'>
+                {translate('common.show')}
+              </RawText>
+              <Select
+                size='sm'
+                variant='filled'
+                value={limit}
+                onChange={handleSetLimit}
+                borderRadius='lg'
+                fontWeight='medium'
+              >
+                <option value='25'>25</option>
+                <option value='50'>50</option>
+                <option value='100'>100</option>
+              </Select>
+            </Flex>
+          </DrawerHeader>
+
+          <Box pe={2}>
+            <Box
+              overflow='auto'
+              height='calc(100vh - 70px - env(safe-area-inset-top))'
+              className='scroll-container'
+            >
+              <TxsByStatus txStatus='all' limit={limit} />
+            </Box>
+          </Box>
         </DrawerContent>
       </Drawer>
     </>

--- a/src/components/Layout/Header/TxWindow/TxWindow.tsx
+++ b/src/components/Layout/Header/TxWindow/TxWindow.tsx
@@ -18,7 +18,11 @@ import { CircularProgress } from '@/components/CircularProgress/CircularProgress
 import { TxHistoryIcon } from '@/components/Icons/TxHistory'
 import { RawText } from '@/components/Text'
 import { TransactionsGroupByDate } from '@/components/TransactionHistory/TransactionsGroupByDate'
-import { selectIsAnyTxHistoryApiQueryPending, selectTxIdsByFilter } from '@/state/slices/selectors'
+import {
+  selectIsAnyTxHistoryApiQueryPending,
+  selectTxIdsByFilter,
+  selectTxIdsByFilterWithPendingFirst,
+} from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
 const paddingProp = { base: 4, md: 6 }
@@ -33,7 +37,7 @@ export const TxsByStatus: React.FC<TxsByStatusProps> = ({ txStatus, limit }) => 
     () => ({ txStatus: txStatus === 'all' ? undefined : txStatus }),
     [txStatus],
   )
-  const txIds = useAppSelector(state => selectTxIdsByFilter(state, filter))
+  const txIds = useAppSelector(state => selectTxIdsByFilterWithPendingFirst(state, filter))
   const isAnyTxHistoryApiQueryPending = useAppSelector(selectIsAnyTxHistoryApiQueryPending)
   const limitTxIds = useMemo(() => {
     return txIds.slice(0, Number(limit))

--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -4,6 +4,7 @@ import { arbitrumChainId, fromAccountId } from '@shapeshiftoss/caip'
 import type { TxTransfer } from '@shapeshiftoss/chain-adapters'
 import type { AccountMetadata } from '@shapeshiftoss/types'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
 import intersection from 'lodash/intersection'
 import isEmpty from 'lodash/isEmpty'
 import pickBy from 'lodash/pickBy'
@@ -167,6 +168,25 @@ export const selectTxIdsByFilter = createCachedSelector(
         filter.assetId ?? 'assetId'
       }`
     : 'txIdsByFilter',
+)
+
+export const selectTxIdsByFilterWithPendingFirst = createCachedSelector(
+  selectTxs,
+  selectTxIdsByFilter,
+  (txs, filteredTxIds): TxId[] => {
+    return [...filteredTxIds].sort((a, b) => {
+      if (txs[a].status === TxStatus.Pending && txs[b].status !== TxStatus.Pending) return -1
+      if (txs[b].status === TxStatus.Pending && txs[a].status !== TxStatus.Pending) return 1
+
+      return 0
+    })
+  },
+)((_state: ReduxState, filter) =>
+  filter
+    ? `${filter.accountId ?? 'accountId'}-${filter.txStatus ?? 'txStatus'}-${
+        filter.assetId ?? 'assetId'
+      }`
+    : 'txIdsByFilterWithPendingFirst',
 )
 
 export const selectTxIdsBasedOnSearchTermAndFilters = createCachedSelector(

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -117,7 +117,6 @@ const styles = {
     },
     '.scroll-container': {
       visibility: 'hidden',
-      paddingRight: '12px',
       transition: 'visibility .5s ease-in-out',
     },
     '.scroll-container::-webkit-scrollbar': {


### PR DESCRIPTION
## Description
Remove tabs from the notification drawer, use only one, make sure pending TXs are always on top

leverage `.scroll-container` class to have a beautiful scrollbar instead of the system native one (don't worry windows user I'm here for you)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8982

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Open the notification drawer, it should be beautiful/working without tabs
- Try to do a swap (long swap like longtail with thorchain or rune to doge or BTC to ETH...)
- Pending TX should be on top of the list
- Bonus if you want you can do a fast TX after while waiting for the pending TX, the pending TX should stay on top of the list while the new completed TX should be under

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="418" alt="image" src="https://github.com/user-attachments/assets/ae865b5d-4059-4ef0-8d75-99dfe8413071" />
