### PR TITLE
fix: fiat ramps content shift

### DIFF
--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -403,13 +403,15 @@ export const Overview: React.FC<OverviewProps> = ({
               <Text color='text.subtle' translation={fiatRampsTitleTranslation} />
             </Box>
           )}
-          {isRampsLoading ? (
-            <Center minHeight='150px'>
-              <CircularProgress />
-            </Center>
-          ) : (
-            <Stack>{renderProviders}</Stack>
-          )}
+          <Box minHeight='170px'>
+            {isRampsLoading ? (
+              <Center minHeight='150px'>
+                <CircularProgress />
+              </Center>
+            ) : (
+              <Stack>{renderProviders}</Stack>
+            )}
+          </Box>
         </Stack>
       </Flex>
     </>


### PR DESCRIPTION
## Description

Wraps the content in a box with minHeight so that content doesn't shift depending on the amount of providers (i.e default buy tab has one more than sell tab, which produced the content shift between the two).

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9140

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Fiat ramps buy/sell change doesn't shift content
- Things look the same as before on mobile

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/8c6ea211-3268-42ac-814e-f72d6b802bb3


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
