### PR TITLE
fix: reset sell amount on standalone swapper mount

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -185,6 +185,14 @@ export const TradeInput = ({
     dispatch(tradeQuoteSlice.actions.clearTradeQuotes())
   }, [dispatch])
 
+  // Reset the sell amount to zero on mount if this is a standalone swapper, since we may be coming from a different
+  // sell asset in regular swapper
+  useEffect(() => {
+    if (isStandalone) {
+      dispatch(tradeInput.actions.setSellAmountCryptoPrecision('0'))
+    }
+  }, [dispatch, isStandalone])
+
   useEffect(() => {
     // Reset the trade warning if the active quote has changed, i.e. a better quote has come in and the
     // user has not yet confirmed the previous one


### PR DESCRIPTION
## Description

... precisely for the reason stated in the comment, unless a swapper pair/amounts reset happens (which does for e.g BTC), then the previous crypto sell amount will be used for the new default pair in standalone swapper.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9047

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Input some sell amount in regular swapper e.g 2 FOX on any chain
- Select another asset e.g USDC on Base/USDC on mainnet in asset search
- Ensure amount resets to zero on mini swapper

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/899f6aa4-662f-4ac6-8092-745e861b9119

- this diff

https://jam.dev/c/2401bfeb-7717-42c7-a6fb-d34d7b2b4658


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
