### PR TITLE
fix: make limit orders great again

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -270,23 +270,11 @@ export const LimitOrderConfig = ({
     }
 
     if (priceDirection === PriceDirection.BuyAssetDenomination) {
-      return bnOrZero(sellAmountCryptoPrecision)
-        .times(limitPrice.buyAssetDenomination)
-        .decimalPlaces(buyAsset.precision)
-        .toString()
+      return bnOrZero(sellAmountCryptoPrecision).times(limitPrice.buyAssetDenomination).toString()
     }
 
-    return bnOrZero(sellAmountCryptoPrecision)
-      .div(limitPrice.sellAssetDenomination)
-      .decimalPlaces(sellAsset.precision)
-      .toString()
-  }, [
-    limitPrice,
-    priceDirection,
-    sellAmountCryptoPrecision,
-    buyAsset.precision,
-    sellAsset.precision,
-  ])
+    return bnOrZero(sellAmountCryptoPrecision).div(limitPrice.sellAssetDenomination).toString()
+  }, [limitPrice, priceDirection, sellAmountCryptoPrecision])
 
   const limitOrderExplanation = useMemo(() => {
     if (

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -62,7 +62,7 @@ import {
   selectSellAccountId,
   selectSellAssetBalanceCryptoBaseUnit,
 } from '@/state/slices/limitOrderInputSlice/selectors'
-import { makeLimitInputOutputRatio } from '@/state/slices/limitOrderSlice/helpers'
+import { calcLimitPriceTargetAsset } from '@/state/slices/limitOrderSlice/helpers'
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
 import { selectActiveQuoteNetworkFeeUserCurrency } from '@/state/slices/limitOrderSlice/selectors'
 import { useFindMarketDataByAssetIdQuery } from '@/state/slices/marketDataSlice/marketDataSlice'
@@ -247,12 +247,27 @@ export const LimitOrderInput = ({
   const marketPriceBuyAsset = useMemo(() => {
     if (!(sellAssetMarketDataUsd && buyAssetMarketDataUsd)) return '0'
 
-    return makeLimitInputOutputRatio({
-      sellPriceUsd: sellAssetMarketDataUsd,
-      buyPriceUsd: buyAssetMarketDataUsd,
-      targetAssetPrecision: buyAsset.precision,
+    // Ensure we zero out the price if there is an error, and when we are fetching, as `quoteResponse` will be stale data in both cases
+    if (isLimitOrderQuoteFetching || quoteResponseError) return '0'
+    // RTK query returns stale data when `skipToken` is used, so we need to handle that case here.
+    if (!quoteResponse || limitOrderQuoteParams === skipToken) return '0'
+
+    return calcLimitPriceTargetAsset({
+      sellAmountCryptoBaseUnit: quoteResponse.quote.sellAmount,
+      buyAmountCryptoBaseUnit: quoteResponse.quote.buyAmount,
+      sellAsset,
+      buyAsset,
     })
-  }, [sellAssetMarketDataUsd, buyAssetMarketDataUsd, buyAsset])
+  }, [
+    sellAssetMarketDataUsd,
+    buyAssetMarketDataUsd,
+    isLimitOrderQuoteFetching,
+    quoteResponseError,
+    quoteResponse,
+    limitOrderQuoteParams,
+    sellAsset,
+    buyAsset,
+  ])
 
   // Update the limit price when the market price changes.
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -62,10 +62,7 @@ import {
   selectSellAccountId,
   selectSellAssetBalanceCryptoBaseUnit,
 } from '@/state/slices/limitOrderInputSlice/selectors'
-import {
-  calcLimitPriceTargetAsset,
-  makeLimitInputOutputRatio,
-} from '@/state/slices/limitOrderSlice/helpers'
+import { makeLimitInputOutputRatio } from '@/state/slices/limitOrderSlice/helpers'
 import { limitOrderSlice } from '@/state/slices/limitOrderSlice/limitOrderSlice'
 import { selectActiveQuoteNetworkFeeUserCurrency } from '@/state/slices/limitOrderSlice/selectors'
 import { useFindMarketDataByAssetIdQuery } from '@/state/slices/marketDataSlice/marketDataSlice'

--- a/src/state/slices/limitOrderSlice/helpers.ts
+++ b/src/state/slices/limitOrderSlice/helpers.ts
@@ -37,3 +37,17 @@ export const calcLimitPriceTargetAsset = ({
     .div(fromBaseUnit(sellAmountCryptoBaseUnit, sellAsset.precision))
     .toFixed()
 }
+
+export const makeLimitInputOutputRatio = ({
+  sellPriceUsd,
+  buyPriceUsd,
+  targetAssetPrecision,
+}: {
+  sellPriceUsd: string
+  buyPriceUsd: string
+  targetAssetPrecision: number
+}): string => {
+  const ratio = bnOrZero(sellPriceUsd).div(bnOrZero(buyPriceUsd))
+
+  return ratio.toFixed(targetAssetPrecision)
+}

--- a/src/state/slices/limitOrderSlice/helpers.ts
+++ b/src/state/slices/limitOrderSlice/helpers.ts
@@ -37,17 +37,3 @@ export const calcLimitPriceTargetAsset = ({
     .div(fromBaseUnit(sellAmountCryptoBaseUnit, sellAsset.precision))
     .toFixed()
 }
-
-export const makeLimitInputOutputRatio = ({
-  sellPriceUsd,
-  buyPriceUsd,
-  targetAssetPrecision,
-}: {
-  sellPriceUsd: string
-  buyPriceUsd: string
-  targetAssetPrecision: number
-}): string => {
-  const ratio = bnOrZero(buyPriceUsd).div(bnOrZero(sellPriceUsd))
-
-  return ratio.toFixed(targetAssetPrecision)
-}


### PR DESCRIPTION
## Description

Fixes issue where the limit ratio used for calculations is backwards: https://github.com/shapeshift/web/pull/9053#issuecomment-2731666028

Also ensures that `receiveAmountFormatted` is constant and does not change when `PriceDirection` changes.

## Issue (if applicable)

N/A, blocking current release.

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Limit order quote UI.

## Testing

Get limit order quotes and observe that the values make sense again (including fiat and price direction toggles).

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See review comment above.