### PR TITLE
fix: choosing a different swapper route in the mini swapper causes the input field to go to zero

### DIFF
--- a/src/components/Layout/Header/GlobalSearch/GlobalSearchModal.tsx
+++ b/src/components/Layout/Header/GlobalSearch/GlobalSearchModal.tsx
@@ -27,7 +27,8 @@ import {
   GlobalSearchResultType,
   selectGlobalItemsFromFilter,
 } from '@/state/slices/search-selectors'
-import { useAppSelector } from '@/state/store'
+import { tradeInput } from '@/state/slices/tradeInputSlice/tradeInputSlice'
+import { useAppDispatch, useAppSelector } from '@/state/store'
 
 const inputGroupProps = { size: 'xl' }
 const sxProp2 = { p: 0 }
@@ -46,6 +47,7 @@ export const GlobalSearchModal = memo(
     const [menuNodes] = useState(() => new MultiRef<number, HTMLElement>())
     const eventRef = useRef<'mouse' | 'keyboard' | null>(null)
     const history = useHistory()
+    const dispatch = useAppDispatch()
 
     const globalSearchFilter = useMemo(() => ({ searchQuery }), [searchQuery])
     const results = useAppSelector(state => selectGlobalItemsFromFilter(state, globalSearchFilter))
@@ -102,6 +104,8 @@ export const GlobalSearchModal = memo(
             break
           }
           case GlobalSearchResultType.Asset: {
+            // Reset the sell amount to zero, since we may be coming from a different sell asset in regular swapper
+            dispatch(tradeInput.actions.setSellAmountCryptoPrecision('0'))
             const url = `/assets/${item.id}`
             history.push(url)
             onToggle()
@@ -119,7 +123,7 @@ export const GlobalSearchModal = memo(
             break
         }
       },
-      [history, onToggle, searchQuery, send],
+      [history, onToggle, searchQuery, send, dispatch],
     )
 
     const onKeyDown = useCallback(

--- a/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/TradeInput.tsx
@@ -185,14 +185,6 @@ export const TradeInput = ({
     dispatch(tradeQuoteSlice.actions.clearTradeQuotes())
   }, [dispatch])
 
-  // Reset the sell amount to zero on mount if this is a standalone swapper, since we may be coming from a different
-  // sell asset in regular swapper
-  useEffect(() => {
-    if (isStandalone) {
-      dispatch(tradeInput.actions.setSellAmountCryptoPrecision('0'))
-    }
-  }, [dispatch, isStandalone])
-
   useEffect(() => {
     // Reset the trade warning if the active quote has changed, i.e. a better quote has come in and the
     // user has not yet confirmed the previous one


### PR DESCRIPTION


## Description
Moves the sell amount reset logic into `GlobalSearchModal `, so we don't have to rely on the life cycle of `TradeInput`
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9090

## Risk

> High Risk PRs Require 2 approvals

None
<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

- Input any sell amount in mini swapper
- Choose another route
- Ensure the amount is not reseted
---
- Input any sell amount in regular swapper on any chain
- Select another asset on mainnet in asset search
- Ensure amount resets to zero on mini swapper

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
