### PR TITLE
fix: auto resize limit order with flex

### DIFF
--- a/src/components/FoxWifHatBanner.tsx
+++ b/src/components/FoxWifHatBanner.tsx
@@ -8,14 +8,16 @@ import { FOX_WIF_HAT_CAMPAIGN_ENDING_TIME_MS } from '@/lib/fees/constant'
 
 const display = { base: 'none', md: 'flex' }
 
-export const FoxWifHatBanner = () => {
+type FoxWifHatBannerProps = { maxWidth?: number }
+export const FoxWifHatBanner: React.FC<FoxWifHatBannerProps> = props => {
+  const { maxWidth } = props
   const translate = useTranslate()
 
   // Hide the banner after the campaign ends
   if (Date.now() > FOX_WIF_HAT_CAMPAIGN_ENDING_TIME_MS) return null
 
   return (
-    <Card overflow='hidden' position='relative' mb={4} display={display}>
+    <Card overflow='hidden' maxWidth={maxWidth} position='relative' mb={4} display={display}>
       <CardBody
         display='flex'
         alignItems='center'

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -3,7 +3,7 @@ import { Box, Card, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import type { FormEvent } from 'react'
 
 import { SharedTradeInputHeader } from '../SharedTradeInput/SharedTradeInputHeader'
-import { useSharedHeight } from '../TradeInput/hooks/useSharedHeight'
+import { useSharedWidth } from '../TradeInput/hooks/useSharedWidth'
 
 import { FoxWifHatBanner } from '@/components/FoxWifHatBanner'
 import type { TradeInputTab } from '@/components/MultiHopTrade/types'
@@ -47,7 +47,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   isStandalone,
 }) => {
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
-  const totalHeight = useSharedHeight(tradeInputRef)
+  const inputWidth = useSharedWidth(tradeInputRef)
 
   return (
     <Flex
@@ -56,34 +56,36 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
       justifyContent='center'
       maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
     >
-      <Center width='inherit' alignItems='flex-end'>
-        <Box width='full' maxWidth='500px'>
-          <FoxWifHatBanner />
-          <Card
-            flex={1}
-            width='full'
-            maxWidth='500px'
-            ref={tradeInputRef}
-            as='form'
-            onSubmit={onSubmit}
-          >
-            <SharedTradeInputHeader
-              initialTab={tradeInputTab}
-              rightContent={headerRightContent}
-              onChangeTab={onChangeTab}
-              isStandalone={isStandalone}
+      <Center width='inherit'>
+        <Box alignItems='flex-end'>
+          <FoxWifHatBanner maxWidth={inputWidth} />
+          <Box width='full' maxWidth='1000px' display='flex'>
+            <Card
+              flex={1}
+              width='full'
+              maxWidth='500px'
+              ref={tradeInputRef}
+              as='form'
+              onSubmit={onSubmit}
+            >
+              <SharedTradeInputHeader
+                initialTab={tradeInputTab}
+                rightContent={headerRightContent}
+                onChangeTab={onChangeTab}
+                isStandalone={isStandalone}
+              />
+              {bodyContent}
+              {footerContent}
+            </Card>
+            <SideComponent
+              isOpen={!isCompact && !isSmallerThanXl && shouldOpenSideComponent}
+              isLoading={isLoading}
+              width={inputWidth ?? 'full'}
+              height={'full'}
+              ml={4}
             />
-            {bodyContent}
-            {footerContent}
-          </Card>
+          </Box>
         </Box>
-        <SideComponent
-          isOpen={!isCompact && !isSmallerThanXl && shouldOpenSideComponent}
-          isLoading={isLoading}
-          width={tradeInputRef.current?.offsetWidth ?? 'full'}
-          height={totalHeight ?? 'full'}
-          ml={4}
-        />
       </Center>
     </Flex>
   )

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -57,11 +57,12 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
       maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
     >
       <Center width='inherit'>
-        <Box alignItems='flex-end'>
-          <FoxWifHatBanner maxWidth={inputWidth} />
+        <Box>
+          <FoxWifHatBanner maxWidth={inputWidth ?? 500} />
           <Box width='full' maxWidth='1000px' display='flex'>
             <Card
-              flex={1}
+              flexShrink={0}
+              flexGrow={1}
               width='full'
               maxWidth='500px'
               ref={tradeInputRef}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -61,9 +61,8 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
           <FoxWifHatBanner maxWidth={inputWidth ?? 500} />
           <Box width='full' maxWidth='1000px' display='flex'>
             <Card
-              flexShrink={0}
-              flexGrow={1}
-              width='full'
+              flex={1}
+              width={isSmallerThanXl ? 'full' : '500px'}
               maxWidth='500px'
               ref={tradeInputRef}
               as='form'

--- a/src/components/MultiHopTrade/components/TradeInput/components/HorizontalCollapse.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/HorizontalCollapse.tsx
@@ -28,7 +28,21 @@ export const HorizontalCollapse = ({
     [height],
   )
 
-  const animateProp = useMemo(() => ({ width: isOpen ? width : 1 }), [isOpen, width])
+  // Add a small buffer to the width to prevent content cutoff issues
+  const animateWidth = useMemo(() => {
+    // Only add buffer to numeric widths
+    if (typeof width === 'number') {
+      return isOpen ? width + 8 : 1
+    }
+    return isOpen ? width : 1
+  }, [isOpen, width])
+
+  const animateProp = useMemo(
+    () => ({
+      width: animateWidth,
+    }),
+    [animateWidth],
+  )
 
   const handleAnimationStart = useCallback(() => setHidden(false), [])
   const handleAnimationComplete = useCallback(() => setHidden(!isOpen), [isOpen])

--- a/src/components/MultiHopTrade/components/TradeInput/components/HorizontalCollapse.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/HorizontalCollapse.tsx
@@ -28,21 +28,7 @@ export const HorizontalCollapse = ({
     [height],
   )
 
-  // Add a small buffer to the width to prevent content cutoff issues
-  const animateWidth = useMemo(() => {
-    // Only add buffer to numeric widths
-    if (typeof width === 'number') {
-      return isOpen ? width + 8 : 1
-    }
-    return isOpen ? width : 1
-  }, [isOpen, width])
-
-  const animateProp = useMemo(
-    () => ({
-      width: animateWidth,
-    }),
-    [animateWidth],
-  )
+  const animateProp = useMemo(() => ({ width: isOpen ? width : 1 }), [isOpen, width])
 
   const handleAnimationStart = useCallback(() => setHidden(false), [])
   const handleAnimationComplete = useCallback(() => setHidden(!isOpen), [isOpen])

--- a/src/components/MultiHopTrade/components/TradeInput/hooks/useSharedWidth.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/hooks/useSharedWidth.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 
-export const useSharedHeight = (observedRef: React.MutableRefObject<HTMLDivElement | null>) => {
-  const [height, setHeight] = useState(0)
+export const useSharedWidth = (observedRef: React.MutableRefObject<HTMLDivElement | null>) => {
+  const [width, setWidth] = useState<number>()
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {
       for (let entry of entries) {
-        setHeight(entry.contentRect.height)
+        setWidth(entry.contentRect.width)
       }
     })
 
@@ -23,5 +23,5 @@ export const useSharedHeight = (observedRef: React.MutableRefObject<HTMLDivEleme
     }
   }, [observedRef])
 
-  return height
+  return width
 }


### PR DESCRIPTION
## Description

The current issue is when you're on the Trade/Bridge page on the limit section specifically and add or remove a number from the pay section you'll see some jitteriness when the order history side panel resizes (only on larger viewports like a desktop). 

This is because the current rendering strategy is to wait for the primary component to grow in height, detect that, then apply the same height to the side panel. This leads to an intermediary state where the primary component is larger or smaller than the side panel, before it then resizes to match the height. This leads to the flickering effect. 

Ideally all the components on the page would be auto resized with flex box. But that becomes fairly difficult with the Fox with hat component also sizing itself to match the width of the primary input component (which is does nicely with flex right now).

What i've done it just swap the resizing method of the fox with hat component with the sidebar. Now the sidebar renders nicely with flex and the fox with hat component relies on width measuring. This leads to a better experience overall because we don't have to regularly need to resize the fox with had widget.

## Issue (if applicable)

closes #9172

## Risk

> High Risk PRs Require 2 approvals

Risk of sizing strangeness on the main element of the Trade/Bridge page

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

### Engineering

* Test test this working try going to production and adding and removing numbers from the Trade Input in limit order to see the resize flickering. Then try it on this branch
* Check various viewport sizes including rendering on mobile to ensure the new arrangement doesn't break anything
* Check that scrolling all still works ok in the side panels
* Check resizing the page on Trade/Bridge

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Video [here](https://www.loom.com/share/7ab3bcafb52442788b1aa3baf089fda2?sid=96a37f25-431d-4d91-a56e-fb2c5a055b35) of a delayed version of it to see what's happening (when it was broken)

