### PR TITLE
feat: thorchain swapper parse refund errors

### DIFF
--- a/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
@@ -655,6 +655,14 @@ export const thorchainApi: SwapperApi = {
       const hasOutboundL1Tx = lastOutTx !== undefined && lastOutTx.chain !== 'THOR'
       const hasOutboundRuneTx = lastOutTx !== undefined && lastOutTx.chain === 'THOR'
 
+      if (txStatusData.planned_out_txs?.some(plannedOutTx => plannedOutTx.refund)) {
+        return {
+          buyTxHash,
+          status: TxStatus.Failed,
+          message: undefined,
+        }
+      }
+
       // We consider the transaction confirmed as soon as we have a buyTxHash
       // For UTXOs, this means that the swap will be confirmed as soon as Txs hit the mempool
       // Which is actually correct, as we update UTXO balances optimistically

--- a/packages/swapper/src/thorchain-utils/memo/addLimitToMemo.ts
+++ b/packages/swapper/src/thorchain-utils/memo/addLimitToMemo.ts
@@ -1,5 +1,3 @@
-import { bnOrZero } from '@shapeshiftoss/utils'
-
 import { assertAndProcessMemo } from './assertAndProcessMemo'
 import { MEMO_PART_DELIMITER } from './constants'
 
@@ -33,9 +31,9 @@ export const addLimitToMemo = ({ memo, limit }: AddLimitToMemoArgs) => {
     case 's': {
       // SWAP:ASSET:DESTADDR:LIM/INTERVAL/QUANTITY:AFFILIATE:FEE
       const [, asset, destAddr, _limit, affiliate, fee] = memoParts
-      updatedMemo = `${action}:${asset}:${destAddr}:${bnOrZero(limit).times(100).toFixed()}:${
-        affiliate || ''
-      }:${fee || ''}`
+      if (!_limit) {
+        updatedMemo = `${action}:${asset}:${destAddr}:${limit}:${affiliate || ''}:${fee || ''}`
+      }
       break
     }
     case '$+':

--- a/packages/swapper/src/thorchain-utils/memo/addLimitToMemo.ts
+++ b/packages/swapper/src/thorchain-utils/memo/addLimitToMemo.ts
@@ -1,3 +1,5 @@
+import { bnOrZero } from '@shapeshiftoss/utils'
+
 import { assertAndProcessMemo } from './assertAndProcessMemo'
 import { MEMO_PART_DELIMITER } from './constants'
 
@@ -31,9 +33,9 @@ export const addLimitToMemo = ({ memo, limit }: AddLimitToMemoArgs) => {
     case 's': {
       // SWAP:ASSET:DESTADDR:LIM/INTERVAL/QUANTITY:AFFILIATE:FEE
       const [, asset, destAddr, _limit, affiliate, fee] = memoParts
-      if (!_limit) {
-        updatedMemo = `${action}:${asset}:${destAddr}:${limit}:${affiliate || ''}:${fee || ''}`
-      }
+      updatedMemo = `${action}:${asset}:${destAddr}:${bnOrZero(limit).times(100).toFixed()}:${
+        affiliate || ''
+      }:${fee || ''}`
       break
     }
     case '$+':


### PR DESCRIPTION
## Description

Precisely what it says on the box.

We were precisely checking for `out_txs` as our own only criteria for complete, however, a refund Tx *is* an out Tx.

This fixes it by:

- Checking for refund `planned_out_txs` (note, not in `out_txs` as refund data isn't present there as an explicit prop, only in the memo)
- Using the same buyTxHash we did above, but with error status for this specific branch. Note, `buyTxHash` could potentially be undefined if for any reason a planned out Tx cannot be sent, so this allows us to have our cake and eat it.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9016

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, relates to THOR refunds only

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure THOR Txs still go through 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Revert 69328597042eb80f223b8ac46a83b655a4794fcb
- Ensure refunds are properly detected as failures

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<img width="526" alt="image" src="https://github.com/user-attachments/assets/0e83a923-5750-41b3-92dc-34e12e1fab76" />

https://jam.dev/c/13c4219b-d894-49c3-ba95-1e1f83c2c3ac


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
