### PR TITLE
feat: remove happy/error quotes buckets

### DIFF
--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -152,12 +152,9 @@ const sortApiQuotes = (
   unorderedQuotes: ApiQuote[],
   sortOption: QuoteSortOption = QuoteSortOption.BEST_RATE,
 ): ApiQuote[] => {
-  // First, filter out quotes with errors - those belong in the unavailable section
-  const quotesWithoutErrors = unorderedQuotes.filter(quote => quote.errors.length === 0)
-
   // Custom sorting function rather than an orderBy iteratee to keep my sanity, since this didn't play too well with it
   if (sortOption === QuoteSortOption.FASTEST) {
-    const sorted = [...quotesWithoutErrors].sort((a, b) => {
+    const sorted = [...unorderedQuotes].sort((a, b) => {
       const getExecutionTime = (quote: ApiQuote) => {
         if (!quote.quote?.steps?.length) return undefined
 
@@ -232,7 +229,7 @@ const sortApiQuotes = (
     }
   })()
 
-  const ordered = orderBy(quotesWithoutErrors, iteratees, sortOrders)
+  const ordered = orderBy(unorderedQuotes, iteratees, sortOrders)
 
   return ordered
 }
@@ -246,15 +243,7 @@ export const sortTradeQuotes = (
     .map(swapperQuotes => Object.values(swapperQuotes))
     .flat()
 
-  // Split quotes into those with and without errors
-  const quotesWithoutErrors = allQuotes.filter(quote => quote.errors.length === 0)
-  const quotesWithErrors = allQuotes.filter(quote => quote.errors.length > 0)
-
-  // Only sort quotes without errors
-  const sortedHappyQuotes = sortApiQuotes(quotesWithoutErrors, sortOption)
-
-  // Return sorted quotes without errors first, then quotes with errors
-  return [...sortedHappyQuotes, ...quotesWithErrors]
+  return sortApiQuotes(allQuotes, sortOption)
 }
 
 export const getActiveQuoteMetaOrDefault = (

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -443,10 +443,8 @@ export const tradeQuoteSlice = createSlice({
 
       const allQuotes = uniqBy(sortedQuotesWithoutOriginalIndex.concat(staleQuotes), 'id')
 
-      const happyQuotes = allQuotes.filter(({ errors }) => errors.length === 0)
-      const errorQuotes = allQuotes.filter(({ errors }) => errors.length > 0)
-
-      state.tradeQuoteDisplayCache = happyQuotes.concat(errorQuotes)
+      // Keep all quotes in their sorted order, regardless of errors
+      state.tradeQuoteDisplayCache = allQuotes
     },
     setHopProgress: (
       state,


### PR DESCRIPTION
## Description

...in quotes sorting.

See [this comment](https://github.com/shapeshift/web/pull/9010#discussion_r1996051032):

> It's a bit of a confusing one and I was just as confused by it but yeah this is still needed!
There's kind of like two layers of errors:

"hard errors" meaning there was no quote gotten whatsoever, these go to "Unavailable"
"soft errors" (there was a quote but it's not actionable e.g not enough fundus, these get pushed at the end of the quotes list because they can't be actioned


This PR removes the logic pushing "soft-errored" quotes at the end of the list anymore, which doesn't play nicely with sorting. This also simplifies things as what we call errors are now actual 
errors and there's no mental overhead in trying to figure out an inherent and undocumented notion of "soft errors" / "user errors" vs. "actual bad boi errors".
Unable to get a quote and we error? That's an error and it goes to unavailable. Available to get a quote? Display it. Easy as!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9069

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test quotes/sorting with/out a wallet connected and ensure we're looking gucci

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/6103b95a-6392-4ab1-994c-add4f7ddaa04


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
