### PR TITLE
feat: dynamic hash routing

### DIFF
--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -15,7 +15,7 @@ jobs:
     # syntax is if condition && true || false
     # i.e. if it's a pull request, use the head ref, otherwise use the ref name
     # so ultimately we only run this workflow against the whitelisted branches
-    if: contains(fromJSON('["develop", "release", "yeet", "main", "private", "beard", "juice", "wood", "gome", "neo", "arkeo"]'), github.event_name == 'pull_request' && github.head_ref || github.ref_name)
+    if: contains(fromJSON('["develop", "release", "yeet", "main", "private", "beard", "juice", "wood", "gome", "neo", "arkeo", "dynamic-hash-routing"]'), github.event_name == 'pull_request' && github.head_ref || github.ref_name)
     runs-on: size-bertha
     name: Build
     steps:

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -74,5 +74,5 @@ jobs:
         run: npx -y wrangler@2 pages publish build --project-name="${{ env.PROJECT_NAME }}" --branch="${{ env.CURRENT_BRANCH_NAME }}" --commit-hash="${{ env.COMMIT_SHORT_HASH }}" --commit-message="${{ env.CURRENT_BRANCH_NAME }}-${{ env.COMMIT_SHORT_HASH }}"
       # deploy main branch to fleek.xyz alpha environment
       - name: Deploy to Fleek
-        if: contains(fromJSON('["main"]'), github.event_name == 'pull_request' && github.head_ref || github.ref_name)
+        if: contains(fromJSON('["main", "dynamic-hash-routing"]'), github.event_name == 'pull_request' && github.head_ref || github.ref_name)
         run: npm i -g @fleekxyz/cli && fleek sites deploy

--- a/public/ipfs-404.html
+++ b/public/ipfs-404.html
@@ -1,17 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <script>
-      const target = new URL(window.location.href);
-      if (target.pathname !== '/') {
+
+<head>
+  <meta charset="utf-8" />
+  <script>
+    const target = new URL(window.location.href);
+    const isIPFS = () => {
+      return (
+        target.includes('fleek.')
+      );
+    };
+
+    if (isIPFS()) {
+      if (target.pathname !== '/' && !target.pathname.includes('.')) {
         target.hash = '#' + target.pathname;
         target.pathname = '/';
         window.location.replace(target.toString());
       }
-    </script>
-  </head>
-  <body>
-    Redirecting...
-  </body>
+    }
+  </script>
+</head>
+
+<body>
+  Redirecting...
+</body>
+
 </html>

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -16,7 +16,7 @@ import { Provider as ReduxProvider } from 'react-redux'
 import { PersistGate } from 'redux-persist/integration/react'
 import { WagmiProvider } from 'wagmi'
 
-import { ConditionalRouter } from './components/ConditionalRouter'
+import { ConditionalRouter } from './context/ConditionalRouter'
 import { ScrollToTop } from './Routes/ScrollToTop'
 
 import { ChatwootWidget } from '@/components/ChatWoot'

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -13,10 +13,10 @@ import React, { useCallback } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { HelmetProvider } from 'react-helmet-async'
 import { Provider as ReduxProvider } from 'react-redux'
-import { HashRouter } from 'react-router-dom'
 import { PersistGate } from 'redux-persist/integration/react'
 import { WagmiProvider } from 'wagmi'
 
+import { ConditionalRouter } from './components/ConditionalRouter'
 import { ScrollToTop } from './Routes/ScrollToTop'
 
 import { ChatwootWidget } from '@/components/ChatWoot'
@@ -78,7 +78,7 @@ export function AppProviders({ children }: ProvidersProps) {
                 <ChakraProvider theme={theme} colorModeManager={manager} cssVarsRoot='body'>
                   <ToastContainer />
                   <PersistGate loading={splashScreen} persistor={persistor}>
-                    <HashRouter basename='/'>
+                    <ConditionalRouter basename='/'>
                       <ScrollToTop />
                       <BrowserRouterProvider>
                         <I18nProvider>
@@ -108,7 +108,7 @@ export function AppProviders({ children }: ProvidersProps) {
                           </WalletProvider>
                         </I18nProvider>
                       </BrowserRouterProvider>
-                    </HashRouter>
+                    </ConditionalRouter>
                   </PersistGate>
                 </ChakraProvider>
               </PluginProvider>

--- a/src/context/ConditionalRouter.tsx
+++ b/src/context/ConditionalRouter.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { BrowserRouter, HashRouter } from 'react-router-dom'
+
+type ConditionalRouterProps = {
+  children: React.ReactNode
+  basename?: string
+}
+
+export const ConditionalRouter: React.FC<ConditionalRouterProps> = ({ children, basename }) => {
+  // Check if we're on Fleek hosting
+  const useHashRouter = window.location.hostname.includes('fleek.')
+
+  if (useHashRouter) {
+    return <HashRouter basename={basename}>{children}</HashRouter>
+  }
+
+  return <BrowserRouter basename={basename}>{children}</BrowserRouter>
+}


### PR DESCRIPTION
## Description

Implements dynamic hash routing so we can:

- Clean up our URL paths by removing the `/#` for non-IPFS deployments
- Keep our fleek IPFS deployment working by keeping the `/#` when the fleek URL is detected

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8948

## Risk

Small - assuming routing works during testing for IPFS and non-IPFS deployments, we should be good.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

- This diff deployed to IPFS should route correctly (i.e. use the hash routing)
- The diff deplored to production should route correctly (no hash routing)

### Engineering

TODO - I'll monkey-patch a yml file before opening this to deploy to IPFS and confirm it all works as expected.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

TODO 

## Screenshots (if applicable)

N/A