### PR TITLE
fix: send mixpanel quotes event only if the user receive quotes

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeQuotes.tsx
@@ -417,7 +417,7 @@ export const useGetTradeQuotes = () => {
   // TODO: move to separate hook so we don't need to pull quote data into here
   useEffect(() => {
     if (isAnyTradeQuoteLoading) return
-    if (mixpanel) {
+    if (mixpanel && sortedTradeQuotes.length > 0) {
       const quoteData = getMixPanelDataFromApiQuotes(sortedTradeQuotes)
       mixpanel.track(MixPanelEvent.QuotesReceived, quoteData)
     }

--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
@@ -320,7 +320,7 @@ export const useGetTradeRates = () => {
   // TODO: move to separate hook so we don't need to pull quote data into here
   useEffect(() => {
     if (isAnyTradeQuoteLoading) return
-    if (mixpanel) {
+    if (mixpanel && sortedTradeQuotes.length) {
       const quoteData = getMixPanelDataFromApiRates(sortedTradeQuotes)
       mixpanel.track(MixPanelEvent.QuotesReceived, quoteData)
     }


### PR DESCRIPTION
## Description

The `Quotes Received` event was sent even if there were no quotes, causing it to send useless event + sending an event on first render which is weird

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9079

## Risk
Low

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- I would suggest to make it tested by an engineer in local: monkeypatch to see when the user receive the quotes and compare with develop, the event shouldn't be sent until the user types some amount and receive quotes
- When releasing, check the network tabs, mixpanel quotes event shouldn't be sent until the user actually receive quotes

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Hard to show but, no amount entered and no quotes fetch:
![image](https://github.com/user-attachments/assets/e937ca91-bc4e-439b-968b-0c6885fa9336)


Amount entered and quote fetch:
![image](https://github.com/user-attachments/assets/91f1f221-5d76-443f-9244-6d795ebb0f79)

