### PR TITLE
chore: release v1.792.0

### DIFF
--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeQuote/getPortalsTradeQuote.ts
@@ -259,7 +259,8 @@ export async function getPortalsTradeQuote(
             },
           },
           source: SwapperName.Portals,
-          estimatedExecutionTimeMs: undefined, // Portals doesn't provide this info
+          // Assume instant execution since this is a same-chain AMM Tx which will happen within the same block
+          estimatedExecutionTimeMs: 0,
           portalsTransactionMetadata: tx,
         },
       ] as SingleHopTradeQuoteSteps,

--- a/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeRate/getPortalsTradeRate.tsx
+++ b/packages/swapper/src/swappers/PortalsSwapper/getPortalsTradeRate/getPortalsTradeRate.tsx
@@ -148,7 +148,8 @@ export async function getPortalsTradeRate(
       swapperName: SwapperName.Portals,
       steps: [
         {
-          estimatedExecutionTimeMs: undefined, // Portals doesn't provide this info
+          // Assume instant execution since this is a same-chain AMM Tx which will happen within the same block
+          estimatedExecutionTimeMs: 0,
           allowanceContract,
           accountNumber,
           rate: inputOutputRate,

--- a/packages/swapper/src/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
+++ b/packages/swapper/src/swappers/ZrxSwapper/getZrxTradeQuote/getZrxTradeQuote.ts
@@ -137,7 +137,8 @@ export async function getZrxTradeQuote(
       swapperName: SwapperName.Zrx,
       steps: [
         {
-          estimatedExecutionTimeMs: undefined,
+          // Assume instant execution since this is a same-chain AMM Tx which will happen within the same block
+          estimatedExecutionTimeMs: 0,
           allowanceContract:
             isNativeEvmAsset(sellAsset.assetId) || isWrappedNative ? undefined : PERMIT2_CONTRACT,
           buyAsset,

--- a/packages/swapper/src/swappers/ZrxSwapper/getZrxTradeRate/getZrxTradeRate.ts
+++ b/packages/swapper/src/swappers/ZrxSwapper/getZrxTradeRate/getZrxTradeRate.ts
@@ -85,7 +85,8 @@ export async function getZrxTradeRate(
     swapperName: SwapperName.Zrx,
     steps: [
       {
-        estimatedExecutionTimeMs: undefined,
+        // Assume instant execution since this is a same-chain AMM Tx which will happen within the same block
+        estimatedExecutionTimeMs: 0,
         allowanceContract:
           isNativeEvmAsset(sellAsset.assetId) || isWrappedNative ? undefined : PERMIT2_CONTRACT,
         buyAsset,

--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -25,6 +25,8 @@ import { makeSuspenseful } from '@/utils/makeSuspenseful'
 
 export const TRADE_ROUTE_ASSET_SPECIFIC =
   '/trade/:chainId/:assetSubId/:sellChainId/:sellAssetSubId/:sellAmountCryptoBaseUnit'
+export const LIMIT_ORDER_ROUTE_ASSET_SPECIFIC =
+  '/limit/:chainId/:assetSubId/:sellChainId/:sellAssetSubId/:sellAmountCryptoBaseUnit'
 
 const Home = makeSuspenseful(
   lazy(() =>
@@ -296,6 +298,11 @@ export const routes: Route[] = [
     hideDesktop: true,
     main: Trade,
     routes: [
+      {
+        path: LIMIT_ORDER_ROUTE_ASSET_SPECIFIC,
+        main: Trade,
+        hide: true,
+      },
       {
         path: LimitOrderRoutePaths.Confirm,
         main: Trade,

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -900,6 +900,7 @@
     "thisIsYourCustomRecipientAddress": "This is your custom recipient address",
     "enterCustomRecipientAddress": "Enter custom recipient address",
     "receiveAtLeast": "Receive at least",
+    "viewOnBlockExplorer": "View on block explorer",
     "tooltip": {
       "continueSwapping": "Continue swapping for final details",
       "changeQuote": "Change quote",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -847,6 +847,14 @@
       "warning": "High slippage tolerances can result in unfavorable trades.",
       "lowSlippage": "Slippage below 0.05% may result in a failed transaction."
     },
+    "sort": {
+      "sortBy": "Sort By",
+      "auto": "Auto",
+      "bestRate": "Best Rate",
+      "lowestGas": "Lowest Gas",
+      "fastest": "Fastest",
+      "info": "Choose how to sort available quotes"
+    },
     "from": "From",
     "to": "To",
     "on": "on",

--- a/src/components/Layout/Header/TxWindow/TxWindow.tsx
+++ b/src/components/Layout/Header/TxWindow/TxWindow.tsx
@@ -1,4 +1,3 @@
-import type { TabProps } from '@chakra-ui/react'
 import {
   Box,
   Circle,
@@ -10,11 +9,6 @@ import {
   Flex,
   IconButton,
   Select,
-  Tab,
-  TabList,
-  TabPanel,
-  TabPanels,
-  Tabs,
 } from '@chakra-ui/react'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import React, { memo, useCallback, useMemo, useState } from 'react'
@@ -24,32 +18,26 @@ import { CircularProgress } from '@/components/CircularProgress/CircularProgress
 import { TxHistoryIcon } from '@/components/Icons/TxHistory'
 import { RawText } from '@/components/Text'
 import { TransactionsGroupByDate } from '@/components/TransactionHistory/TransactionsGroupByDate'
-import { selectIsAnyTxHistoryApiQueryPending, selectTxIdsByFilter } from '@/state/slices/selectors'
+import {
+  selectIsAnyTxHistoryApiQueryPending,
+  selectTxIdsByFilter,
+  selectTxIdsByFilterWithPendingFirst,
+} from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
 const paddingProp = { base: 4, md: 6 }
-const selectedProp = { color: 'text.base' }
-const hoverProp = { cursor: 'pointer' }
 
-const CustomTab: React.FC<TabProps> = props => (
-  <Tab
-    px={0}
-    fontWeight='medium'
-    color='text.subtle'
-    cursor='pointer'
-    _selected={selectedProp}
-    _hover={hoverProp}
-    {...props}
-  />
-)
 type TxsByStatusProps = {
-  txStatus: TxStatus
+  txStatus: TxStatus | 'all'
   limit: string
 }
 export const TxsByStatus: React.FC<TxsByStatusProps> = ({ txStatus, limit }) => {
   const translate = useTranslate()
-  const filter = useMemo(() => ({ txStatus }), [txStatus])
-  const txIds = useAppSelector(state => selectTxIdsByFilter(state, filter))
+  const filter = useMemo(
+    () => ({ txStatus: txStatus === 'all' ? undefined : txStatus }),
+    [txStatus],
+  )
+  const txIds = useAppSelector(state => selectTxIdsByFilterWithPendingFirst(state, filter))
   const isAnyTxHistoryApiQueryPending = useAppSelector(selectIsAnyTxHistoryApiQueryPending)
   const limitTxIds = useMemo(() => {
     return txIds.slice(0, Number(limit))
@@ -110,63 +98,49 @@ export const TxWindow = memo(() => {
       </Box>
       <Drawer isOpen={isOpen} onClose={handleClose} size='sm'>
         <DrawerOverlay backdropBlur='10px' />
-        <DrawerContent
-          minHeight='100vh'
-          maxHeight='100vh'
-          overflow='auto'
-          paddingTop='env(safe-area-inset-top)'
-        >
-          <DrawerCloseButton top='calc(var(--chakra-space-2) + env(safe-area-inset-top))' />
-          <DrawerHeader px={paddingProp} display='flex' alignItems='center' gap={2}>
-            <TxHistoryIcon color='text.subtle' />
-            {translate('navBar.transactions')}
-          </DrawerHeader>
-          <Tabs variant='unstyled' isLazy>
-            <Flex
-              gap={4}
-              justifyContent='space-between'
-              px={paddingProp}
-              bg='background.surface.overlay.base'
-              position='sticky'
-              top={0}
-              py={2}
-              zIndex='banner'
-            >
-              <TabList gap={4}>
-                <CustomTab>{translate('transactionRow.pending')}</CustomTab>
-                <CustomTab>{translate('transactionRow.confirmed')}</CustomTab>
-                <CustomTab>{translate('transactionRow.failed')}</CustomTab>
-              </TabList>
-              <Flex alignItems='center' gap={2}>
-                <RawText fontSize='sm' color='text.subtle'>
-                  {translate('common.show')}
-                </RawText>
-                <Select
-                  size='sm'
-                  variant='filled'
-                  value={limit}
-                  onChange={handleSetLimit}
-                  borderRadius='lg'
-                  fontWeight='medium'
-                >
-                  <option value='25'>25</option>
-                  <option value='50'>50</option>
-                  <option value='100'>100</option>
-                </Select>
-              </Flex>
+
+        <DrawerContent minHeight='100vh' maxHeight='100vh' paddingTop='env(safe-area-inset-top)'>
+          <DrawerCloseButton top='calc(18px + env(safe-area-inset-top))' />
+          <DrawerHeader
+            px={paddingProp}
+            display='flex'
+            alignItems='center'
+            gap={2}
+            justifyContent='space-between'
+          >
+            <Flex alignItems='center' gap={2}>
+              <TxHistoryIcon color='text.subtle' />
+              {translate('navBar.transactions')}
             </Flex>
-            <TabPanels>
-              <TabPanel px={0}>
-                <TxsByStatus txStatus={TxStatus.Pending} limit={limit} />
-              </TabPanel>
-              <TabPanel px={0}>
-                <TxsByStatus txStatus={TxStatus.Confirmed} limit={limit} />
-              </TabPanel>
-              <TabPanel px={0}>
-                <TxsByStatus txStatus={TxStatus.Failed} limit={limit} />
-              </TabPanel>
-            </TabPanels>
-          </Tabs>
+
+            <Flex alignItems='center' gap={2} me={8}>
+              <RawText fontSize='sm' color='text.subtle'>
+                {translate('common.show')}
+              </RawText>
+              <Select
+                size='sm'
+                variant='filled'
+                value={limit}
+                onChange={handleSetLimit}
+                borderRadius='lg'
+                fontWeight='medium'
+              >
+                <option value='25'>25</option>
+                <option value='50'>50</option>
+                <option value='100'>100</option>
+              </Select>
+            </Flex>
+          </DrawerHeader>
+
+          <Box pe={2}>
+            <Box
+              overflow='auto'
+              height='calc(100vh - 70px - env(safe-area-inset-top))'
+              className='scroll-container'
+            >
+              <TxsByStatus txStatus='all' limit={limit} />
+            </Box>
+          </Box>
         </DrawerContent>
       </Drawer>
     </>

--- a/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/LimitOrder.tsx
@@ -1,6 +1,6 @@
 import { Flex } from '@chakra-ui/react'
-import { useCallback } from 'react'
-import { Route, Switch, useLocation } from 'react-router-dom'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { matchPath, Route, Switch, useHistory, useLocation } from 'react-router-dom'
 
 import { LimitOrderConfirm as LimitOrderShared } from '../LimitOrderV2/LimitOrderConfirm'
 import { SlideTransitionRoute } from '../SlideTransitionRoute'
@@ -13,16 +13,110 @@ import { LimitOrderRoutePaths } from './types'
 
 import type { TradeInputTab } from '@/components/MultiHopTrade/types'
 import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
+import { fromBaseUnit } from '@/lib/math'
+import type { TradeRouterMatchParams } from '@/pages/Trade/types'
+import { LIMIT_ORDER_ROUTE_ASSET_SPECIFIC } from '@/Routes/RoutesCommon'
+import { selectAssetById } from '@/state/slices/assetsSlice/selectors'
+import { limitOrderInput } from '@/state/slices/limitOrderInputSlice/limitOrderInputSlice'
+import {
+  selectInputBuyAsset,
+  selectInputSellAmountCryptoBaseUnit,
+  selectInputSellAsset,
+} from '@/state/slices/limitOrderInputSlice/selectors'
+import { useAppDispatch, useAppSelector } from '@/state/store'
 
 type LimitOrderProps = {
   tradeInputRef: React.MutableRefObject<HTMLDivElement | null>
   isCompact?: boolean
+  isRewritingUrl?: boolean
+  defaultBuyAssetId?: string
+  defaultSellAssetId?: string
   onChangeTab: (newTab: TradeInputTab) => void
 }
 
-export const LimitOrder = ({ isCompact, tradeInputRef, onChangeTab }: LimitOrderProps) => {
+export const LimitOrder = ({
+  isCompact,
+  isRewritingUrl,
+  defaultBuyAssetId,
+  defaultSellAssetId,
+  tradeInputRef,
+  onChangeTab,
+}: LimitOrderProps) => {
   const location = useLocation()
+  const history = useHistory()
+  const dispatch = useAppDispatch()
   const isNewLimitFlowEnabled = useFeatureFlag('NewLimitFlow')
+  const [isInitialized, setIsInitialized] = useState(false)
+
+  const match = useMemo(
+    () =>
+      matchPath<TradeRouterMatchParams>(location.pathname, {
+        path: LIMIT_ORDER_ROUTE_ASSET_SPECIFIC,
+        exact: true,
+      }),
+    [location.pathname],
+  )
+
+  const { chainId, assetSubId, sellChainId, sellAssetSubId, sellAmountCryptoBaseUnit } =
+    match?.params || {}
+
+  // Get the necessary state for URL rewriting
+  const buyAsset = useAppSelector(selectInputBuyAsset)
+  const sellAsset = useAppSelector(selectInputSellAsset)
+  const sellInputAmountCryptoBaseUnit = useAppSelector(selectInputSellAmountCryptoBaseUnit)
+
+  const buyAssetId = useMemo(() => {
+    if (defaultBuyAssetId) return defaultBuyAssetId
+    if (chainId && assetSubId) return `${chainId}/${assetSubId}`
+  }, [defaultBuyAssetId, chainId, assetSubId])
+
+  const sellAssetId = useMemo(() => {
+    if (defaultSellAssetId) return defaultSellAssetId
+    if (sellChainId && sellAssetSubId) return `${sellChainId}/${sellAssetSubId}`
+  }, [defaultSellAssetId, sellChainId, sellAssetSubId])
+
+  const routeSellAsset = useAppSelector(state => selectAssetById(state, sellAssetId ?? ''))
+  const routeBuyAsset = useAppSelector(state => selectAssetById(state, buyAssetId ?? ''))
+
+  // Initialize state from URL params
+  useEffect(() => {
+    if (isInitialized) return
+
+    if (routeBuyAsset) {
+      dispatch(limitOrderInput.actions.setBuyAsset(routeBuyAsset))
+    }
+
+    if (routeSellAsset) {
+      dispatch(limitOrderInput.actions.setSellAsset(routeSellAsset))
+    }
+
+    if (sellAmountCryptoBaseUnit && routeSellAsset) {
+      dispatch(
+        limitOrderInput.actions.setSellAmountCryptoPrecision(
+          fromBaseUnit(sellAmountCryptoBaseUnit, routeSellAsset.precision),
+        ),
+      )
+    }
+
+    setIsInitialized(true)
+  }, [dispatch, routeBuyAsset, routeSellAsset, sellAmountCryptoBaseUnit, isInitialized])
+
+  // Implement URL rewriting logic
+  useEffect(() => {
+    if (isRewritingUrl && isInitialized && buyAsset && sellAsset) {
+      const sellAmountBaseUnit = sellInputAmountCryptoBaseUnit ?? sellAmountCryptoBaseUnit ?? ''
+
+      history.push(`/limit/${buyAsset.assetId}/${sellAsset.assetId}/${sellAmountBaseUnit ?? ''}`)
+    }
+  }, [
+    isInitialized,
+    isRewritingUrl,
+    buyAsset,
+    sellAsset,
+    history,
+    sellInputAmountCryptoBaseUnit,
+    sellAmountCryptoBaseUnit,
+  ])
 
   const renderLimitOrderInput = useCallback(() => {
     return (
@@ -52,8 +146,8 @@ export const LimitOrder = ({ isCompact, tradeInputRef, onChangeTab }: LimitOrder
   }, [isCompact])
 
   return (
-    <Switch location={location}>
-      <Flex flex={1} width='full' justifyContent='center'>
+    <Flex flex={1} width='full' justifyContent='center'>
+      <Switch location={location}>
         <Route
           key={LimitOrderRoutePaths.Confirm}
           path={LimitOrderRoutePaths.Confirm}
@@ -80,10 +174,9 @@ export const LimitOrder = ({ isCompact, tradeInputRef, onChangeTab }: LimitOrder
         <Route
           key={LimitOrderRoutePaths.Input}
           path={LimitOrderRoutePaths.Input}
-          exact
           render={renderLimitOrderInput}
         />
-      </Flex>
-    </Switch>
+      </Switch>
+    </Flex>
   )
 }

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -53,6 +53,7 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
     onSelectedChainIdChange,
   }) => {
     const [isInputtingFiatSellAmount, setIsInputtingFiatSellAmount] = useState(false)
+    const [buyAmount, setBuyAmount] = useState<string | null>(null)
     const translate = useTranslate()
     const buyAssetSearch = useModal('buyTradeAssetSearch')
 
@@ -72,8 +73,9 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
 
     const handleAmountChange = useCallback(
       (value: string) => {
+        setBuyAmount(value)
+
         if (bnOrZero(sellAmountCryptoPrecision).gt(0)) {
-          // Convert value to crypto amount if it's in fiat
           const cryptoValue = isInputtingFiatSellAmount
             ? bnOrZero(value).div(marketData.price).toString()
             : value
@@ -133,6 +135,26 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
       ],
     )
 
+    const isUserTypedAmount = useMemo(() => {
+      return buyAmount !== '' && buyAmount !== null
+    }, [buyAmount])
+
+    const cryptoAmount = useMemo(() => {
+      if (bnOrZero(buyAmountCryptoPrecision).isZero() && !isUserTypedAmount) {
+        return ''
+      }
+
+      return buyAmountCryptoPrecision
+    }, [buyAmountCryptoPrecision, isUserTypedAmount])
+
+    const fiatAmount = useMemo(() => {
+      if (bnOrZero(buyAmountUserCurrency).isZero() && !isUserTypedAmount) {
+        return ''
+      }
+
+      return buyAmountUserCurrency
+    }, [buyAmountUserCurrency, isUserTypedAmount])
+
     return (
       <TradeAssetInput
         isAccountSelectionHidden={Boolean(manualReceiveAddress)}
@@ -142,8 +164,8 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         assetSymbol={asset.symbol}
         assetIcon={asset.icon}
         placeholder={isInputtingFiatSellAmount ? '$0' : '0'}
-        cryptoAmount={bnOrZero(buyAmountCryptoPrecision).isZero() ? '' : buyAmountCryptoPrecision}
-        fiatAmount={bnOrZero(buyAmountUserCurrency).isZero() ? '' : buyAmountUserCurrency}
+        cryptoAmount={cryptoAmount}
+        fiatAmount={fiatAmount}
         percentOptions={emptyPercentOptions}
         isFiat={isInputtingFiatSellAmount}
         onToggleIsFiat={handleToggleIsFiat}

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -94,10 +94,28 @@ export const LimitOrderConfig = ({
   }, [limitPriceForSelectedPriceDirection, priceAsset.precision])
 
   const inputValue = useMemo(() => {
-    if (bnOrZero(limitPriceForSelectedPriceDirection).isZero()) return ''
+    if (isInputtingFiatSellAmount) {
+      if (!fiatValue || (bnOrZero(fiatValue).isZero() && !priceAmountRef.current)) {
+        return ''
+      }
+
+      return bnOrZero(fiatValue).toFixed(2)
+    }
+
+    if (
+      !limitPriceForSelectedPriceDirection ||
+      (bnOrZero(limitPriceForSelectedPriceDirection).isZero() && !priceAmountRef.current)
+    )
+      return ''
 
     return bnOrZero(limitPriceForSelectedPriceDirection).toFixed(priceAsset.precision)
-  }, [limitPriceForSelectedPriceDirection, priceAsset.precision])
+  }, [
+    limitPriceForSelectedPriceDirection,
+    priceAsset.precision,
+    fiatValue,
+    isInputtingFiatSellAmount,
+    priceAmountRef,
+  ])
 
   const handleSetPresetLimit = useCallback(
     (limitPriceMode: LimitPriceMode) => {
@@ -136,7 +154,6 @@ export const LimitOrderConfig = ({
         cryptoValue = bnOrZero(value).div(priceAssetMarketData.price).toFixed(priceAsset.precision)
       }
 
-      priceAmountRef.current = cryptoValue
       setLimitPriceMode(LimitPriceMode.CustomValue)
       setLimitPrice({ marketPriceBuyAsset: cryptoValue ?? '0' })
     },
@@ -393,13 +410,7 @@ export const LimitOrderConfig = ({
               placeholder={isInputtingFiatSellAmount ? '$0' : '0'}
               suffix={isInputtingFiatSellAmount ? localeParts.postfix : ''}
               prefix={isInputtingFiatSellAmount ? localeParts.prefix : ''}
-              value={
-                isInputtingFiatSellAmount
-                  ? bnOrZero(fiatValue).isZero()
-                    ? ''
-                    : bnOrZero(fiatValue).toFixed(2)
-                  : inputValue
-              }
+              value={inputValue}
               onValueChange={handleValueChange}
               onChange={handleInputValueChange}
             />

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -41,21 +41,6 @@ const textSelectedProps = {
   color: 'text.base',
 }
 
-const customScrollbarSx = {
-  '&::-webkit-scrollbar': {
-    width: '6px',
-    backgroundColor: 'transparent',
-  },
-  '&::-webkit-scrollbar-thumb': {
-    backgroundColor: 'gray.600',
-    borderRadius: '3px',
-    '&:hover': {
-      backgroundColor: 'gray.500',
-    },
-  },
-  paddingRight: '6px',
-}
-
 const tableStyles = {
   'tr:not(:last-of-type)': {
     borderBottom: '1px solid',
@@ -179,7 +164,7 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
             <Text translation='limitOrder.orderHistory' />
           </Tab>
         </TabList>
-        <CardBody flex='1' minH={0} px={2} py={0}>
+        <CardBody flex='1' minH={0} px={2} py={0} pe={1}>
           <TabPanels height='100%'>
             <TabPanel px={0} py={0} height='100%'>
               {isLoading && (
@@ -194,7 +179,7 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
                 <TableContainer
                   height={tableContainerHeight}
                   overflowY='auto'
-                  sx={customScrollbarSx}
+                  className='scroll-container'
                 >
                   <Table variant='unstyled' size='sm' sx={tableStyles}>
                     <Thead>
@@ -247,7 +232,7 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
                 <TableContainer
                   height={tableContainerHeight}
                   overflowY='auto'
-                  sx={customScrollbarSx}
+                  className='scroll-container'
                 >
                   <Table variant='unstyled' size='sm' sx={tableStyles}>
                     <Thead>

--- a/src/components/MultiHopTrade/components/LimitOrderV2/InnerSteps.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/InnerSteps.tsx
@@ -60,12 +60,27 @@ export const InnerSteps = ({ isLoading }: InnerStepsProps) => {
     return { quoteId: quoteId ?? 0 }
   }, [quoteId])
 
+  const limitOrderSubmissionMetadata = useSelectorWithArgs(
+    selectLimitOrderSubmissionMetadata,
+    orderSubmissionMetadataFilter,
+  )
+
   const {
     state: orderSubmissionState,
     allowanceReset,
     allowanceApproval,
     limitOrder,
-  } = useSelectorWithArgs(selectLimitOrderSubmissionMetadata, orderSubmissionMetadataFilter)
+  } = useMemo(() => {
+    if (!limitOrderSubmissionMetadata)
+      return {
+        state: undefined,
+        allowanceReset: undefined,
+        allowanceApproval: undefined,
+        limitOrder: undefined,
+      }
+
+    return limitOrderSubmissionMetadata
+  }, [limitOrderSubmissionMetadata])
 
   const summaryStepIndicator = useMemo(() => {
     switch (true) {
@@ -140,9 +155,9 @@ export const InnerSteps = ({ isLoading }: InnerStepsProps) => {
     return (
       <Flex alignItems='center' justifyContent='space-between' flex={1}>
         <Text translation='trade.resetTitle' />
-        {allowanceReset.txHash && sellAsset && sellAccountId && (
+        {allowanceReset?.txHash && sellAsset && sellAccountId && (
           <TxLabel
-            txHash={allowanceReset.txHash}
+            txHash={allowanceReset?.txHash}
             explorerBaseUrl={sellAsset.explorerTxLink}
             accountId={sellAccountId}
             stepSource={undefined} // no swapper base URL here, this is an allowance Tx
@@ -151,15 +166,15 @@ export const InnerSteps = ({ isLoading }: InnerStepsProps) => {
         )}
       </Flex>
     )
-  }, [allowanceReset.txHash, sellAccountId, sellAsset])
+  }, [allowanceReset?.txHash, sellAccountId, sellAsset])
 
   const allowanceApprovalTitle = useMemo(() => {
     return (
       <Flex alignItems='center' justifyContent='space-between' flex={1}>
         <Text translation='trade.approvalTitle' />
-        {allowanceApproval.txHash && sellAsset && sellAccountId && (
+        {allowanceApproval?.txHash && sellAsset && sellAccountId && (
           <TxLabel
-            txHash={allowanceApproval.txHash}
+            txHash={allowanceApproval?.txHash}
             explorerBaseUrl={sellAsset.explorerTxLink}
             accountId={sellAccountId}
             stepSource={undefined} // no swapper base URL here, this is an allowance Tx
@@ -168,7 +183,9 @@ export const InnerSteps = ({ isLoading }: InnerStepsProps) => {
         )}
       </Flex>
     )
-  }, [allowanceApproval.txHash, sellAccountId, sellAsset])
+  }, [allowanceApproval?.txHash, sellAccountId, sellAsset])
+
+  if (currentStep === undefined || !allowanceReset || !allowanceApproval) return null
 
   return (
     <Skeleton isLoaded={!!orderSubmissionState && !isLoading} width='100%'>

--- a/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
@@ -2,7 +2,7 @@ import { Box, Button, HStack, Skeleton, Stack, usePrevious } from '@chakra-ui/re
 import { bn, fromBaseUnit } from '@shapeshiftoss/utils'
 import type { InterpolationOptions } from 'node-polyglot'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
-import { useHistory } from 'react-router-dom'
+import { Redirect, useHistory } from 'react-router-dom'
 
 import { getMixpanelLimitOrderEventData } from '../LimitOrder/helpers'
 import { LimitOrderRoutePaths } from '../LimitOrder/types'
@@ -88,11 +88,24 @@ export const LimitOrderConfirm = () => {
     return { quoteId: quoteId ?? 0 }
   }, [quoteId])
 
+  const limitOrderSubmissionMetadata = useSelectorWithArgs(
+    selectLimitOrderSubmissionMetadata,
+    orderSubmissionMetadataFilter,
+  )
+
   const {
     state: orderSubmissionState,
     allowanceReset,
     allowanceApproval,
-  } = useSelectorWithArgs(selectLimitOrderSubmissionMetadata, orderSubmissionMetadataFilter)
+  } = useMemo(() => {
+    if (!limitOrderSubmissionMetadata)
+      return {
+        state: undefined,
+        allowanceApproval: undefined,
+        allowanceReset: undefined,
+      }
+    return limitOrderSubmissionMetadata
+  }, [limitOrderSubmissionMetadata])
 
   useEffect(() => {
     if (isLoadingSetIsApprovalInitiallyNeeded) return
@@ -109,12 +122,12 @@ export const LimitOrderConfirm = () => {
     approvalNetworkFeeCryptoBaseUnit,
   } = useAllowanceApproval({
     activeQuote,
-    isQueryEnabled: !!allowanceApproval.isInitiallyRequired && !!activeQuote,
+    isQueryEnabled: !!allowanceApproval?.isInitiallyRequired && !!activeQuote,
     // Stop refetching when the approval tx is pending, but keep it enabled (see above) so we can leverage stale data, see
     // https://github.com/shapeshift/web/issues/8702
     isRefetchEnabled:
       orderSubmissionState === LimitOrderSubmissionState.AwaitingAllowanceApproval &&
-      allowanceApproval.state !== TransactionExecutionState.Pending,
+      allowanceApproval?.state !== TransactionExecutionState.Pending,
   })
 
   const {
@@ -123,12 +136,12 @@ export const LimitOrderConfirm = () => {
     allowanceResetNetworkFeeCryptoBaseUnit,
   } = useAllowanceReset({
     activeQuote,
-    isQueryEnabled: !!allowanceReset.isInitiallyRequired && !!activeQuote,
+    isQueryEnabled: !!allowanceReset?.isInitiallyRequired && !!activeQuote,
     // Stop refetching when the reset tx is pending, but keep it enabled (see above) so we can leverage stale data, see
     // https://github.com/shapeshift/web/issues/8702
     isRefetchEnabled:
       orderSubmissionState === LimitOrderSubmissionState.AwaitingAllowanceReset &&
-      allowanceReset.state !== TransactionExecutionState.Pending,
+      allowanceReset?.state !== TransactionExecutionState.Pending,
   })
 
   const [placeLimitOrder, { data: _data, error: _error, isLoading: isLoadingLimitOrderPlacement }] =
@@ -418,6 +431,8 @@ export const LimitOrderConfirm = () => {
     return <SharedConfirmFooter detail={detail} button={button} />
   }, [detail, button])
 
+  // We should have some submission state here... unless we're rehydrating or trying to access /limit/confirm directly
+  if (!orderSubmissionState) return <Redirect to={LimitOrderRoutePaths.Input} />
   if (!body) return null
   return (
     <SharedConfirm

--- a/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderDetail.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderDetail.tsx
@@ -48,8 +48,8 @@ export const LimitOrderDetail = () => {
   return (
     <RateGasRow
       affiliateBps={feeBps?.toFixed(0)}
-      buyAssetSymbol={buyAsset?.symbol ?? ''}
-      sellAssetSymbol={sellAsset?.symbol ?? ''}
+      buyAssetId={buyAsset?.assetId ?? ''}
+      sellAssetId={sellAsset?.assetId ?? ''}
       rate={bnOrZero(limitPrice?.buyAssetDenomination).toFixed(buyAsset?.precision ?? 0)}
       networkFeeFiatUserCurrency='0' // no network fees for CoW, this is a message signing
       swapperName={SwapperName.CowSwap}

--- a/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useAllowanceApproval.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useAllowanceApproval.tsx
@@ -53,7 +53,7 @@ export const useAllowanceApproval = ({
 
   const { evmFeesResult } = useApprovalFees({
     amountCryptoBaseUnit: activeQuote?.params.sellAmountCryptoBaseUnit ?? '',
-    assetId: activeQuote?.params.sellAssetId ?? '',
+    assetId: activeQuote?.params.sellAssetId,
     from: activeQuote?.params.sellAccountAddress,
     allowanceType: AllowanceType.Unlimited, // All limit order approvals are unlimited
     spender: COW_SWAP_VAULT_RELAYER_ADDRESS,

--- a/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useSetIsApprovalInitiallyNeeded.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useSetIsApprovalInitiallyNeeded.tsx
@@ -18,10 +18,20 @@ export const useSetIsApprovalInitiallyNeeded = () => {
     return { quoteId: activeQuote?.response.id ?? 0 }
   }, [activeQuote?.response.id])
 
-  const { allowanceReset, allowanceApproval } = useSelectorWithArgs(
+  const limitOrderSubmissionMeta = useSelectorWithArgs(
     selectLimitOrderSubmissionMetadata,
     orderSubmissionMetadataFilter,
   )
+
+  const { allowanceApproval, allowanceReset } = useMemo(() => {
+    if (!limitOrderSubmissionMeta)
+      return { allowanceApproval: undefined, allowanceReset: undefined }
+
+    return {
+      allowanceApproval: limitOrderSubmissionMeta.allowanceApproval,
+      allowanceReset: limitOrderSubmissionMeta.allowanceReset,
+    }
+  }, [limitOrderSubmissionMeta])
 
   const { allowanceCryptoBaseUnitResult, isAllowanceApprovalRequired } =
     useIsAllowanceApprovalRequired({
@@ -29,7 +39,7 @@ export const useSetIsApprovalInitiallyNeeded = () => {
       assetId: activeQuote?.params.sellAssetId,
       from: activeQuote?.params.sellAccountAddress,
       spender: COW_SWAP_VAULT_RELAYER_ADDRESS,
-      isDisabled: allowanceApproval.isInitiallyRequired !== undefined,
+      isDisabled: allowanceApproval?.isInitiallyRequired !== undefined,
     })
 
   const { isAllowanceResetRequired, isLoading: isAllowanceResetRequirementsLoading } =
@@ -38,7 +48,7 @@ export const useSetIsApprovalInitiallyNeeded = () => {
       assetId: activeQuote?.params.sellAssetId,
       from: activeQuote?.params.sellAccountAddress,
       spender: COW_SWAP_VAULT_RELAYER_ADDRESS,
-      isDisabled: allowanceReset.isInitiallyRequired !== undefined,
+      isDisabled: allowanceReset?.isInitiallyRequired !== undefined,
     })
 
   // Reset the approval requirements if the trade quote ID changes
@@ -64,8 +74,8 @@ export const useSetIsApprovalInitiallyNeeded = () => {
     // We already have *initial* approval requirements. The whole intent of this hook is to return initial allowance requirements,
     // so we never want to overwrite them with subsequent allowance results.
     if (
-      allowanceReset.isInitiallyRequired !== undefined ||
-      allowanceApproval.isInitiallyRequired !== undefined
+      allowanceReset?.isInitiallyRequired !== undefined ||
+      allowanceApproval?.isInitiallyRequired !== undefined
     )
       return
 
@@ -93,8 +103,8 @@ export const useSetIsApprovalInitiallyNeeded = () => {
     isAllowanceResetRequired,
     dispatch,
     activeQuote?.response.id,
-    allowanceReset.isInitiallyRequired,
-    allowanceApproval.isInitiallyRequired,
+    allowanceReset?.isInitiallyRequired,
+    allowanceApproval?.isInitiallyRequired,
   ])
 
   return {

--- a/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/hooks/useStepperSteps.tsx
@@ -74,13 +74,28 @@ export const useStepperSteps = () => {
     return { quoteId: quoteId ?? 0 }
   }, [quoteId])
 
+  const limitOrderSubmissionMetadata = useSelectorWithArgs(
+    selectLimitOrderSubmissionMetadata,
+    orderSubmissionMetadataFilter,
+  )
+
   const {
     state: orderSubmissionState,
     allowanceReset,
     allowanceApproval,
-  } = useSelectorWithArgs(selectLimitOrderSubmissionMetadata, orderSubmissionMetadataFilter)
+  } = useMemo(() => {
+    if (!limitOrderSubmissionMetadata)
+      return {
+        state: LimitOrderSubmissionState.Initializing,
+        allowanceReset: undefined,
+        allowanceApproval: undefined,
+      }
+    return limitOrderSubmissionMetadata
+  }, [limitOrderSubmissionMetadata])
 
-  const params: StepperStepParams = useMemo(() => {
+  const params: StepperStepParams | undefined = useMemo(() => {
+    if (!(allowanceReset && allowanceApproval)) return undefined
+
     return {
       allowanceReset,
       allowanceApproval,
@@ -89,18 +104,22 @@ export const useStepperSteps = () => {
   }, [allowanceReset, allowanceApproval, orderSubmissionState])
 
   const limitOrderSteps = useMemo(() => {
+    if (!params) return
     return getStepperSteps(params)
   }, [params])
 
   const totalSteps = useMemo(() => {
+    if (!params) return
     return countStepperSteps(params)
   }, [params])
 
   const currentLimitOrderStep = useMemo(() => {
+    if (!params) return
     return getCurrentStepperStep(params)
   }, [params])
 
   const currentLimitOrderStepIndex = useMemo(() => {
+    if (!params) return
     return getCurrentStepperStepIndex(params)
   }, [params])
 

--- a/src/components/MultiHopTrade/components/SettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SettingsPopover.tsx
@@ -11,12 +11,12 @@ import {
 } from '@/state/slices/tradeQuoteSlice/selectors'
 import { useAppDispatch, useAppSelector } from '@/state/store'
 
-type SlippagePopoverProps = {
+type SettingsPopoverProps = {
   isDisabled?: boolean
   tooltipTranslation?: string
 }
 
-export const SlippagePopover: FC<SlippagePopoverProps> = memo(
+export const SettingsPopover: FC<SettingsPopoverProps> = memo(
   ({ tooltipTranslation, isDisabled }) => {
     const dispatch = useAppDispatch()
     const defaultSlippagePercentage = useAppSelector(selectDefaultSlippagePercentage)
@@ -38,7 +38,7 @@ export const SlippagePopover: FC<SlippagePopoverProps> = memo(
         tooltipTranslation={tooltipTranslation}
         userSlippagePercentage={userSlippagePercentage}
         setUserSlippagePercentage={setSlippagePreferencePercentage}
-        enableSortBy={false}
+        enableSortBy
       />
     )
   },

--- a/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
@@ -1,0 +1,132 @@
+import { Button, ButtonGroup, FormControl, InputGroup } from '@chakra-ui/react'
+import type { FC } from 'react'
+import { memo, useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+
+import { HelperTooltip } from '@/components/HelperTooltip/HelperTooltip'
+import { Row } from '@/components/Row/Row'
+import { Text } from '@/components/Text'
+import { selectQuoteSortOption } from '@/state/slices/tradeQuoteSlice/selectors'
+import { tradeQuoteSlice } from '@/state/slices/tradeQuoteSlice/tradeQuoteSlice'
+import { QuoteSortOption } from '@/state/slices/tradeQuoteSlice/types'
+import { useAppDispatch, useAppSelector } from '@/state/store'
+
+enum SortType {
+  BestRate = 'BestRate',
+  LowestGas = 'LowestGas',
+  Fastest = 'Fastest',
+}
+
+export const QuoteSortSelector: FC = memo(() => {
+  const dispatch = useAppDispatch()
+  const translate = useTranslate()
+  const currentSortOption = useAppSelector(selectQuoteSortOption)
+
+  const currentSortType = useMemo(() => {
+    switch (currentSortOption) {
+      case QuoteSortOption.LOWEST_GAS:
+        return SortType.LowestGas
+      case QuoteSortOption.FASTEST:
+        return SortType.Fastest
+      case QuoteSortOption.BEST_RATE:
+      default:
+        return SortType.BestRate
+    }
+  }, [currentSortOption])
+
+  const sortTypeTranslation = useMemo(() => {
+    switch (currentSortType) {
+      case SortType.BestRate:
+        return translate('trade.sort.bestRate')
+      case SortType.LowestGas:
+        return translate('trade.sort.lowestGas')
+      case SortType.Fastest:
+        return translate('trade.sort.fastest')
+      default:
+        return ''
+    }
+  }, [currentSortType, translate])
+
+  const handleSortTypeChange = useCallback(
+    (sortType: SortType) => {
+      const sortOption: QuoteSortOption = (() => {
+        switch (sortType) {
+          case SortType.LowestGas:
+            return QuoteSortOption.LOWEST_GAS
+          case SortType.Fastest:
+            return QuoteSortOption.FASTEST
+          case SortType.BestRate:
+          default:
+            return QuoteSortOption.BEST_RATE
+        }
+      })()
+      dispatch(tradeQuoteSlice.actions.setSortOption(sortOption))
+    },
+    [dispatch],
+  )
+
+  const handleBestRateSortTypeChange = useCallback(
+    () => handleSortTypeChange(SortType.BestRate),
+    [handleSortTypeChange],
+  )
+
+  const handleLowestGasSortTypeChange = useCallback(
+    () => handleSortTypeChange(SortType.LowestGas),
+    [handleSortTypeChange],
+  )
+
+  const handleFastestSortTypeChange = useCallback(
+    () => handleSortTypeChange(SortType.Fastest),
+    [handleSortTypeChange],
+  )
+
+  return (
+    <>
+      <Row>
+        <Row.Label>
+          <HelperTooltip label={translate('trade.sort.info')}>
+            <Text translation='trade.sort.sortBy' />
+          </HelperTooltip>
+        </Row.Label>
+        <Row.Value>{sortTypeTranslation}</Row.Value>
+      </Row>
+      <Row py={2} gap={2} mt={2}>
+        <Row.Value>
+          <FormControl>
+            <InputGroup variant='filled'>
+              <ButtonGroup
+                size='sm'
+                bg='background.input.base'
+                px={1}
+                py={1}
+                borderRadius='xl'
+                variant='ghost'
+                isAttached
+                width='full'
+              >
+                <Button
+                  onClick={handleBestRateSortTypeChange}
+                  isActive={currentSortType === SortType.BestRate}
+                >
+                  {translate('trade.sort.bestRate')}
+                </Button>
+                <Button
+                  onClick={handleLowestGasSortTypeChange}
+                  isActive={currentSortType === SortType.LowestGas}
+                >
+                  {translate('trade.sort.lowestGas')}
+                </Button>
+                <Button
+                  onClick={handleFastestSortTypeChange}
+                  isActive={currentSortType === SortType.Fastest}
+                >
+                  {translate('trade.sort.fastest')}
+                </Button>
+              </ButtonGroup>
+            </InputGroup>
+          </FormControl>
+        </Row.Value>
+      </Row>
+    </>
+  )
+})

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -22,6 +22,8 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FaGear } from 'react-icons/fa6'
 import { useTranslate } from 'react-polyglot'
 
+import { QuoteSortSelector } from './QuoteSortSelector'
+
 import { HelperTooltip } from '@/components/HelperTooltip/HelperTooltip'
 import { Row } from '@/components/Row/Row'
 import { Text } from '@/components/Text'
@@ -38,16 +40,17 @@ const focusStyle = { '&[aria-invalid=true]': { borderColor: 'red.500' } }
 
 const faGear = <FaGear />
 
-type SharedSlippagePopoverProps = {
+type SharedSettingsPopoverProps = {
   defaultSlippagePercentage: string | undefined
   isDisabled?: boolean
   quoteSlippagePercentage: string | undefined
   tooltipTranslation?: string
   userSlippagePercentage: string | undefined
   setUserSlippagePercentage: (slippagePercentage: string | undefined) => void
+  enableSortBy?: boolean
 }
 
-export const SharedSlippagePopover: FC<SharedSlippagePopoverProps> = memo(
+export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
   ({
     defaultSlippagePercentage,
     isDisabled,
@@ -55,6 +58,7 @@ export const SharedSlippagePopover: FC<SharedSlippagePopoverProps> = memo(
     tooltipTranslation,
     userSlippagePercentage,
     setUserSlippagePercentage,
+    enableSortBy,
   }) => {
     const [slippageType, setSlippageType] = useState<SlippageType>(SlippageType.Auto)
     const [slippageAmount, setSlippageAmount] = useState<string | undefined>(
@@ -157,6 +161,7 @@ export const SharedSlippagePopover: FC<SharedSlippagePopoverProps> = memo(
                   py={1}
                   borderRadius='xl'
                   variant='ghost'
+                  width='full'
                 >
                   <Button
                     onClick={handleAutoSlippageTypeChange}
@@ -204,6 +209,12 @@ export const SharedSlippagePopover: FC<SharedSlippagePopoverProps> = memo(
                   {translate('trade.slippage.lowSlippage')}
                 </AlertDescription>
               </Alert>
+            )}
+
+            {enableSortBy && (
+              <Box mt={4} borderTop='1px solid' borderTopColor='border.base' pt={4}>
+                <QuoteSortSelector />
+              </Box>
             )}
           </PopoverBody>
         </PopoverContent>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -118,8 +118,8 @@ export const SharedTradeInputFooter = ({
         {hasUserEnteredAmount && (
           <RateGasRow
             affiliateBps={affiliateBps}
-            buyAssetSymbol={buyAsset.symbol}
-            sellAssetSymbol={sellAsset.symbol}
+            buyAssetId={buyAsset.assetId}
+            sellAssetId={sellAsset.assetId}
             isDisabled={shouldDisableGasRateRowClick}
             rate={rate}
             deltaPercentage={deltaPercentage?.toString()}

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirm.tsx
@@ -1,7 +1,7 @@
 import { Stepper, usePrevious } from '@chakra-ui/react'
 import { isArbitrumBridgeTradeQuoteOrRate } from '@shapeshiftoss/swapper'
 import { useCallback, useEffect, useMemo } from 'react'
-import { useHistory } from 'react-router-dom'
+import { Redirect, useHistory } from 'react-router-dom'
 
 import { SharedConfirm } from '../SharedConfirm/SharedConfirm'
 import { TradeSuccess } from '../TradeSuccess/TradeSuccess'
@@ -128,6 +128,8 @@ export const TradeConfirm = ({ isCompact }: { isCompact: boolean | undefined }) 
     return <TradeConfirmBody />
   }, [activeQuote, handleBack, isArbitrumBridgeWithdraw, isTradeComplete, tradeQuoteLastHop])
 
+  // We should have some execution state here... unless we're rehydrating or trying to access /trade/confirm directly
+  if (!confirmedTradeExecutionState) return <Redirect to={TradeRoutePaths.Input} />
   if (!headerTranslation) return null
 
   return (

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -13,6 +13,7 @@ import { useTradeNetworkFeeCryptoBaseUnit } from './hooks/useTradeNetworkFeeCryp
 import { TradeFooterButton } from './TradeFooterButton'
 
 import { Amount } from '@/components/Amount/Amount'
+import { RecipientAddressRow } from '@/components/RecipientAddressRow'
 import { Row } from '@/components/Row/Row'
 import { Text } from '@/components/Text/Text'
 import { useToggle } from '@/hooks/useToggle/useToggle'
@@ -20,7 +21,9 @@ import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
 import { selectFeeAssetById } from '@/state/slices/assetsSlice/selectors'
 import { selectMarketDataByAssetIdUserCurrency } from '@/state/slices/marketDataSlice/selectors'
+import { selectInputSellAsset } from '@/state/slices/tradeInputSlice/selectors'
 import {
+  selectActiveQuote,
   selectHopExecutionMetadata,
   selectIsActiveSwapperQuoteLoading,
 } from '@/state/slices/tradeQuoteSlice/selectors'
@@ -66,6 +69,9 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isExactAllowance,
     activeTradeId,
   })
+  const activeQuote = useAppSelector(selectActiveQuote)
+  const sellAsset = useAppSelector(selectInputSellAsset)
+  const receiveAddress = activeQuote?.receiveAddress
 
   const hopExecutionMetadataFilter = useMemo(() => {
     if (!activeTradeId) return undefined
@@ -251,6 +257,10 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
             </Skeleton>
           </Row.Value>
         </Row>
+        <RecipientAddressRow
+          explorerAddressLink={sellAsset.explorerAddressLink}
+          recipientAddress={receiveAddress ?? ''}
+        />
       </Stack>
     )
   }, [
@@ -260,6 +270,8 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isNetworkFeeCryptoBaseUnitRefetching,
     networkFeeCryptoPrecision,
     networkFeeUserCurrency,
+    sellAsset.explorerAddressLink,
+    receiveAddress,
   ])
 
   const tradeDetail = useMemo(() => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
@@ -85,8 +85,8 @@ export const TradeConfirmSummary = () => {
   return (
     <RateGasRow
       affiliateBps={affiliateBps}
-      buyAssetSymbol={buyAsset.symbol}
-      sellAssetSymbol={sellAsset.symbol}
+      buyAssetId={buyAsset.assetId}
+      sellAssetId={sellAsset.assetId}
       rate={bnOrZero(rate).toFixed(buyAsset.precision)}
       isLoading={isLoading}
       networkFeeFiatUserCurrency={totalNetworkFeeFiatPrecision}

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
@@ -1,5 +1,4 @@
-import { ExternalLinkIcon } from '@chakra-ui/icons'
-import { Divider, HStack, Icon, Link, Stack, Tooltip } from '@chakra-ui/react'
+import { Divider, HStack, Stack, Tooltip } from '@chakra-ui/react'
 import { getHopByIndex } from '@shapeshiftoss/swapper'
 import { bnOrZero, fromBaseUnit } from '@shapeshiftoss/utils'
 import { useCallback, useMemo } from 'react'
@@ -13,9 +12,9 @@ import { useIsApprovalInitiallyNeeded } from '../hooks/useIsApprovalInitiallyNee
 import { Amount } from '@/components/Amount/Amount'
 import { parseAmountDisplayMeta } from '@/components/MultiHopTrade/helpers'
 import { usePriceImpact } from '@/components/MultiHopTrade/hooks/quoteValidation/usePriceImpact'
+import { RecipientAddressRow } from '@/components/RecipientAddressRow'
 import { Row } from '@/components/Row/Row'
 import { RawText, Text } from '@/components/Text'
-import { middleEllipsis } from '@/lib/utils'
 import { selectFeeAssetById } from '@/state/slices/selectors'
 import {
   selectInputBuyAsset,
@@ -161,23 +160,10 @@ export const TradeConfirmSummary = () => {
         />
         {priceImpactPercentage && <PriceImpact priceImpactPercentage={priceImpactPercentage} />}
         <Divider />
-        <Row>
-          <Row.Label>
-            <Text translation='trade.recipientAddress' />
-          </Row.Label>
-          <Row.Value>
-            <HStack>
-              <RawText>{middleEllipsis(receiveAddress ?? '')}</RawText>
-              <Link
-                href={`${sellAsset.explorerAddressLink}${receiveAddress}`}
-                isExternal
-                aria-label='View on block explorer'
-              >
-                <Icon as={ExternalLinkIcon} />
-              </Link>
-            </HStack>
-          </Row.Value>
-        </Row>
+        <RecipientAddressRow
+          explorerAddressLink={sellAsset.explorerAddressLink}
+          recipientAddress={receiveAddress ?? ''}
+        />
       </Stack>
     </RateGasRow>
   )

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/Claim.tsx
@@ -1,7 +1,7 @@
 import { Card, Stack } from '@chakra-ui/react'
 import type { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useState } from 'react'
-import { Route, Switch, useLocation } from 'react-router-dom'
+import { Redirect, Route, Switch, useLocation } from 'react-router-dom'
 
 import { SharedTradeInputHeader } from '../../../SharedTradeInput/SharedTradeInputHeader'
 import { ClaimConfirm } from './ClaimConfirm'
@@ -25,7 +25,10 @@ export const Claim = ({ onChangeTab }: { onChangeTab: (newTab: TradeInputTab) =>
   }, [])
 
   const renderClaimConfirm = useCallback(() => {
-    if (!activeClaim) return null
+    // We should always have an active claim at confirm step.
+    // If we don't, we've either rehydrated, tried to access /claim/confirm directly, or something went wrong.
+    // Either way, route back to select
+    if (!activeClaim) return <Redirect to={ClaimRoutePaths.Select} />
 
     return (
       <ClaimConfirm

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -292,13 +292,13 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
     ].includes(errors?.[0]?.error)
     const showSwapper = !!quote || showSwapperError
 
-    const totalEstimatedExecutionTimeMs = useMemo(
-      () =>
-        quote?.steps.reduce((acc, step) => {
-          return acc + (step.estimatedExecutionTimeMs ?? 0)
-        }, 0),
-      [quote?.steps],
-    )
+    const totalEstimatedExecutionTimeMs = useMemo(() => {
+      if (quote?.steps.every(step => step.estimatedExecutionTimeMs === undefined)) return
+
+      return quote?.steps.reduce((acc, step) => {
+        return acc + (step.estimatedExecutionTimeMs ?? 0)
+      }, 0)
+    }, [quote?.steps])
 
     const slippage = useMemo(() => {
       if (!quote) return

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -31,6 +31,7 @@ import {
   selectIsSwapperResponseAvailable,
   selectIsTradeQuoteRequestAborted,
   selectLoadingSwappers,
+  selectQuoteSortOption,
   selectSortedTradeQuotes,
   selectUserAvailableTradeQuotes,
   selectUserUnavailableTradeQuotes,
@@ -71,6 +72,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ isLoading, onBack
   const bestTotalReceiveAmountCryptoPrecision = useAppSelector(
     selectBuyAmountAfterFeesCryptoPrecision,
   )
+  const sortOption = useAppSelector(selectQuoteSortOption)
 
   const shouldUseComisSansMs = useMemo(() => {
     return buyAsset?.assetId === dogeAssetId || sellAsset?.assetId === dogeAssetId
@@ -84,7 +86,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ isLoading, onBack
         isSwapperQuoteAvailable,
       }),
     )
-  }, [dispatch, isTradeQuoteApiQueryPending, isSwapperQuoteAvailable, sortedQuotes])
+  }, [dispatch, isTradeQuoteApiQueryPending, isSwapperQuoteAvailable, sortedQuotes, sortOption])
 
   const isQuoteRefetching = useCallback(
     (quoteData: ApiQuote) => {

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteContent.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteContent.tsx
@@ -100,6 +100,23 @@ export const TradeQuoteContent = ({
     }
   }, [isHighPriceImpact, isModeratePriceImpact, priceImpactPercentage, translate])
 
+  const eta = useMemo(() => {
+    if (totalEstimatedExecutionTimeMs === undefined) return null
+
+    return (
+      <Skeleton isLoaded={!isLoading}>
+        <Flex gap={2} alignItems='center'>
+          <RawText color='text.subtle'>
+            <FaRegClock />
+          </RawText>
+          {totalEstimatedExecutionTimeMs === 0
+            ? '0s'
+            : prettyMilliseconds(totalEstimatedExecutionTimeMs)}
+        </Flex>
+      </Skeleton>
+    )
+  }, [totalEstimatedExecutionTimeMs, isLoading])
+
   return (
     <>
       <CardBody py={2} px={4} display='flex' alignItems='center' justifyContent='space-between'>
@@ -178,16 +195,7 @@ export const TradeQuoteContent = ({
           )}
 
           {slippage}
-          {totalEstimatedExecutionTimeMs !== undefined && totalEstimatedExecutionTimeMs > 0 && (
-            <Skeleton isLoaded={!isLoading}>
-              <Flex gap={2} alignItems='center'>
-                <RawText color='text.subtle'>
-                  <FaRegClock />
-                </RawText>
-                {prettyMilliseconds(totalEstimatedExecutionTimeMs)}
-              </Flex>
-            </Skeleton>
-          )}
+          {eta}
           <Skeleton isLoaded={!isLoading}>
             {numHops > 1 && (
               <Tooltip label={translate('trade.numHops', { numHops })}>

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeSettingsMenu.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeSettingsMenu.tsx
@@ -2,7 +2,7 @@ import { useMediaQuery } from '@chakra-ui/react'
 import { DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL, swappers } from '@shapeshiftoss/swapper'
 import { useMemo } from 'react'
 
-import { SlippagePopover } from '../../SlippagePopover'
+import { SettingsPopover } from '../../SettingsPopover'
 import { CountdownSpinner } from './TradeQuotes/components/CountdownSpinner'
 
 import { selectIsTradeQuoteApiQueryPending } from '@/state/apis/swapper/selectors'
@@ -39,7 +39,7 @@ export const TradeSettingsMenu = ({ isCompact, isLoading }: TradeSettingsMenuPro
       {activeQuote && (isCompact || isSmallerThanXl) && (
         <CountdownSpinner isLoading={isLoading || isRefetching} initialTimeMs={pollingInterval} />
       )}
-      <SlippagePopover />
+      <SettingsPopover />
     </>
   )
 }

--- a/src/components/RecipientAddressRow.tsx
+++ b/src/components/RecipientAddressRow.tsx
@@ -1,0 +1,38 @@
+import { ExternalLinkIcon } from '@chakra-ui/icons'
+import { HStack, Icon, Link } from '@chakra-ui/react'
+import { useTranslate } from 'react-polyglot'
+
+import { Row } from '@/components/Row/Row'
+import { RawText, Text } from '@/components/Text'
+import { middleEllipsis } from '@/lib/utils'
+
+type RecipientAddressRowProps = {
+  explorerAddressLink: string
+  recipientAddress: string
+}
+
+export const RecipientAddressRow = ({
+  explorerAddressLink,
+  recipientAddress,
+}: RecipientAddressRowProps) => {
+  const translate = useTranslate()
+  return (
+    <Row>
+      <Row.Label>
+        <Text translation='trade.recipientAddress' />
+      </Row.Label>
+      <Row.Value>
+        <HStack>
+          <RawText>{middleEllipsis(recipientAddress)}</RawText>
+          <Link
+            href={`${explorerAddressLink}${recipientAddress}`}
+            isExternal
+            aria-label={translate('trade.viewOnBlockExplorer')}
+          >
+            <Icon as={ExternalLinkIcon} />
+          </Link>
+        </HStack>
+      </Row.Value>
+    </Row>
+  )
+}

--- a/src/context/WalletProvider/NativeWallet/components/NativeSuccess.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeSuccess.tsx
@@ -1,5 +1,6 @@
 import { Box, ModalBody, ModalHeader } from '@chakra-ui/react'
 import { useQueryClient } from '@tanstack/react-query'
+import { useEffect } from 'react'
 
 import { useNativeSuccess } from '../hooks/useNativeSuccess'
 import type { NativeSetupProps } from '../types'
@@ -11,9 +12,21 @@ export const NativeSuccess = ({ location }: NativeSetupProps) => {
   const queryClient = useQueryClient()
   const { isSuccessful } = useNativeSuccess({ vault: location.state.vault })
 
-  queryClient.invalidateQueries({
-    queryKey: reactQueries.common.hdwalletNativeVaultsList().queryKey,
-  })
+  useEffect(() => {
+    queryClient.invalidateQueries({
+      queryKey: reactQueries.common.hdwalletNativeVaultsList().queryKey,
+    })
+    queryClient.invalidateQueries({
+      queryKey: ['native-create-vault'],
+      exact: false,
+      refetchType: 'all',
+    })
+    queryClient.invalidateQueries({
+      queryKey: ['native-create-words'],
+      exact: false,
+      refetchType: 'all',
+    })
+  }, [queryClient])
 
   return (
     <>

--- a/src/hooks/queries/useApprovalFees.ts
+++ b/src/hooks/queries/useApprovalFees.ts
@@ -15,7 +15,7 @@ export enum AllowanceType {
 }
 
 type UseApprovalFeesInput = {
-  assetId: AssetId
+  assetId: AssetId | undefined
   from: string | undefined
   spender: string
   amountCryptoBaseUnit: string
@@ -34,11 +34,13 @@ export const useApprovalFees = ({
   isRefetchEnabled,
 }: UseApprovalFeesInput) => {
   const { assetReference: to, chainId } = useMemo(() => {
+    if (!assetId) return { assetReference: undefined, chainId: undefined }
+
     return fromAssetId(assetId)
   }, [assetId])
 
   const approveContractData = useMemo(() => {
-    if (!amountCryptoBaseUnit || !spender || !enabled) return
+    if (!amountCryptoBaseUnit || !spender || !to || !chainId || !enabled) return
 
     return getApproveContractData({
       approvalAmountCryptoBaseUnit: getApprovalAmountCryptoBaseUnit(

--- a/src/pages/RFOX/hooks/useCurrentApyQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentApyQuery.ts
@@ -49,7 +49,7 @@ export const useCurrentApyQuery = ({ stakingAssetId }: useCurrentApyQueryProps) 
       if (!stakingAsset) return
       if (!totalStakedCryptoCurrencyQuery?.data) return
 
-      const previousEpoch = epochs[epochs.length - 1]
+      const previousEpoch = epochs[0]
 
       const closestRunePrice = runePriceHistory.find(
         (price, index) =>
@@ -60,7 +60,7 @@ export const useCurrentApyQuery = ({ stakingAssetId }: useCurrentApyQueryProps) 
       const closestFoxPrice = stakingAssetPriceHistory.find(
         (price, index) =>
           price.date <= previousEpoch.endTimestamp &&
-          runePriceHistory[index + 1]?.date > previousEpoch.endTimestamp,
+          stakingAssetPriceHistory[index + 1]?.date > previousEpoch.endTimestamp,
       )
 
       const previousDistributionRate =

--- a/src/state/slices/limitOrderSlice/limitOrderSlice.ts
+++ b/src/state/slices/limitOrderSlice/limitOrderSlice.ts
@@ -11,7 +11,18 @@ import {
   LimitOrderSubmissionState,
 } from './constants'
 import { buildUnsignedLimitOrder } from './helpers'
-import type { LimitOrderActiveQuote } from './types'
+import type { LimitOrderActiveQuote, LimitOrderState, LimitOrderSubmissionMetadata } from './types'
+
+// Create a type-safe immer draft that will populate the orderSubmission object if undefined
+const makeOrderSubmissionDraft = (
+  orderSubmission: LimitOrderState['orderSubmission'],
+  id: QuoteId,
+): LimitOrderSubmissionMetadata => {
+  if (!orderSubmission[id]) {
+    orderSubmission[id] = limitOrderSubmissionInitialState
+  }
+  return orderSubmission[id] as LimitOrderSubmissionMetadata
+}
 
 export const limitOrderSlice = createSlice({
   name: 'limitOrder',
@@ -38,7 +49,8 @@ export const limitOrderSlice = createSlice({
       state.orderSubmission[quoteId] = limitOrderSubmissionInitialState
     },
     setLimitOrderInitialized: (state, action: PayloadAction<QuoteId>) => {
-      state.orderSubmission[action.payload].state = LimitOrderSubmissionState.Previewing
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, action.payload)
+      draftOrderSubmission.state = LimitOrderSubmissionState.Previewing
     },
     confirmSubmit: (state, action: PayloadAction<QuoteId>) => {
       const limitOrderQuoteId = action.payload
@@ -62,10 +74,12 @@ export const limitOrderSlice = createSlice({
 
       // This should never actually happen because the view layer should prevent calling this when
       // the state isn't valid, but it's here to protect us from ourselves.
-      if (state.orderSubmission[limitOrderQuoteId].state !== LimitOrderSubmissionState.Previewing) {
-        if (
-          state.orderSubmission[limitOrderQuoteId].state === LimitOrderSubmissionState.Initializing
-        ) {
+      const draftOrderSubmission = makeOrderSubmissionDraft(
+        state.orderSubmission,
+        limitOrderQuoteId,
+      )
+      if (draftOrderSubmission.state !== LimitOrderSubmissionState.Previewing) {
+        if (draftOrderSubmission.state === LimitOrderSubmissionState.Initializing) {
           console.error('Attempted to confirm an uninitialized limit order')
         } else {
           console.error('Attempted to confirm an in-progress limit order')
@@ -73,82 +87,87 @@ export const limitOrderSlice = createSlice({
         return
       }
 
-      const allowanceResetRequired =
-        state.orderSubmission[limitOrderQuoteId].allowanceReset.isRequired
-      const approvalRequired =
-        state.orderSubmission[limitOrderQuoteId].allowanceApproval.isInitiallyRequired
+      const allowanceResetRequired = draftOrderSubmission.allowanceReset.isRequired
+      const approvalRequired = draftOrderSubmission.allowanceApproval.isInitiallyRequired
 
       switch (true) {
         case allowanceResetRequired:
-          state.orderSubmission[limitOrderQuoteId].state =
-            LimitOrderSubmissionState.AwaitingAllowanceReset
+          draftOrderSubmission.state = LimitOrderSubmissionState.AwaitingAllowanceReset
           break
         case approvalRequired:
-          state.orderSubmission[limitOrderQuoteId].state =
-            LimitOrderSubmissionState.AwaitingAllowanceApproval
+          draftOrderSubmission.state = LimitOrderSubmissionState.AwaitingAllowanceApproval
           break
         default:
-          state.orderSubmission[limitOrderQuoteId].state =
-            LimitOrderSubmissionState.AwaitingLimitOrderSubmission
+          draftOrderSubmission.state = LimitOrderSubmissionState.AwaitingLimitOrderSubmission
           break
       }
     },
     setAllowanceResetTxPending: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].allowanceReset.state = TransactionExecutionState.Pending
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceReset.state = TransactionExecutionState.Pending
     },
     setAllowanceApprovalTxPending: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].allowanceApproval.state = TransactionExecutionState.Pending
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceApproval.state = TransactionExecutionState.Pending
     },
     setAllowanceResetTxFailed: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].allowanceApproval.state = TransactionExecutionState.Failed
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceApproval.state = TransactionExecutionState.Failed
     },
     setAllowanceApprovalTxFailed: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].allowanceApproval.state = TransactionExecutionState.Failed
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceApproval.state = TransactionExecutionState.Failed
     },
     setAllowanceResetTxComplete: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].allowanceReset.state = TransactionExecutionState.Complete
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceReset.state = TransactionExecutionState.Complete
     },
     // marks the approval tx as complete, but the allowance check needs to pass before proceeding to swap step
     setAllowanceApprovalTxComplete: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].allowanceApproval.state = TransactionExecutionState.Complete
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceApproval.state = TransactionExecutionState.Complete
     },
     // This is deliberately disjoint to the allowance reset transaction orchestration to allow users to
     // complete an approval externally and have the app respond to the updated allowance on chain.
     setAllowanceResetStepComplete: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
 
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
       // Don't update the state if we're on a different stage of the flow
-      if (state.orderSubmission[id].state !== LimitOrderSubmissionState.AwaitingAllowanceReset) {
+      if (draftOrderSubmission.state !== LimitOrderSubmissionState.AwaitingAllowanceReset) {
         return
       }
 
-      state.orderSubmission[id].state = LimitOrderSubmissionState.AwaitingAllowanceApproval
+      draftOrderSubmission.state = LimitOrderSubmissionState.AwaitingAllowanceApproval
     },
     // This is deliberately disjoint to the allowance approval transaction orchestration to allow users to
     // complete an approval externally and have the app respond to the updated allowance on chain.
     setAllowanceApprovalStepComplete: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
 
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
       // Don't update the state if we're on a different stage of the flow
-      if (state.orderSubmission[id].state !== LimitOrderSubmissionState.AwaitingAllowanceApproval) {
+      if (draftOrderSubmission.state !== LimitOrderSubmissionState.AwaitingAllowanceApproval) {
         return
       }
 
-      state.orderSubmission[id].state = LimitOrderSubmissionState.AwaitingLimitOrderSubmission
+      draftOrderSubmission.state = LimitOrderSubmissionState.AwaitingLimitOrderSubmission
     },
     setLimitOrderTxPending: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].limitOrder.state = TransactionExecutionState.Pending
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.limitOrder.state = TransactionExecutionState.Pending
     },
     setLimitOrderTxFailed: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
-      state.orderSubmission[id].limitOrder.state = TransactionExecutionState.Failed
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.limitOrder.state = TransactionExecutionState.Failed
     },
     setLimitOrderTxMessage: (
       state,
@@ -159,31 +178,40 @@ export const limitOrderSlice = createSlice({
       }>,
     ) => {
       const { id, message } = action.payload
-      state.orderSubmission[id].limitOrder.message = message
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.limitOrder.message = message
     },
     setLimitOrderTxComplete: (state, action: PayloadAction<QuoteId>) => {
       const id = action.payload
 
-      state.orderSubmission[id].limitOrder.state = TransactionExecutionState.Complete
-      state.orderSubmission[id].limitOrder.message = undefined
-      state.orderSubmission[id].state = LimitOrderSubmissionState.Complete
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.limitOrder.state = TransactionExecutionState.Complete
+      draftOrderSubmission.limitOrder.message = undefined
+      draftOrderSubmission.state = LimitOrderSubmissionState.Complete
     },
     setInitialApprovalRequirements: (
       state,
       action: PayloadAction<{ isAllowanceApprovalRequired: boolean | undefined; id: QuoteId }>,
     ) => {
-      state.orderSubmission[action.payload.id].allowanceApproval.isRequired =
+      const draftOrderSubmission = makeOrderSubmissionDraft(
+        state.orderSubmission,
+        action.payload.id,
+      )
+      draftOrderSubmission.allowanceApproval.isRequired =
         action.payload?.isAllowanceApprovalRequired
-      state.orderSubmission[action.payload.id].allowanceApproval.isInitiallyRequired =
+      draftOrderSubmission.allowanceApproval.isInitiallyRequired =
         action.payload?.isAllowanceApprovalRequired
     },
     setAllowanceResetRequirements: (
       state,
       action: PayloadAction<{ isAllowanceResetRequired: boolean | undefined; id: QuoteId }>,
     ) => {
-      state.orderSubmission[action.payload.id].allowanceReset.isRequired =
-        action.payload?.isAllowanceResetRequired
-      state.orderSubmission[action.payload.id].allowanceReset.isInitiallyRequired =
+      const draftOrderSubmission = makeOrderSubmissionDraft(
+        state.orderSubmission,
+        action.payload.id,
+      )
+      draftOrderSubmission.allowanceReset.isRequired = action.payload?.isAllowanceResetRequired
+      draftOrderSubmission.allowanceReset.isInitiallyRequired =
         action.payload?.isAllowanceResetRequired
     },
     setAllowanceResetTxHash: (
@@ -194,7 +222,8 @@ export const limitOrderSlice = createSlice({
       }>,
     ) => {
       const { txHash, id } = action.payload
-      state.orderSubmission[id].allowanceReset.txHash = txHash
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceReset.txHash = txHash
     },
     setAllowanceApprovalTxHash: (
       state,
@@ -204,14 +233,19 @@ export const limitOrderSlice = createSlice({
       }>,
     ) => {
       const { txHash, id } = action.payload
-      state.orderSubmission[id].allowanceApproval.txHash = txHash
+      const draftOrderSubmission = makeOrderSubmissionDraft(state.orderSubmission, id)
+      draftOrderSubmission.allowanceApproval.txHash = txHash
     },
     setLimitOrderSubmissionTxHash: (
       state,
       action: PayloadAction<{ txHash: string; id: QuoteId }>,
     ) => {
       const { txHash } = action.payload
-      state.orderSubmission[action.payload.id].limitOrder.txHash = txHash
+      const draftOrderSubmission = makeOrderSubmissionDraft(
+        state.orderSubmission,
+        action.payload.id,
+      )
+      draftOrderSubmission.limitOrder.txHash = txHash
     },
   },
 })

--- a/src/state/slices/limitOrderSlice/selectors.ts
+++ b/src/state/slices/limitOrderSlice/selectors.ts
@@ -10,7 +10,7 @@ import {
   selectUserCurrencyToUsdRate,
 } from '../selectors'
 import { calcLimitPriceBuyAsset } from './helpers'
-import type { LimitOrderState } from './types'
+import type { LimitOrderState, LimitOrderSubmissionMetadata } from './types'
 
 import type { ReduxState } from '@/state/reducer'
 import { createDeepEqualOutputSelector } from '@/state/selector-utils'
@@ -193,7 +193,7 @@ export const selectConfirmedLimitOrder = createSelector(
 export const selectLimitOrderSubmissionMetadata = createDeepEqualOutputSelector(
   selectLimitOrderSlice,
   selectQuoteIdParamFromRequiredFilter,
-  (limitOrders, quoteId) => {
+  (limitOrders, quoteId): LimitOrderSubmissionMetadata | undefined => {
     return limitOrders.orderSubmission[quoteId]
   },
 )

--- a/src/state/slices/limitOrderSlice/types.ts
+++ b/src/state/slices/limitOrderSlice/types.ts
@@ -1,5 +1,10 @@
 import type { AccountId } from '@shapeshiftoss/caip'
-import type { OrderQuoteResponse, QuoteId, UnsignedOrderCreation } from '@shapeshiftoss/types'
+import type {
+  OrderQuoteResponse,
+  PartialRecord,
+  QuoteId,
+  UnsignedOrderCreation,
+} from '@shapeshiftoss/types'
 import type { InterpolationOptions } from 'node-polyglot'
 
 import type { ApprovalExecutionMetadata, TransactionExecutionState } from '../tradeQuoteSlice/types'
@@ -37,5 +42,5 @@ export type LimitOrderState = {
     QuoteId,
     { params: LimitOrderCreationParams; unsignedOrderCreation: UnsignedOrderCreation }
   >
-  orderSubmission: Record<QuoteId, LimitOrderSubmissionMetadata>
+  orderSubmission: PartialRecord<QuoteId, LimitOrderSubmissionMetadata>
 }

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -1,7 +1,12 @@
 import { TradeQuoteError } from '@shapeshiftoss/swapper'
 
 import type { TradeQuoteSliceState } from './types'
-import { HopExecutionState, TradeExecutionState, TransactionExecutionState } from './types'
+import {
+  HopExecutionState,
+  QuoteSortOption,
+  TradeExecutionState,
+  TransactionExecutionState,
+} from './types'
 
 import { TradeQuoteValidationError } from '@/state/apis/swapper/types'
 
@@ -42,6 +47,7 @@ export const initialState: TradeQuoteSliceState = {
   tradeQuotes: {},
   tradeQuoteDisplayCache: [],
   isTradeQuoteRequestAborted: false,
+  sortOption: QuoteSortOption.BEST_RATE,
 }
 
 export const SWAPPER_USER_ERRORS = [

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -10,15 +10,17 @@ import type {
 import { getHopByIndex } from '@shapeshiftoss/swapper'
 import type { Asset, PartialRecord } from '@shapeshiftoss/types'
 import { orderBy } from 'lodash'
-import partition from 'lodash/partition'
 
 import type { ActiveQuoteMeta } from './types'
+import { QuoteSortOption } from './types'
 
 import type { BigNumber } from '@/lib/bignumber/bignumber'
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
 import { isSome } from '@/lib/utils'
 import type { ApiQuote } from '@/state/apis/swapper/types'
+import { selectFeeAssetById, selectMarketDataByFilter } from '@/state/slices/selectors'
+import { store } from '@/state/store'
 
 export const getHopTotalNetworkFeeUserCurrency = (
   networkFeeCryptoBaseUnit: string | undefined,
@@ -60,6 +62,29 @@ export const getTotalNetworkFeeUserCurrencyPrecision = (
     )
     return acc.plus(networkFeeFiatPrecision ?? '0')
   }, bn(0))
+}
+
+const getNetworkFeeUserCurrency = (quote: TradeQuote | TradeRate | undefined): BigNumber => {
+  if (!quote) return bn(Number.MAX_SAFE_INTEGER)
+
+  const state = store.getState()
+  const getFeeAsset = (assetId: AssetId) => {
+    const feeAsset = selectFeeAssetById(state, assetId)
+    if (feeAsset === undefined) {
+      throw Error(`missing fee asset for assetId ${assetId}`)
+    }
+    return feeAsset
+  }
+
+  const getFeeAssetUserCurrencyRate = (feeAssetId: AssetId) =>
+    selectMarketDataByFilter(state, {
+      assetId: feeAssetId,
+    }).price
+
+  return (
+    getTotalNetworkFeeUserCurrencyPrecision(quote, getFeeAsset, getFeeAssetUserCurrencyRate) ??
+    bn(Number.MAX_SAFE_INTEGER)
+  )
 }
 
 /**
@@ -123,31 +148,113 @@ export const getTotalProtocolFeeByAsset = (
     {},
   )
 
-const isKnownNetworkFees = (quote: ApiQuote): boolean => {
-  return Boolean(quote?.quote?.steps?.every(step => Boolean(step.feeData.networkFeeCryptoBaseUnit)))
-}
+const sortApiQuotes = (
+  unorderedQuotes: ApiQuote[],
+  sortOption: QuoteSortOption = QuoteSortOption.BEST_RATE,
+): ApiQuote[] => {
+  // First, filter out quotes with errors - those belong in the unavailable section
+  const quotesWithoutErrors = unorderedQuotes.filter(quote => quote.errors.length === 0)
 
-const sortApiQuotes = (unorderedQuotes: ApiQuote[]): ApiQuote[] => {
-  const orderedQuotes = orderBy(
-    unorderedQuotes,
-    ['inputOutputRatio', 'quote.rate', 'swapperName'],
-    ['desc', 'desc', 'asc'],
-  )
-  const [quotesWithKnownFees, quotesWithUnknownFees] = partition(orderedQuotes, isKnownNetworkFees)
+  // Custom sorting function rather than an orderBy iteratee to keep my sanity, since this didn't play too well with it
+  if (sortOption === QuoteSortOption.FASTEST) {
+    const sorted = [...quotesWithoutErrors].sort((a, b) => {
+      const getExecutionTime = (quote: ApiQuote) => {
+        if (!quote.quote?.steps?.length) return undefined
 
-  return [...quotesWithKnownFees, ...quotesWithUnknownFees]
+        // Note, we *need* this and don't want to sum to 0. undefined and 0 have two v. diff meanings
+        if (quote.quote.steps.every(step => step.estimatedExecutionTimeMs === undefined)) {
+          return undefined
+        }
+
+        return quote.quote.steps.reduce((total, step) => {
+          // Opt chain to keep tsc happy, we already know it will be defined after the above check
+          return total + (step.estimatedExecutionTimeMs ?? 0)
+        }, 0)
+      }
+
+      const aTime = getExecutionTime(a)
+      const bTime = getExecutionTime(b)
+
+      if (aTime === undefined && bTime === undefined) return 0
+      if (aTime === undefined) return 1 // Push undefined to last, we don't know the ETA here
+      if (bTime === undefined) return -1 // Keep defined ETA above undefined
+
+      // Number compare is safe since we're dealing with unix timestamps
+      return aTime - bTime
+    })
+    return sorted
+  }
+  const iteratees: ((quote: ApiQuote) => any)[] = (() => {
+    switch (sortOption) {
+      case QuoteSortOption.LOWEST_GAS:
+        return [
+          // Presort by un/available network fees
+          (quote: ApiQuote) => {
+            if (!quote.quote?.steps) return true
+
+            // Unknown gas - assume latest
+            if (quote.quote.steps.every(step => !step?.feeData?.networkFeeCryptoBaseUnit))
+              return true
+
+            return false
+          },
+          // Then sort by the actual fee amount in user currency
+          (quote: ApiQuote) => {
+            return getNetworkFeeUserCurrency(quote.quote)
+          },
+        ]
+      case QuoteSortOption.BEST_RATE:
+      default:
+        return [
+          (quote: ApiQuote) => {
+            if (!quote.quote?.steps?.length) return bn(0)
+
+            // Get the last step for multi-hop trades
+            const steps = quote.quote.steps
+            const lastStep = steps[steps.length - 1]
+
+            // Use buyAmountAfterFeesCryptoBaseUnit which should match the displayed amount
+            const buyAmount = bnOrZero(lastStep.buyAmountAfterFeesCryptoBaseUnit)
+
+            return buyAmount
+          },
+        ]
+    }
+  })()
+
+  const sortOrders: ('asc' | 'desc')[] = (() => {
+    switch (sortOption) {
+      case QuoteSortOption.LOWEST_GAS:
+        return ['asc', 'asc'] // Lowest to highest network fees
+      case QuoteSortOption.BEST_RATE:
+      default:
+        return ['desc'] // Highest to lowest received amount after fees
+    }
+  })()
+
+  const ordered = orderBy(quotesWithoutErrors, iteratees, sortOrders)
+
+  return ordered
 }
 
 export const sortTradeQuotes = (
   tradeQuotes: PartialRecord<SwapperName, Record<string, ApiQuote>>,
+  sortOption: QuoteSortOption = QuoteSortOption.BEST_RATE,
 ): ApiQuote[] => {
   const allQuotes = Object.values(tradeQuotes)
     .filter(isSome)
     .map(swapperQuotes => Object.values(swapperQuotes))
     .flat()
-  const happyQuotes = sortApiQuotes(allQuotes.filter(({ errors }) => errors.length === 0))
-  const errorQuotes = sortApiQuotes(allQuotes.filter(({ errors }) => errors.length > 0))
-  return [...happyQuotes, ...errorQuotes]
+
+  // Split quotes into those with and without errors
+  const quotesWithoutErrors = allQuotes.filter(quote => quote.errors.length === 0)
+  const quotesWithErrors = allQuotes.filter(quote => quote.errors.length > 0)
+
+  // Only sort quotes without errors
+  const sortedHappyQuotes = sortApiQuotes(quotesWithoutErrors, sortOption)
+
+  // Return sorted quotes without errors first, then quotes with errors
+  return [...sortedHappyQuotes, ...quotesWithErrors]
 }
 
 export const getActiveQuoteMetaOrDefault = (

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -23,7 +23,7 @@ import {
 } from '../marketDataSlice/selectors'
 import { selectFeatureFlags } from '../preferencesSlice/selectors'
 import { SWAPPER_USER_ERRORS } from './constants'
-import type { ActiveQuoteMeta } from './types'
+import type { ActiveQuoteMeta, QuoteSortOption } from './types'
 
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
@@ -187,10 +187,14 @@ export const selectTradeQuoteResponseErrors = createDeepEqualOutputSelector(
   },
 )
 
+export const selectQuoteSortOption = (state: ReduxState): QuoteSortOption =>
+  state.tradeQuoteSlice.sortOption
+
 export const selectSortedTradeQuotes = createDeepEqualOutputSelector(
-  selectTradeQuotes,
-  tradeQuotes => {
-    return sortTradeQuotes(tradeQuotes)
+  [selectTradeQuotes, selectQuoteSortOption],
+  (tradeQuotes, sortOption) => {
+    const result = sortTradeQuotes(tradeQuotes, sortOption)
+    return result
   },
 )
 
@@ -598,9 +602,7 @@ export const selectHopExecutionMetadata = createDeepEqualOutputSelector(
 
 export const selectTradeQuoteDisplayCache = createDeepEqualOutputSelector(
   selectTradeQuoteSlice,
-  tradeQuoteSlice => {
-    return tradeQuoteSlice.tradeQuoteDisplayCache
-  },
+  tradeQuoteSlice => tradeQuoteSlice.tradeQuoteDisplayCache,
 )
 
 export const selectIsTradeQuoteRequestAborted = createSelector(

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -14,6 +14,7 @@ export type TradeQuoteSliceState = {
   tradeQuotes: PartialRecord<SwapperName, Record<string, ApiQuote>> // mapping from swapperName to quoteId to ApiQuote
   tradeQuoteDisplayCache: ApiQuote[]
   isTradeQuoteRequestAborted: boolean // used to conditionally render results and loading state
+  sortOption: QuoteSortOption // the selected quote sorting option
 }
 
 export enum TransactionExecutionState {
@@ -30,6 +31,12 @@ export enum HopExecutionState {
   AwaitingPermit2Eip712Sign = 'AwaitingPermit2Eip712Sign',
   AwaitingSwap = 'AwaitingSwap',
   Complete = 'Complete',
+}
+
+export enum QuoteSortOption {
+  BEST_RATE = 'BEST_RATE', // Default sorting - best receive amount after all fees
+  LOWEST_GAS = 'LOWEST_GAS',
+  FASTEST = 'FASTEST',
 }
 
 export enum TradeExecutionState {

--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -4,6 +4,7 @@ import { arbitrumChainId, fromAccountId } from '@shapeshiftoss/caip'
 import type { TxTransfer } from '@shapeshiftoss/chain-adapters'
 import type { AccountMetadata } from '@shapeshiftoss/types'
 import { HistoryTimeframe } from '@shapeshiftoss/types'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
 import intersection from 'lodash/intersection'
 import isEmpty from 'lodash/isEmpty'
 import pickBy from 'lodash/pickBy'
@@ -167,6 +168,25 @@ export const selectTxIdsByFilter = createCachedSelector(
         filter.assetId ?? 'assetId'
       }`
     : 'txIdsByFilter',
+)
+
+export const selectTxIdsByFilterWithPendingFirst = createCachedSelector(
+  selectTxs,
+  selectTxIdsByFilter,
+  (txs, filteredTxIds): TxId[] => {
+    return [...filteredTxIds].sort((a, b) => {
+      if (txs[a].status === TxStatus.Pending && txs[b].status !== TxStatus.Pending) return -1
+      if (txs[b].status === TxStatus.Pending && txs[a].status !== TxStatus.Pending) return 1
+
+      return 0
+    })
+  },
+)((_state: ReduxState, filter) =>
+  filter
+    ? `${filter.accountId ?? 'accountId'}-${filter.txStatus ?? 'txStatus'}-${
+        filter.assetId ?? 'assetId'
+      }`
+    : 'txIdsByFilterWithPendingFirst',
 )
 
 export const selectTxIdsBasedOnSearchTermAndFilters = createCachedSelector(

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -7,6 +7,7 @@ import {
   PriceDirection,
 } from '@/state/slices/limitOrderInputSlice/constants'
 import { CurrencyFormats, HomeMarketView } from '@/state/slices/preferencesSlice/preferencesSlice'
+import { QuoteSortOption } from '@/state/slices/tradeQuoteSlice/types'
 
 const mockApiFactory = <T extends unknown>(reducerPath: T) => ({
   queries: {},
@@ -278,6 +279,7 @@ export const mockStore: ReduxState = {
     tradeQuotes: {},
     tradeQuoteDisplayCache: [],
     isTradeQuoteRequestAborted: false,
+    sortOption: QuoteSortOption.BEST_RATE,
   },
   limitOrderSlice: {
     activeQuote: undefined,

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -115,11 +115,6 @@ const styles = {
     '.app-height': {
       minHeight: '100vh',
     },
-    '.scroll-container': {
-      visibility: 'hidden',
-      paddingRight: '12px',
-      transition: 'visibility .5s ease-in-out',
-    },
     '.scroll-container::-webkit-scrollbar': {
       background: 'transparent',
       width: '8px',


### PR DESCRIPTION
fix: allow users to type 0 in limit inputs (#9052)
feat: limit url rewrite (#9042)
Merge branch 'main' into develop
fix: rFox APY rate (#9046)
feat: better limitOrderSlice type-safety (#9041)
feat: single tx list in the notification drawer (#9043)
feat: trade pages redirects on rehydration (#9040)
fix: leverage scroll-container instead of homemade scrollbar on limit orders (#9044)
feat: sortable quotes (#9010)
fix: precision things (#9039)
feat: show receive address throughout the entire execution flow (#9027)
fix: create multiple native wallets in a row (#9038)