### PR TITLE
fix: global qr code button WCV2 crash

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -84,8 +84,8 @@ export function AppProviders({ children }: ProvidersProps) {
                         <I18nProvider>
                           <WalletProvider>
                             <KeepKeyProvider>
-                              <ModalProvider>
                                 <WalletConnectV2Provider>
+                              <ModalProvider>
                                   <ErrorBoundary
                                     FallbackComponent={ErrorPage}
                                     onError={handleError}
@@ -102,8 +102,8 @@ export function AppProviders({ children }: ProvidersProps) {
                                       </AppProvider>
                                     </TransactionsProvider>
                                   </ErrorBoundary>
-                                </WalletConnectV2Provider>
                               </ModalProvider>
+                                </WalletConnectV2Provider>
                             </KeepKeyProvider>
                           </WalletProvider>
                         </I18nProvider>

--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -84,8 +84,8 @@ export function AppProviders({ children }: ProvidersProps) {
                         <I18nProvider>
                           <WalletProvider>
                             <KeepKeyProvider>
-                                <WalletConnectV2Provider>
-                              <ModalProvider>
+                              <WalletConnectV2Provider>
+                                <ModalProvider>
                                   <ErrorBoundary
                                     FallbackComponent={ErrorPage}
                                     onError={handleError}
@@ -102,8 +102,8 @@ export function AppProviders({ children }: ProvidersProps) {
                                       </AppProvider>
                                     </TransactionsProvider>
                                   </ErrorBoundary>
-                              </ModalProvider>
-                                </WalletConnectV2Provider>
+                                </ModalProvider>
+                              </WalletConnectV2Provider>
                             </KeepKeyProvider>
                           </WalletProvider>
                         </I18nProvider>


### PR DESCRIPTION
## Description

Fixes the top-level QR code button (i.e the one on dashboard page, and in the app drawer menu on mobile) to not crash when scanning WalletConnect QR codes.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/8877

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Top level QR code button is happy when scanning a WCV2 QR Code

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="1726" alt="Screenshot 2025-03-25 at 19 13 14" src="https://github.com/user-attachments/assets/860895c9-6965-4b42-b012-2c549d8d6f46" />


- this diff

<img width="859" alt="Screenshot 2025-03-25 at 19 14 02" src="https://github.com/user-attachments/assets/1511c580-2fe1-4581-a3b3-1faa707374de" />
<img width="417" alt="image" src="https://github.com/user-attachments/assets/c98a655d-349f-44df-a5a4-40560901c5eb" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
