### PR TITLE
feat: hide custom slippage input when auto is selected

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -177,22 +177,24 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
                   </Button>
                 </ButtonGroup>
               </Row.Value>
-              <Row.Value>
-                <FormControl isInvalid={isInvalid}>
-                  <InputGroup variant='filled'>
-                    <Input
-                      placeholder={slippageAmount}
-                      value={slippageAmount}
-                      type='number'
-                      _focus={focusStyle}
-                      onChange={handleChange}
-                      ref={inputRef}
-                      isDisabled={slippageType === SlippageType.Auto}
-                    />
-                    <InputRightElement>%</InputRightElement>
-                  </InputGroup>
-                </FormControl>
-              </Row.Value>
+              {slippageType === SlippageType.Custom && (
+                <Row.Value>
+                  <FormControl isInvalid={isInvalid}>
+                    <InputGroup variant='filled'>
+                      <Input
+                        placeholder={slippageAmount}
+                        value={slippageAmount}
+                        type='number'
+                        _focus={focusStyle}
+                        onChange={handleChange}
+                        ref={inputRef}
+                        autoFocus
+                      />
+                      <InputRightElement>%</InputRightElement>
+                    </InputGroup>
+                  </FormControl>
+                </Row.Value>
+              )}
             </Row>
             {isHighSlippage && (
               <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>


### PR DESCRIPTION
## Description

Based on user feedback, we will be hiding the custom input field while auto is selected. This should avoid any confusion on what the slippage actually is for the trade.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Go to the trade page.
Open the trade settings
Toggle auto to custom
You will see the custom slippage input appear

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>


## Screenshots (if applicable)
![Screenshot 2025-03-17 at 11 27 13 AM](https://github.com/user-attachments/assets/68b29d5f-c291-4783-ab9a-08b1c1757e00)
![Screenshot 2025-03-17 at 11 27 16 AM](https://github.com/user-attachments/assets/b454934d-7e4a-449c-be5f-608154b3e640)
