### PR TITLE
fix: allow users to type 0 in limit inputs

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -53,6 +53,7 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
     onSelectedChainIdChange,
   }) => {
     const [isInputtingFiatSellAmount, setIsInputtingFiatSellAmount] = useState(false)
+    const [buyAmount, setBuyAmount] = useState<string | null>(null)
     const translate = useTranslate()
     const buyAssetSearch = useModal('buyTradeAssetSearch')
 
@@ -72,8 +73,9 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
 
     const handleAmountChange = useCallback(
       (value: string) => {
+        setBuyAmount(value)
+
         if (bnOrZero(sellAmountCryptoPrecision).gt(0)) {
-          // Convert value to crypto amount if it's in fiat
           const cryptoValue = isInputtingFiatSellAmount
             ? bnOrZero(value).div(marketData.price).toString()
             : value
@@ -142,8 +144,16 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         assetSymbol={asset.symbol}
         assetIcon={asset.icon}
         placeholder={isInputtingFiatSellAmount ? '$0' : '0'}
-        cryptoAmount={bnOrZero(buyAmountCryptoPrecision).isZero() ? '' : buyAmountCryptoPrecision}
-        fiatAmount={bnOrZero(buyAmountUserCurrency).isZero() ? '' : buyAmountUserCurrency}
+        cryptoAmount={
+          bnOrZero(buyAmountCryptoPrecision).isZero() && (buyAmount === '' || buyAmount === null)
+            ? ''
+            : buyAmountCryptoPrecision
+        }
+        fiatAmount={
+          bnOrZero(buyAmountUserCurrency).isZero() && (buyAmount === '' || buyAmount === null)
+            ? ''
+            : buyAmountUserCurrency
+        }
         percentOptions={emptyPercentOptions}
         isFiat={isInputtingFiatSellAmount}
         onToggleIsFiat={handleToggleIsFiat}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -135,6 +135,26 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
       ],
     )
 
+    const isUserTypedAmount = useMemo(() => {
+      return buyAmount !== '' && buyAmount !== null
+    }, [buyAmount])
+
+    const cryptoAmount = useMemo(() => {
+      if (bnOrZero(buyAmountCryptoPrecision).isZero() && !isUserTypedAmount) {
+        return ''
+      }
+
+      return buyAmountCryptoPrecision
+    }, [buyAmountCryptoPrecision, isUserTypedAmount])
+
+    const fiatAmount = useMemo(() => {
+      if (bnOrZero(buyAmountUserCurrency).isZero() && !isUserTypedAmount) {
+        return ''
+      }
+
+      return buyAmountUserCurrency
+    }, [buyAmountUserCurrency, isUserTypedAmount])
+
     return (
       <TradeAssetInput
         isAccountSelectionHidden={Boolean(manualReceiveAddress)}
@@ -144,16 +164,8 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         assetSymbol={asset.symbol}
         assetIcon={asset.icon}
         placeholder={isInputtingFiatSellAmount ? '$0' : '0'}
-        cryptoAmount={
-          bnOrZero(buyAmountCryptoPrecision).isZero() && (buyAmount === '' || buyAmount === null)
-            ? ''
-            : buyAmountCryptoPrecision
-        }
-        fiatAmount={
-          bnOrZero(buyAmountUserCurrency).isZero() && (buyAmount === '' || buyAmount === null)
-            ? ''
-            : buyAmountUserCurrency
-        }
+        cryptoAmount={cryptoAmount}
+        fiatAmount={fiatAmount}
         percentOptions={emptyPercentOptions}
         isFiat={isInputtingFiatSellAmount}
         onToggleIsFiat={handleToggleIsFiat}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -131,7 +131,6 @@ export const LimitOrderConfig = ({
 
   const handleInputChange = useCallback(
     (value: string | null, isFiatValue?: boolean) => {
-      console.log(value, 'handleInputChange')
       if (isFiatValue !== undefined) {
         setIsInputtingFiatSellAmount(isFiatValue)
       }
@@ -140,8 +139,6 @@ export const LimitOrderConfig = ({
       if (isInputtingFiatSellAmount || isFiatValue) {
         cryptoValue = bnOrZero(value).div(priceAssetMarketData.price).toFixed(priceAsset.precision)
       }
-
-      console.log(cryptoValue, 'cryptoValue')
 
       setLimitPriceMode(LimitPriceMode.CustomValue)
       setLimitPrice({ marketPriceBuyAsset: cryptoValue ?? '0' })

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -131,6 +131,7 @@ export const LimitOrderConfig = ({
 
   const handleInputChange = useCallback(
     (value: string | null, isFiatValue?: boolean) => {
+      console.log(value, 'handleInputChange')
       if (isFiatValue !== undefined) {
         setIsInputtingFiatSellAmount(isFiatValue)
       }
@@ -140,7 +141,8 @@ export const LimitOrderConfig = ({
         cryptoValue = bnOrZero(value).div(priceAssetMarketData.price).toFixed(priceAsset.precision)
       }
 
-      priceAmountRef.current = cryptoValue
+      console.log(cryptoValue, 'cryptoValue')
+
       setLimitPriceMode(LimitPriceMode.CustomValue)
       setLimitPrice({ marketPriceBuyAsset: cryptoValue ?? '0' })
     },

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -94,6 +94,14 @@ export const LimitOrderConfig = ({
   }, [limitPriceForSelectedPriceDirection, priceAsset.precision])
 
   const inputValue = useMemo(() => {
+    if (isInputtingFiatSellAmount) {
+      if (!fiatValue || (bnOrZero(fiatValue).isZero() && !priceAmountRef.current)) {
+        return ''
+      }
+
+      return bnOrZero(fiatValue).toFixed(2)
+    }
+
     if (
       !limitPriceForSelectedPriceDirection ||
       (bnOrZero(limitPriceForSelectedPriceDirection).isZero() && !priceAmountRef.current)
@@ -101,7 +109,13 @@ export const LimitOrderConfig = ({
       return ''
 
     return bnOrZero(limitPriceForSelectedPriceDirection).toFixed(priceAsset.precision)
-  }, [limitPriceForSelectedPriceDirection, priceAsset.precision])
+  }, [
+    limitPriceForSelectedPriceDirection,
+    priceAsset.precision,
+    fiatValue,
+    isInputtingFiatSellAmount,
+    priceAmountRef,
+  ])
 
   const handleSetPresetLimit = useCallback(
     (limitPriceMode: LimitPriceMode) => {
@@ -396,13 +410,7 @@ export const LimitOrderConfig = ({
               placeholder={isInputtingFiatSellAmount ? '$0' : '0'}
               suffix={isInputtingFiatSellAmount ? localeParts.postfix : ''}
               prefix={isInputtingFiatSellAmount ? localeParts.prefix : ''}
-              value={
-                isInputtingFiatSellAmount
-                  ? !fiatValue || (bnOrZero(fiatValue).isZero() && !priceAmountRef.current)
-                    ? ''
-                    : bnOrZero(fiatValue).toFixed(2)
-                  : inputValue
-              }
+              value={inputValue}
               onValueChange={handleValueChange}
               onChange={handleInputValueChange}
             />

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -94,7 +94,11 @@ export const LimitOrderConfig = ({
   }, [limitPriceForSelectedPriceDirection, priceAsset.precision])
 
   const inputValue = useMemo(() => {
-    if (bnOrZero(limitPriceForSelectedPriceDirection).isZero()) return ''
+    if (
+      !limitPriceForSelectedPriceDirection ||
+      (bnOrZero(limitPriceForSelectedPriceDirection).isZero() && !priceAmountRef.current)
+    )
+      return ''
 
     return bnOrZero(limitPriceForSelectedPriceDirection).toFixed(priceAsset.precision)
   }, [limitPriceForSelectedPriceDirection, priceAsset.precision])
@@ -395,7 +399,7 @@ export const LimitOrderConfig = ({
               prefix={isInputtingFiatSellAmount ? localeParts.prefix : ''}
               value={
                 isInputtingFiatSellAmount
-                  ? bnOrZero(fiatValue).isZero()
+                  ? !fiatValue || (bnOrZero(fiatValue).isZero() && !priceAmountRef.current)
                     ? ''
                     : bnOrZero(fiatValue).toFixed(2)
                   : inputValue


### PR DESCRIPTION
## Description

Users couldn't input 0 in limit orders inputs, it's particularly boring if you are dealing with high prices assets such as ETH

I used the ref in LimitOrderConfig to allow for user input, and added another state variable in `LimitOrderBuyAsset` to conditionally use the amount or the user-typed amount so we could allow users to type `0`, `0.` and other types of amounts

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9050

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to play with the limit order inputs
- Try to empty the input, then type 0, then type 0.12, etc etc
- Try to switch between fiat amounts and crypto amounts

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/1192e012-ccf3-46cc-8017-6f0552b6aaee