### PR TITLE
fix: rFox APY rate

### DIFF
--- a/src/pages/RFOX/hooks/useCurrentApyQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentApyQuery.ts
@@ -49,7 +49,7 @@ export const useCurrentApyQuery = ({ stakingAssetId }: useCurrentApyQueryProps) 
       if (!stakingAsset) return
       if (!totalStakedCryptoCurrencyQuery?.data) return
 
-      const previousEpoch = epochs[epochs.length - 1]
+      const previousEpoch = epochs[0]
 
       const closestRunePrice = runePriceHistory.find(
         (price, index) =>
@@ -60,7 +60,7 @@ export const useCurrentApyQuery = ({ stakingAssetId }: useCurrentApyQueryProps) 
       const closestFoxPrice = stakingAssetPriceHistory.find(
         (price, index) =>
           price.date <= previousEpoch.endTimestamp &&
-          runePriceHistory[index + 1]?.date > previousEpoch.endTimestamp,
+          stakingAssetPriceHistory[index + 1]?.date > previousEpoch.endTimestamp,
       )
 
       const previousDistributionRate =


### PR DESCRIPTION
## Description
The rFox page, a key feature of the platform, has been incorrectly showing a 0% APY. The two APY display boxes are the highest contrast items on the page, which highlights their importance. File history suggests this bug has persisted since its inception 5 months ago, likely never working as intended. This fix corrects the container reference and order assumption to restore accurate APY display.

- `epochs[]` is sorted with the most recent first, so `previousEpoch` is at the start—not the end—breaking `closestRunePrice`. Adjusted to use the correct index.
- `closestFoxPrice` was pulling from `runePriceHistory` in `stakingAssetPriceHistory.find()`, likely a copy-paste error. Updated to reference the right data.

Tested locally—APY now displays accurately.

## Issue (if applicable)
closes #9045 
<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

## Risk

> High Risk PRs Require 2 approvals

Low risk, display only. Minimal changes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?
Impacts all that can view rFox page.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
Test by opening up the rFox page and checking that the rates do not display 0%. Rates should be functional regardless of user balances.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![apy_fixed](https://github.com/user-attachments/assets/219e54e0-43f6-4179-b735-c34d9ba6da17)

