### PR TITLE
fix: use correct mixpanel dev project id

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -7,7 +7,7 @@
 # feature flags
 
 # mixpanel
-VITE_MIXPANEL_TOKEN=1c1369f6ea23a6404bac41b42817cc4b
+VITE_MIXPANEL_TOKEN=a867ce40912a6b7d01d088cf62b0e1ff
 
 # unchained
 VITE_UNCHAINED_ETHEREUM_HTTP_URL=https://dev-api.ethereum.shapeshift.com

--- a/.env.test
+++ b/.env.test
@@ -2,7 +2,7 @@
 VITE_FEATURE_CHATWOOT=true
 
 # mixpanel
-VITE_MIXPANEL_TOKEN=1c1369f6ea23a6404bac41b42817cc4b
+VITE_MIXPANEL_TOKEN=a867ce40912a6b7d01d088cf62b0e1ff
 
 # unchained
 VITE_UNCHAINED_ETHEREUM_HTTP_URL=https://api.ethereum.shapeshift.com

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ MixPanel is used for non-private deployments of the interface.
 We have a test MixPanel environment for developing and testing. To use this, update the `.env` file to include:
 
 ```sh
-REACT_APP_MIXPANEL_TOKEN=dev-project-id
-REACT_APP_FEATURE_MIXPANEL=true
+VITE_MIXPANEL_TOKEN=dev-project-id
+VITE_FEATURE_MIXPANEL=true
 ```
 
 The MixPanel project UI will now show events from your local session.


### PR DESCRIPTION
## Description

Fixes an issue where we use the wrong MixPanel project ID for the dev project.

<img width="1278" alt="Screenshot 2025-03-21 at 1 28 03 pm" src="https://github.com/user-attachments/assets/b31d2cef-3886-477e-96b0-7e780443afa8" />

## Issue (if applicable)

N/A

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

When locally devving with default dev env vars MixPanel events should work again.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Retrosepcctively this will _probably_ backfill to develop.shapeshift.com(?)

## Screenshots (if applicable)

See above.