### PR TITLE
fix: unrevert fix for limit order jittering when resizing 

### DIFF
--- a/src/components/FoxWifHatBanner.tsx
+++ b/src/components/FoxWifHatBanner.tsx
@@ -8,14 +8,16 @@ import { FOX_WIF_HAT_CAMPAIGN_ENDING_TIME_MS } from '@/lib/fees/constant'
 
 const display = { base: 'none', md: 'flex' }
 
-export const FoxWifHatBanner = () => {
+type FoxWifHatBannerProps = { maxWidth?: number }
+export const FoxWifHatBanner: React.FC<FoxWifHatBannerProps> = props => {
+  const { maxWidth } = props
   const translate = useTranslate()
 
   // Hide the banner after the campaign ends
   if (Date.now() > FOX_WIF_HAT_CAMPAIGN_ENDING_TIME_MS) return null
 
   return (
-    <Card overflow='hidden' position='relative' mb={4} display={display}>
+    <Card overflow='hidden' maxWidth={maxWidth} position='relative' mb={4} display={display}>
       <CardBody
         display='flex'
         alignItems='center'

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -331,7 +331,12 @@ export const LimitOrderConfig = ({
     ],
   )
   const limitOrderExplainer = useMemo(() => {
-    if (isLoading) return null
+    if (
+      isLoading ||
+      bnOrZero(sellAmountCryptoPrecision).isZero() ||
+      bnOrZero(limitPriceForSelectedPriceDirection).isZero()
+    )
+      return null
 
     return (
       <Text
@@ -342,7 +347,12 @@ export const LimitOrderConfig = ({
         color='text.subtle'
       />
     )
-  }, [isLoading, humanReadableExplanationComponents])
+  }, [
+    isLoading,
+    sellAmountCryptoPrecision,
+    limitPriceForSelectedPriceDirection,
+    humanReadableExplanationComponents,
+  ])
 
   const marketPriceCryptoPrecision = useMemo(() => {
     if (bnOrZero(marketPriceBuyAsset).isZero()) return '0'
@@ -357,13 +367,6 @@ export const LimitOrderConfig = ({
 
     return `${marketPriceCryptoPrecision} ${priceAsset.symbol}`
   }, [marketPriceCryptoPrecision, priceAsset.symbol])
-
-  const showExplainer = useMemo(() => {
-    return (
-      !bnOrZero(sellAmountCryptoPrecision).isZero() &&
-      !bnOrZero(limitPriceForSelectedPriceDirection).isZero()
-    )
-  }, [limitPriceForSelectedPriceDirection, sellAmountCryptoPrecision])
 
   return (
     <Stack spacing={6} px={6} py={4}>
@@ -439,23 +442,24 @@ export const LimitOrderConfig = ({
         />
       </HStack>
 
-      {!isLoading && (
-        <Box
-          borderWidth={showExplainer ? 1 : 0}
-          borderStyle='dashed'
-          borderRadius='md'
-          borderColor='whiteAlpha.300'
-          height={showExplainer ? '100%' : 0}
-          overflow='hidden'
-        >
-          <Flex alignItems='flex-start' p={4}>
-            <Box as='span' mr={2} mt={1}>
-              <InfoIcon boxSize={5} color='gray.500' />
-            </Box>
-            {limitOrderExplainer}
-          </Flex>
-        </Box>
-      )}
+      {!isLoading &&
+        !bnOrZero(sellAmountCryptoPrecision).isZero() &&
+        !bnOrZero(limitPriceForSelectedPriceDirection).isZero() && (
+          <Box
+            p={4}
+            borderWidth='1px'
+            borderStyle='dashed'
+            borderRadius='md'
+            borderColor='whiteAlpha.300'
+          >
+            <Flex alignItems='flex-start'>
+              <Box as='span' mr={2} mt={1}>
+                <InfoIcon boxSize={5} color='gray.500' />
+              </Box>
+              {limitOrderExplainer}
+            </Flex>
+          </Box>
+        )}
 
       {maybePriceWarning}
     </Stack>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -331,12 +331,7 @@ export const LimitOrderConfig = ({
     ],
   )
   const limitOrderExplainer = useMemo(() => {
-    if (
-      isLoading ||
-      bnOrZero(sellAmountCryptoPrecision).isZero() ||
-      bnOrZero(limitPriceForSelectedPriceDirection).isZero()
-    )
-      return null
+    if (isLoading) return null
 
     return (
       <Text
@@ -347,12 +342,7 @@ export const LimitOrderConfig = ({
         color='text.subtle'
       />
     )
-  }, [
-    isLoading,
-    sellAmountCryptoPrecision,
-    limitPriceForSelectedPriceDirection,
-    humanReadableExplanationComponents,
-  ])
+  }, [isLoading, humanReadableExplanationComponents])
 
   const marketPriceCryptoPrecision = useMemo(() => {
     if (bnOrZero(marketPriceBuyAsset).isZero()) return '0'
@@ -367,6 +357,13 @@ export const LimitOrderConfig = ({
 
     return `${marketPriceCryptoPrecision} ${priceAsset.symbol}`
   }, [marketPriceCryptoPrecision, priceAsset.symbol])
+
+  const showExplainer = useMemo(() => {
+    return (
+      !bnOrZero(sellAmountCryptoPrecision).isZero() &&
+      !bnOrZero(limitPriceForSelectedPriceDirection).isZero()
+    )
+  }, [limitPriceForSelectedPriceDirection, sellAmountCryptoPrecision])
 
   return (
     <Stack spacing={6} px={6} py={4}>
@@ -442,24 +439,23 @@ export const LimitOrderConfig = ({
         />
       </HStack>
 
-      {!isLoading &&
-        !bnOrZero(sellAmountCryptoPrecision).isZero() &&
-        !bnOrZero(limitPriceForSelectedPriceDirection).isZero() && (
-          <Box
-            p={4}
-            borderWidth='1px'
-            borderStyle='dashed'
-            borderRadius='md'
-            borderColor='whiteAlpha.300'
-          >
-            <Flex alignItems='flex-start'>
-              <Box as='span' mr={2} mt={1}>
-                <InfoIcon boxSize={5} color='gray.500' />
-              </Box>
-              {limitOrderExplainer}
-            </Flex>
-          </Box>
-        )}
+      {!isLoading && (
+        <Box
+          borderWidth={showExplainer ? 1 : 0}
+          borderStyle='dashed'
+          borderRadius='md'
+          borderColor='whiteAlpha.300'
+          height={showExplainer ? '100%' : 0}
+          overflow='hidden'
+        >
+          <Flex alignItems='flex-start' p={4}>
+            <Box as='span' mr={2} mt={1}>
+              <InfoIcon boxSize={5} color='gray.500' />
+            </Box>
+            {limitOrderExplainer}
+          </Flex>
+        </Box>
+      )}
 
       {maybePriceWarning}
     </Stack>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -3,7 +3,7 @@ import { Box, Card, Center, Flex, useMediaQuery } from '@chakra-ui/react'
 import type { FormEvent } from 'react'
 
 import { SharedTradeInputHeader } from '../SharedTradeInput/SharedTradeInputHeader'
-import { useSharedHeight } from '../TradeInput/hooks/useSharedHeight'
+import { useSharedWidth } from '../TradeInput/hooks/useSharedWidth'
 
 import { FoxWifHatBanner } from '@/components/FoxWifHatBanner'
 import type { TradeInputTab } from '@/components/MultiHopTrade/types'
@@ -47,7 +47,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   isStandalone,
 }) => {
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
-  const totalHeight = useSharedHeight(tradeInputRef)
+  const inputWidth = useSharedWidth(tradeInputRef)
 
   return (
     <Flex
@@ -56,34 +56,36 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
       justifyContent='center'
       maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
     >
-      <Center width='inherit' alignItems='flex-end'>
-        <Box width='full' maxWidth='500px'>
-          <FoxWifHatBanner />
-          <Card
-            flex={1}
-            width='full'
-            maxWidth='500px'
-            ref={tradeInputRef}
-            as='form'
-            onSubmit={onSubmit}
-          >
-            <SharedTradeInputHeader
-              initialTab={tradeInputTab}
-              rightContent={headerRightContent}
-              onChangeTab={onChangeTab}
-              isStandalone={isStandalone}
+      <Center width='inherit'>
+        <Box>
+          <FoxWifHatBanner maxWidth={inputWidth ?? 500} />
+          <Box width='full' maxWidth='1000px' display='flex'>
+            <Card
+              flex={1}
+              width={isSmallerThanXl ? 'full' : '500px'}
+              maxWidth='500px'
+              ref={tradeInputRef}
+              as='form'
+              onSubmit={onSubmit}
+            >
+              <SharedTradeInputHeader
+                initialTab={tradeInputTab}
+                rightContent={headerRightContent}
+                onChangeTab={onChangeTab}
+                isStandalone={isStandalone}
+              />
+              {bodyContent}
+              {footerContent}
+            </Card>
+            <SideComponent
+              isOpen={!isCompact && !isSmallerThanXl && shouldOpenSideComponent}
+              isLoading={isLoading}
+              width={inputWidth ?? 'full'}
+              height={'full'}
+              ml={4}
             />
-            {bodyContent}
-            {footerContent}
-          </Card>
+          </Box>
         </Box>
-        <SideComponent
-          isOpen={!isCompact && !isSmallerThanXl && shouldOpenSideComponent}
-          isLoading={isLoading}
-          width={tradeInputRef.current?.offsetWidth ?? 'full'}
-          height={totalHeight ?? 'full'}
-          ml={4}
-        />
       </Center>
     </Flex>
   )

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -57,12 +57,12 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
       maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
     >
       <Center width='inherit'>
-        <Box>
+        <Box maxWidth='100%'>
           <FoxWifHatBanner maxWidth={inputWidth ?? 500} />
           <Box width='full' maxWidth='1000px' display='flex'>
             <Card
               flex={1}
-              width={isSmallerThanXl ? 'full' : '500px'}
+              width={isSmallerThanXl || isStandalone ? 'full' : '500px'}
               maxWidth='500px'
               ref={tradeInputRef}
               as='form'

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -57,12 +57,12 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
       maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
     >
       <Center width='inherit'>
-        <Box maxWidth='100%'>
+        <Box>
           <FoxWifHatBanner maxWidth={inputWidth ?? 500} />
           <Box width='full' maxWidth='1000px' display='flex'>
             <Card
               flex={1}
-              width='full'
+              width={isSmallerThanXl ? 'full' : '500px'}
               maxWidth='500px'
               ref={tradeInputRef}
               as='form'

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -57,12 +57,12 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
       maxWidth={isCompact || isSmallerThanXl ? '500px' : undefined}
     >
       <Center width='inherit'>
-        <Box>
+        <Box maxWidth='100%'>
           <FoxWifHatBanner maxWidth={inputWidth ?? 500} />
           <Box width='full' maxWidth='1000px' display='flex'>
             <Card
               flex={1}
-              width={isSmallerThanXl ? 'full' : '500px'}
+              width='full'
               maxWidth='500px'
               ref={tradeInputRef}
               as='form'

--- a/src/components/MultiHopTrade/components/TradeInput/hooks/useSharedWidth.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/hooks/useSharedWidth.ts
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react'
 
-export const useSharedHeight = (observedRef: React.MutableRefObject<HTMLDivElement | null>) => {
-  const [height, setHeight] = useState(0)
+export const useSharedWidth = (observedRef: React.MutableRefObject<HTMLDivElement | null>) => {
+  const [width, setWidth] = useState<number>()
 
   useEffect(() => {
     const resizeObserver = new ResizeObserver(entries => {
       for (let entry of entries) {
-        setHeight(entry.contentRect.height)
+        setWidth(entry.contentRect.width)
       }
     })
 
@@ -23,5 +23,5 @@ export const useSharedHeight = (observedRef: React.MutableRefObject<HTMLDivEleme
     }
   }, [observedRef])
 
-  return height
+  return width
 }


### PR DESCRIPTION
## Description

This PR unreverts [this original change](https://github.com/shapeshift/web/commit/934c2233cf58d114b9d7cf2b838d1d03863bac74)

@NeOMakinG this PR has turned into a bit of a wild goose chase. If at any point you think this is too high risk for the potential payoff just let me know I'm more than happy to let this one go. I acknowledge that the issue this is fixing is potentially not worth it for potential broken layouts.

That being said i've fixed the known issues. Tested, found another issue and fixed that. And now hopefully all the bugs have been squashed. But considering the change here is a flexbox layout there could be a number of potential layouts and therefore edge cases that i've missed.

I've just added a condition not to hardcode the width if the shared trade input is standalone. I also noticed a bug on the mini picker where when you select certain chains like Avalanche and get the little explainer popup, the trade input grew past it's width boundaries. Which i've fixed with the maxWidth=100%

![image](https://github.com/user-attachments/assets/579f876b-c72e-492c-8a59-8a0866c41789)


## Issue (if applicable)


closes #9172

## Risk

* This change is honestly a bit of a mine field as we've seen with a variety of edge cases popping up with flex box
* This main risk here is strange box sizing behaviour with anything that renders the SharedTradeInput

## Testing


### Engineering

* Consider any pages where the SharedTradeInput component is rendered and test a variety of potential layouts. To my current knowledge that's only the Trade/Limit page and the market view when looking at a particular coin.
* Grow and shrink pages
* Try out in mobile view
* Try different inputs in the trade input which may trigger different information boxes

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/7023e7fd-cc18-4ea7-ad9f-0c15f37b5408
