### PR TITLE
fix: polish swapper footer and gas row style

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderConfirm.tsx
@@ -428,7 +428,7 @@ export const LimitOrderConfirm = () => {
 
   const footer = useMemo(() => {
     if (!detail && !button) return null
-    return <SharedConfirmFooter detail={detail} button={button} />
+    return <SharedConfirmFooter detail={detail} button={button} pt={0} />
   }, [detail, button])
 
   // We should have some submission state here... unless we're rehydrating or trying to access /limit/confirm directly

--- a/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderDetail.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrderV2/LimitOrderDetail.tsx
@@ -21,6 +21,10 @@ import {
 import { selectMarketDataByAssetIdUserCurrency } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
+const rateGasRowSx = {
+  mb: 3,
+}
+
 export const LimitOrderDetail = () => {
   const translate = useTranslate()
 
@@ -54,8 +58,9 @@ export const LimitOrderDetail = () => {
       networkFeeFiatUserCurrency='0' // no network fees for CoW, this is a message signing
       swapperName={SwapperName.CowSwap}
       swapSource={SwapperName.CowSwap}
+      sx={rateGasRowSx}
     >
-      <Stack spacing={4} width='full' px={6} pb={3}>
+      <Stack spacing={4} width='full' px={6} py={3}>
         <Row>
           <Row.Label>
             <Text translation='limitOrder.expiration' />
@@ -64,7 +69,7 @@ export const LimitOrderDetail = () => {
             <TransactionDate blockTime={quoteExpirationTimestamp ?? 0} />
           </Row.Value>
         </Row>
-        <Card bg='background.surface.raised.pressed' borderRadius={6} p={4} mb={2}>
+        <Card borderRadius={6} p={4} mb={2}>
           <HStack>
             <InfoIcon boxSize='1.3em' color='text.info' />
             <RawText>{translate('limitOrder.confirmInfo')}</RawText>

--- a/src/components/MultiHopTrade/components/RateGasRow.tsx
+++ b/src/components/MultiHopTrade/components/RateGasRow.tsx
@@ -1,5 +1,5 @@
 import { ChevronDownIcon, ChevronUpIcon, InfoIcon } from '@chakra-ui/icons'
-import type { FlexProps } from '@chakra-ui/react'
+import type { FlexProps, StackProps } from '@chakra-ui/react'
 import {
   Box,
   Collapse,
@@ -47,6 +47,7 @@ type RateGasRowProps = {
   invertRate?: boolean
   noExpand?: boolean
   isOpen?: boolean
+  sx?: StackProps['sx']
 } & PropsWithChildren
 
 const helpersTooltipFlexProps: FlexProps = { flexDirection: 'row-reverse' }
@@ -66,6 +67,7 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
     deltaPercentage,
     noExpand,
     invertRate,
+    sx,
   }) => {
     const translate = useTranslate()
     const { isOpen, onToggle } = useDisclosure()
@@ -185,6 +187,7 @@ export const RateGasRow: FC<RateGasRowProps> = memo(
             transitionProperty='common'
             transitionDuration='normal'
             fontSize='sm'
+            sx={sx}
           >
             <Flex
               _hover={noExpand ? undefined : rowHover}

--- a/src/components/MultiHopTrade/components/SharedConfirm/SharedConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedConfirm/SharedConfirmFooter.tsx
@@ -1,13 +1,14 @@
+import type { StackProps } from '@chakra-ui/react'
 import { Stack } from '@chakra-ui/react'
 
-type SharedConfirmFooterProps = {
+type SharedConfirmFooterProps = StackProps & {
   detail: JSX.Element | null
   button: JSX.Element | null
 }
 
-export const SharedConfirmFooter = ({ detail, button }: SharedConfirmFooterProps) => {
+export const SharedConfirmFooter = ({ detail, button, ...props }: SharedConfirmFooterProps) => {
   return (
-    <Stack width='full' py={4} bg='background.surface.raised.accent'>
+    <Stack width='full' py={4} bg='background.surface.raised.accent' {...props}>
       {detail}
       {button}
     </Stack>

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -298,6 +298,14 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     tradeExecutionStepSummary,
   ])
 
+  const sharedConfirmFooterPaddingTop = useMemo(() => {
+    if (!currentTradeStep) {
+      return 0
+    }
+
+    return 4
+  }, [currentTradeStep])
+
   const footerButton = useMemo(() => {
     if (!tradeQuoteStep || currentHopIndex === undefined || !activeTradeId) return null
     return (
@@ -318,5 +326,11 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isNetworkFeeCryptoBaseUnitRefetching,
   ])
 
-  return <SharedConfirmFooter detail={tradeDetail} button={footerButton} />
+  return (
+    <SharedConfirmFooter
+      detail={tradeDetail}
+      button={footerButton}
+      pt={sharedConfirmFooterPaddingTop}
+    />
+  )
 }

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
@@ -94,7 +94,7 @@ export const TradeConfirmSummary = () => {
       swapSource={tradeQuoteFirstHop?.source}
       isOpen
     >
-      <Stack spacing={4} px={6} pb={3} width='full'>
+      <Stack spacing={4} px={6} py={3} width='full'>
         <Row Tooltipbody={networkFeeTooltipBody}>
           <Row.Label>
             <Text translation='trade.networkFee' />


### PR DESCRIPTION
## Description

Gas row and footer spacing, background and style was off, this is some details but it makes it more professional!

See the before/after

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

None, on my own

## Risk
Low, mainly visual
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try swapper + limit and see if styles around the footer/confirm button/gas row is fine
- Also try to finish a swap and a limit and see if the style is fine
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

## Swapper
### Before
![image](https://github.com/user-attachments/assets/17189815-6523-41a7-b167-5d9e9942eb1d)
![image](https://github.com/user-attachments/assets/46875568-3250-4846-8db4-2acd0b939d1d)

### After
![image](https://github.com/user-attachments/assets/9588c3fe-f817-4f45-bced-a44c74f8e073)
![image](https://github.com/user-attachments/assets/b393cb67-1f9b-4e58-a9e7-06ab2fdcd985)
![image](https://github.com/user-attachments/assets/719d65b0-9f34-46d9-9752-494f2d754781)

## Limit

### Before
![image](https://github.com/user-attachments/assets/4e5a8299-9c39-42db-a22c-4e65e1758566)
![image](https://github.com/user-attachments/assets/490098f0-e55e-4598-9c39-d583925271d5)
![image](https://github.com/user-attachments/assets/ca461e8b-4ba3-4b34-aa02-383138c50eab)

### After
![image](https://github.com/user-attachments/assets/a4527aea-df04-409c-b7c9-5f9a9e1df886)
![image](https://github.com/user-attachments/assets/e3fc99e3-e6d2-41e1-9412-7297202506e6)
![image](https://github.com/user-attachments/assets/e4ff6f36-0ca0-4e84-ada3-01b6f3647483)

