### PR TITLE
fix: send input validation shenanigans

### DIFF
--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -1,9 +1,9 @@
 import type { SpaceProps } from '@chakra-ui/react'
 import { IconButton, Input, InputGroup, InputRightElement } from '@chakra-ui/react'
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import { isMobile } from 'react-device-detect'
 import type { ControllerProps, ControllerRenderProps, FieldValues } from 'react-hook-form'
-import { Controller, useFormContext } from 'react-hook-form'
+import { Controller, useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
 
@@ -30,6 +30,17 @@ export const AddressInput = ({
   const history = useHistory()
   const translate = useTranslate()
   const isValid = useFormContext<SendInput>().formState.isValid
+  const isValidating = useFormContext<SendInput>().formState.isValidating
+  const value = useWatch<SendInput, SendFormFields.Input>({ name: SendFormFields.Input })
+
+  const isInvalid = useMemo(() => {
+    // Don't go invalid when async invalidation is running
+    if (isValidating) return false
+    // Don't go invalid until there's an actual input
+    if (!value) return false
+
+    return isValid === false
+  }, [isValid, isValidating, value])
 
   const handleQrClick = useCallback(() => {
     history.push(SendRoutes.Scan)
@@ -53,7 +64,7 @@ export const AddressInput = ({
         data-1p-ignore
         // Because the InputRightElement is hover the input, we need to let this space free
         pe={pe}
-        isInvalid={!isValid}
+        isInvalid={isInvalid}
         // This is already a `useCallback()`
         // eslint-disable-next-line react-memo/require-usememo
         sx={
@@ -69,7 +80,7 @@ export const AddressInput = ({
         }
       />
     ),
-    [isValid, pe, placeholder],
+    [isInvalid, pe, placeholder],
   )
 
   return (

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -65,7 +65,9 @@ export const Address = () => {
       validate: {
         validateAddress: async (rawInput: string) => {
           if (!asset) return
-
+          // Don't go invalid on initial empty strin
+          if (!rawInput.trim()) return true
+          
           const urlOrAddress = rawInput.trim() // trim leading/trailing spaces
           setIsValidating(true)
           setValue(SendFormFields.To, '')


### PR DESCRIPTION
## Description

Two birds one stone:

- Don't go invalid on empty input (i.e initial input in the send modal)
- Don't go invalid when we're async validating

Actually, three birds one stone as this also applies to the recipient address in swapper.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/9194

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Send modal address input doesn't go red on initial mount, nor when validating
- Custom receive address input doesn't go red on initial mount, nor when validating

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>


- ^

## Screenshots (if applicable)

- Send modal address input

https://jam.dev/c/47abfdfd-ae9e-4508-8739-adf3f1838a51

- Swapper recipient address input

https://jam.dev/c/e9249ade-3262-4466-b6f3-ab645985336e


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
