### PR TITLE
fix: quote selection click on smaller viewports

### DIFF
--- a/src/components/MultiHopTrade/MultiHopTrade.tsx
+++ b/src/components/MultiHopTrade/MultiHopTrade.tsx
@@ -110,6 +110,14 @@ export const MultiHopTrade = memo(
     }, [dispatch, routeBuyAsset, routeSellAsset, sellAmountCryptoBaseUnit, isInitialized])
 
     useEffect(() => {
+      // Poor man's check for input route. Do not rewrite URL on those routes, or problems.
+      const isInputRoute =
+        !location.pathname.includes(TradeRoutePaths.QuoteList) &&
+        !location.pathname.includes(TradeRoutePaths.Quotes) &&
+        !location.pathname.includes(TradeRoutePaths.VerifyAddresses)
+
+      if (!isInputRoute) return
+
       if (isRewritingUrl) {
         const sellAmountBaseUnit = sellInputAmountCryptoBaseUnit ?? sellAmountCryptoBaseUnit ?? ''
 
@@ -123,6 +131,7 @@ export const MultiHopTrade = memo(
       history,
       sellInputAmountCryptoBaseUnit,
       sellAmountCryptoBaseUnit,
+      location.pathname,
     ])
 
     return (


### PR DESCRIPTION
## Description

Ensures we don't rewrite URL when in /quotes-list (and other non-input routes), which currently routes back to input.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, this was blatantly wrong

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Able to select quotes with a smaller viewport (e.g smaller window or mobile)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Develop

https://jam.dev/c/c74c8993-a89d-4c9c-ac53-aa53308ab874

- This diff

https://jam.dev/c/bbe28293-1ce7-42ed-b49f-3a258afaa1f6


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
