### PR TITLE
chore: add RatesReceived event

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
@@ -322,7 +322,7 @@ export const useGetTradeRates = () => {
     if (isAnyTradeQuoteLoading) return
     if (mixpanel && sortedTradeQuotes.length) {
       const quoteData = getMixPanelDataFromApiRates(sortedTradeQuotes)
-      mixpanel.track(MixPanelEvent.QuotesReceived, quoteData)
+      mixpanel.track(MixPanelEvent.RatesReceived, quoteData)
     }
   }, [sortedTradeQuotes, mixpanel, isAnyTradeQuoteLoading])
 }

--- a/src/lib/mixpanel/types.ts
+++ b/src/lib/mixpanel/types.ts
@@ -51,6 +51,7 @@ export enum MixPanelEvent {
   Error = 'Error',
   PageView = 'Page View',
   QuotesReceived = 'Quotes Received',
+  RatesReceived = 'Rates Received',
   SnapInstalled = 'Snap Installed',
   StartAddSnap = 'Start Add Snap',
   LpDepositPreview = 'LP Deposit Preview',


### PR DESCRIPTION
## Description

Add a `RatesReceived` event to disambiguate the rates and quotes step. See the below flow chart for the current issue this PR will solve. The first event will be solved by https://github.com/shapeshift/web/pull/9091. The second by this PR:

<img width="1273" alt="Screenshot 2025-03-21 at 1 22 12 pm" src="https://github.com/user-attachments/assets/ee1ea5e2-c8ce-41cd-94d2-71b50b4a1dcb" />

<img width="742" alt="Screenshot 2025-03-21 at 1 20 38 pm" src="https://github.com/user-attachments/assets/281a3e27-de26-49fc-bad6-9c022051c09e" />

## Issue (if applicable)

N/A - general followup on helping the marketing team.

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure the `RatesReceived` first when _rates_ are received.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.