### PR TITLE
feat: make limit order better

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -244,7 +244,7 @@ export const LimitOrderConfig = ({
     handleInputChange(priceAmountRef.current)
   }, [handleInputChange])
 
-  const receiveAmount = useMemo(() => {
+  const receiveAmountFormatted = useMemo(() => {
     if (
       bnOrZero(sellAmountCryptoPrecision).isZero() ||
       bnOrZero(limitPrice.buyAssetDenomination).isZero()
@@ -253,11 +253,23 @@ export const LimitOrderConfig = ({
     }
 
     if (priceDirection === PriceDirection.BuyAssetDenomination) {
-      return bnOrZero(sellAmountCryptoPrecision).times(limitPrice.buyAssetDenomination).toString()
+      return bnOrZero(sellAmountCryptoPrecision)
+        .times(limitPrice.buyAssetDenomination)
+        .decimalPlaces(buyAsset.precision)
+        .toString()
     }
 
-    return bnOrZero(sellAmountCryptoPrecision).div(limitPrice.sellAssetDenomination).toString()
-  }, [limitPrice, priceDirection, sellAmountCryptoPrecision])
+    return bnOrZero(sellAmountCryptoPrecision)
+      .div(limitPrice.sellAssetDenomination)
+      .decimalPlaces(sellAsset.precision)
+      .toString()
+  }, [
+    limitPrice,
+    priceDirection,
+    sellAmountCryptoPrecision,
+    buyAsset.precision,
+    sellAsset.precision,
+  ])
 
   const limitOrderExplanation = useMemo(() => {
     if (
@@ -311,7 +323,7 @@ export const LimitOrderConfig = ({
           color='white'
           ml={1}
           fontWeight='medium'
-          value={receiveAmount}
+          value={receiveAmountFormatted}
           symbol={buyAsset.symbol}
           omitDecimalTrailingZeros
         />
@@ -326,7 +338,7 @@ export const LimitOrderConfig = ({
     sellAsset.symbol,
     buyAsset.symbol,
     priceAsset.symbol,
-    receiveAmount,
+    receiveAmountFormatted,
   ])
 
   const marketPriceCryptoPrecision = useMemo(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -65,7 +65,7 @@ import {
 import { makeLimitInputOutputRatio } from '@/state/slices/limitOrderSlice/helpers'
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
 import { selectActiveQuoteNetworkFeeUserCurrency } from '@/state/slices/limitOrderSlice/selectors'
-import { useFindByAssetIdQuery } from '@/state/slices/marketDataSlice/marketDataSlice'
+import { useFindMarketDataByAssetIdQuery } from '@/state/slices/marketDataSlice/marketDataSlice'
 import {
   selectIsAnyAccountMetadataLoadedForChainId,
   selectUsdRateByAssetId,
@@ -241,11 +241,11 @@ export const LimitOrderInput = ({
     isFetching: isLimitOrderQuoteFetching,
   } = useQuoteLimitOrderQuery(limitOrderQuoteParams)
 
-  useFindByAssetIdQuery(sellAsset.assetId, {
+  useFindMarketDataByAssetIdQuery(sellAsset.assetId, {
     pollingInterval: MARKET_DATA_POLLING_INTERVAL,
   })
 
-  useFindByAssetIdQuery(buyAsset.assetId, {
+  useFindMarketDataByAssetIdQuery(buyAsset.assetId, {
     pollingInterval: MARKET_DATA_POLLING_INTERVAL,
   })
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -66,7 +66,6 @@ import { makeLimitInputOutputRatio } from '@/state/slices/limitOrderSlice/helper
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
 import { selectActiveQuoteNetworkFeeUserCurrency } from '@/state/slices/limitOrderSlice/selectors'
 import { useFindByAssetIdQuery } from '@/state/slices/marketDataSlice/marketDataSlice'
-import { selectMarketDataUsd } from '@/state/slices/marketDataSlice/selectors'
 import {
   selectIsAnyAccountMetadataLoadedForChainId,
   selectUsdRateByAssetId,
@@ -250,18 +249,22 @@ export const LimitOrderInput = ({
     pollingInterval: MARKET_DATA_POLLING_INTERVAL,
   })
 
-  const sellAssetMarketData = useAppSelector(state => selectMarketDataUsd(state)[sellAsset.assetId])
-  const buyAssetMarketData = useAppSelector(state => selectMarketDataUsd(state)[buyAsset.assetId])
+  const sellAssetMarketDataUsd = useAppSelector(state =>
+    selectUsdRateByAssetId(state, sellAsset.assetId),
+  )
+  const buyAssetMarketDataUsd = useAppSelector(state =>
+    selectUsdRateByAssetId(state, buyAsset.assetId),
+  )
 
   const marketPriceBuyAsset = useMemo(() => {
-    if (!(sellAssetMarketData?.price && buyAssetMarketData?.price)) return '0'
+    if (!(sellAssetMarketDataUsd && buyAssetMarketDataUsd)) return '0'
 
     return makeLimitInputOutputRatio({
-      sellPriceUsd: sellAssetMarketData.price,
-      buyPriceUsd: buyAssetMarketData.price,
+      sellPriceUsd: sellAssetMarketDataUsd,
+      buyPriceUsd: buyAssetMarketDataUsd,
       targetAssetPrecision: buyAsset.precision,
     })
-  }, [sellAssetMarketData, buyAssetMarketData, buyAsset])
+  }, [sellAssetMarketDataUsd, buyAssetMarketDataUsd, buyAsset])
 
   // Update the limit price when the market price changes.
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -62,9 +62,11 @@ import {
   selectSellAccountId,
   selectSellAssetBalanceCryptoBaseUnit,
 } from '@/state/slices/limitOrderInputSlice/selectors'
-import { calcLimitPriceBuyAsset } from '@/state/slices/limitOrderSlice/helpers'
+import { makeLimitInputOutputRatio } from '@/state/slices/limitOrderSlice/helpers'
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
 import { selectActiveQuoteNetworkFeeUserCurrency } from '@/state/slices/limitOrderSlice/selectors'
+import { useFindByAssetIdQuery } from '@/state/slices/marketDataSlice/marketDataSlice'
+import { selectMarketDataUsd } from '@/state/slices/marketDataSlice/selectors'
 import {
   selectIsAnyAccountMetadataLoadedForChainId,
   selectUsdRateByAssetId,
@@ -83,6 +85,8 @@ type LimitOrderInputProps = {
   onChangeTab: (newTab: TradeInputTab) => void
   noExpand?: boolean
 }
+
+const MARKET_DATA_POLLING_INTERVAL = 10_000
 
 export const LimitOrderInput = ({
   isCompact,
@@ -238,26 +242,26 @@ export const LimitOrderInput = ({
     isFetching: isLimitOrderQuoteFetching,
   } = useQuoteLimitOrderQuery(limitOrderQuoteParams)
 
-  const marketPriceBuyAsset = useMemo(() => {
-    // Ensure we zero out the price if there is an error, and when we are fetching, as `quoteResponse` will be stale data in both cases
-    if (isLimitOrderQuoteFetching || quoteResponseError) return '0'
-    // RTK query returns stale data when `skipToken` is used, so we need to handle that case here.
-    if (!quoteResponse || limitOrderQuoteParams === skipToken) return '0'
+  useFindByAssetIdQuery(sellAsset.assetId, {
+    pollingInterval: MARKET_DATA_POLLING_INTERVAL,
+  })
 
-    return calcLimitPriceBuyAsset({
-      sellAmountCryptoBaseUnit: quoteResponse.quote.sellAmount,
-      buyAmountCryptoBaseUnit: quoteResponse.quote.buyAmount,
-      sellAsset,
-      buyAsset,
+  useFindByAssetIdQuery(buyAsset.assetId, {
+    pollingInterval: MARKET_DATA_POLLING_INTERVAL,
+  })
+
+  const sellAssetMarketData = useAppSelector(state => selectMarketDataUsd(state)[sellAsset.assetId])
+  const buyAssetMarketData = useAppSelector(state => selectMarketDataUsd(state)[buyAsset.assetId])
+
+  const marketPriceBuyAsset = useMemo(() => {
+    if (!(sellAssetMarketData?.price && buyAssetMarketData?.price)) return '0'
+
+    return makeLimitInputOutputRatio({
+      sellPriceUsd: sellAssetMarketData.price,
+      buyPriceUsd: buyAssetMarketData.price,
+      targetAssetPrecision: buyAsset.precision,
     })
-  }, [
-    isLimitOrderQuoteFetching,
-    quoteResponseError,
-    quoteResponse,
-    limitOrderQuoteParams,
-    sellAsset,
-    buyAsset,
-  ])
+  }, [sellAssetMarketData, buyAssetMarketData, buyAsset])
 
   // Update the limit price when the market price changes.
   useEffect(() => {
@@ -376,7 +380,6 @@ export const LimitOrderInput = ({
   const isLoading = useMemo(() => {
     return (
       isCheckingAllowance ||
-      isLimitOrderQuoteFetching ||
       // No account meta loaded for that chain
       !isAnyAccountMetadataLoadedForChainId ||
       (!shouldShowTradeQuoteOrAwaitInput && !isTradeQuoteRequestAborted) ||
@@ -388,7 +391,6 @@ export const LimitOrderInput = ({
   }, [
     isCheckingAllowance,
     isAnyAccountMetadataLoadedForChainId,
-    isLimitOrderQuoteFetching,
     isTradeQuoteRequestAborted,
     isVotingPowerLoading,
     shouldShowTradeQuoteOrAwaitInput,
@@ -538,7 +540,7 @@ export const LimitOrderInput = ({
         hasUserEnteredAmount={hasUserEnteredAmount}
         inputAmountUsd={inputSellAmountUsd}
         isError={isError}
-        isLoading={isLoading}
+        isLoading={isLimitOrderQuoteFetching}
         quoteStatusTranslation={quoteStatusTranslation}
         rate={limitPrice.buyAssetDenomination}
         marketRate={marketPriceBuyAsset}
@@ -573,7 +575,6 @@ export const LimitOrderInput = ({
     hasUserEnteredAmount,
     inputSellAmountUsd,
     isError,
-    isLoading,
     quoteStatusTranslation,
     limitPrice.buyAssetDenomination,
     marketPriceBuyAsset,
@@ -582,6 +583,7 @@ export const LimitOrderInput = ({
     networkFeeUserCurrency,
     renderedRecipientAddress,
     noExpand,
+    isLimitOrderQuoteFetching,
   ])
 
   return (

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -123,7 +123,7 @@ export const SharedTradeInputFooter = ({
             isDisabled={shouldDisableGasRateRowClick}
             rate={rate}
             deltaPercentage={deltaPercentage?.toString()}
-            isLoading={isLoading}
+            isLoading={isLoading && !rate}
             networkFeeFiatUserCurrency={networkFeeFiatUserCurrency}
             swapperName={swapperName}
             swapSource={swapSource}
@@ -156,8 +156,8 @@ export const SharedTradeInputFooter = ({
         {children}
 
         <ButtonWalletPredicate
-          isLoading={isAccountsMetadataLoading && !sellAccountId}
-          loadingText={buttonText}
+          isLoading={isLoading || (isAccountsMetadataLoading && !sellAccountId)}
+          loadingText={isLoading ? undefined : buttonText}
           type='submit'
           colorScheme={isError ? 'red' : 'blue'}
           size='lg-multiline'

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -20,7 +20,7 @@ import { snapshotApi } from '@/state/apis/snapshot/snapshot'
 import {
   marketApi,
   marketData,
-  useFindAllQuery,
+  useFindAllMarketDataQuery,
 } from '@/state/slices/marketDataSlice/marketDataSlice'
 import { portfolio } from '@/state/slices/portfolioSlice/portfolioSlice'
 import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
@@ -90,7 +90,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   // load top 1000 assets market data
   // this is needed to sort assets by market cap
   // and covers most assets users will have
-  useFindAllQuery()
+  useFindAllMarketDataQuery()
 
   // Master hook for accounts fetch as a react-query
   useAccountsFetchQuery()

--- a/src/state/slices/limitOrderSlice/helpers.ts
+++ b/src/state/slices/limitOrderSlice/helpers.ts
@@ -22,7 +22,7 @@ export const buildUnsignedLimitOrder = ({
   }
 }
 
-export const calcLimitPriceBuyAsset = ({
+export const calcLimitPriceTargetAsset = ({
   sellAmountCryptoBaseUnit,
   buyAmountCryptoBaseUnit,
   sellAsset,
@@ -36,4 +36,18 @@ export const calcLimitPriceBuyAsset = ({
   return bnOrZero(fromBaseUnit(buyAmountCryptoBaseUnit, buyAsset.precision))
     .div(fromBaseUnit(sellAmountCryptoBaseUnit, sellAsset.precision))
     .toFixed()
+}
+
+export const makeLimitInputOutputRatio = ({
+  sellPriceUsd,
+  buyPriceUsd,
+  targetAssetPrecision,
+}: {
+  sellPriceUsd: string
+  buyPriceUsd: string
+  targetAssetPrecision: number
+}): string => {
+  const ratio = bnOrZero(buyPriceUsd).div(bnOrZero(sellPriceUsd))
+
+  return ratio.toFixed(targetAssetPrecision)
 }

--- a/src/state/slices/limitOrderSlice/selectors.ts
+++ b/src/state/slices/limitOrderSlice/selectors.ts
@@ -9,7 +9,7 @@ import {
   selectMarketDataUsd,
   selectUserCurrencyToUsdRate,
 } from '../selectors'
-import { calcLimitPriceBuyAsset } from './helpers'
+import { calcLimitPriceTargetAsset } from './helpers'
 import type { LimitOrderState, LimitOrderSubmissionMetadata } from './types'
 
 import type { ReduxState } from '@/state/reducer'
@@ -169,7 +169,7 @@ export const selectActiveQuoteLimitPrice = createSelector(
   (sellAmountCryptoBaseUnit, buyAmountCryptoBaseUnit, sellAsset, buyAsset) => {
     if (!sellAsset || !buyAsset) return
 
-    const marketPriceBuyAsset = calcLimitPriceBuyAsset({
+    const marketPriceBuyAsset = calcLimitPriceTargetAsset({
       sellAmountCryptoBaseUnit,
       buyAmountCryptoBaseUnit,
       sellAsset,

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -250,5 +250,8 @@ export const marketApi = createApi({
   }),
 })
 
-export const { useFindAllQuery, useFindPriceHistoryByAssetIdQuery, useFindByAssetIdQuery } =
-  marketApi
+export const {
+  useFindAllQuery: useFindAllMarketDataQuery,
+  useFindPriceHistoryByAssetIdQuery,
+  useFindByAssetIdQuery: useFindMarketDataByAssetIdQuery,
+} = marketApi

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -250,4 +250,5 @@ export const marketApi = createApi({
   }),
 })
 
-export const { useFindAllQuery, useFindPriceHistoryByAssetIdQuery } = marketApi
+export const { useFindAllQuery, useFindPriceHistoryByAssetIdQuery, useFindByAssetIdQuery } =
+  marketApi


### PR DESCRIPTION
## Description

This PR:

- decouples loading state and quote fetching (only blocking confirm button now)
- ensures we refetch market-data at interval
- improves loading state so that things are reactive immediately, so long as we have market-data

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8999

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure there are now no loading states on inputs, relevant derived amounts, and rate/gas row
- Sanity check the EIP-712 data (by e.g using Rabby or MM) and ensure that the `buyAmount` and `sellAmount` are matching what we display

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/010a5c1b-de7f-4659-b2e9-1af603f173ee


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
