### PR TITLE
feat: surplus improvements

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -995,7 +995,7 @@
     "allowanceResetTxName": "Allowance reset tx:",
     "allowanceApprovalTxName": "Allowance approval tx:",
     "tradeComplete": "You now have %{cryptoAmountFormatted} in your wallet on %{chainName}!",
-    "tradeCompleteSurplus": "You got an extra %{extra}!",
+    "tradeCompleteSurplus": "You got an extra %{extraPercent}!",
     "doAnotherTrade": "Do another trade",
     "summary": "Trade Summary",
     "estimatedCompletionTime": "Estimated Completion Time",

--- a/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
@@ -233,9 +233,19 @@ export const SpotTradeSuccess = ({
     actualBuyAmountCryptoPrecision,
   ])
 
+  const surplusPercentage = useMemo(() => {
+    if (!(actualBuyAmountCryptoPrecision && quoteBuyAmountCryptoPrecision)) return '0'
+
+    return bnOrZero(actualBuyAmountCryptoPrecision)
+      .minus(quoteBuyAmountCryptoPrecision)
+      .div(quoteBuyAmountCryptoPrecision)
+      .times(100)
+      .toString()
+  }, [actualBuyAmountCryptoPrecision, quoteBuyAmountCryptoPrecision])
+
   const surplusComponents = useMemo(
     () => ({
-      extra: (
+      extraPercent: (
         <Box color='green.200' display='inline'>
           <Amount.Crypto
             as='span'
@@ -247,14 +257,14 @@ export const SpotTradeSuccess = ({
             {' '}
             (
           </CText>
-          <Amount.Fiat as='span' value={maybeExraDeltaUserCurrency} />
+          <Amount.Percent as='span' value={bnOrZero(surplusPercentage).div(100).toString()} />
           <CText as='span' color='green.200'>
             )
           </CText>
         </Box>
       ),
     }),
-    [buyAsset?.symbol, maybeExraDeltaUserCurrency, maybeExtraDeltaCryptoPrecision],
+    [buyAsset?.symbol, maybeExtraDeltaCryptoPrecision, surplusPercentage],
   )
 
   const SurplusLine = useCallback(() => {
@@ -263,6 +273,9 @@ export const SpotTradeSuccess = ({
     if (!maybeExtraDeltaCryptoPrecision) return null
     // Superseeded by the "You Saved" explainer
     if (hasFeeSaving) return null
+
+    // 0.3% min heuristic before showing surplus
+    if (bnOrZero(surplusPercentage).lt(0.3)) return null
 
     return (
       <Flex justifyContent='center' alignItems='center' flexWrap='wrap' gap={2} px={4}>
@@ -276,6 +289,7 @@ export const SpotTradeSuccess = ({
     surplusComponents,
     maybeExtraDeltaCryptoPrecision,
     hasFeeSaving,
+    surplusPercentage,
   ])
 
   // NOTE: This is a temporary solution to enable the Fox discount summary only if the user did NOT

--- a/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
@@ -33,7 +33,6 @@ import { useTxDetails, useTxDetailsQuery } from '@/hooks/useTxDetails/useTxDetai
 import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
 import { selectRelatedAssetIdsInclusiveSorted } from '@/state/slices/related-assets-selectors'
-import { selectMarketDataByAssetIdUserCurrency } from '@/state/slices/selectors'
 import {
   selectActiveQuote,
   selectConfirmedTradeExecution,
@@ -116,10 +115,6 @@ export const SpotTradeSuccess = ({
   const manualReceiveAddressTransfers = useTxDetailsQuery(buyTxId ?? '')?.transfers
   const transfers = txTransfers || manualReceiveAddressTransfers
 
-  const buyAssetMarketDataUserCurrency = useAppSelector(state =>
-    selectMarketDataByAssetIdUserCurrency(state, buyAsset?.assetId ?? ''),
-  )
-
   const actualBuyAmountCryptoPrecision = useMemo(() => {
     if (!transfers?.length || !buyAsset) return undefined
 
@@ -138,14 +133,6 @@ export const SpotTradeSuccess = ({
       ? bnOrZero(actualBuyAmountCryptoPrecision).minus(quoteBuyAmountCryptoPrecision).toFixed()
       : undefined
   }, [actualBuyAmountCryptoPrecision, quoteBuyAmountCryptoPrecision])
-
-  const maybeExraDeltaUserCurrency = useMemo(() => {
-    if (!maybeExtraDeltaCryptoPrecision || !buyAsset) return undefined
-
-    return bnOrZero(maybeExtraDeltaCryptoPrecision)
-      .times(buyAssetMarketDataUserCurrency?.price ?? 0)
-      .toString()
-  }, [buyAssetMarketDataUserCurrency, maybeExtraDeltaCryptoPrecision, buyAsset])
 
   const { buyAmountAfterFeesCryptoPrecision, buyAmountBeforeFeesCryptoPrecision } = useMemo(() => {
     const { buyAmountBeforeFeesCryptoBaseUnit, buyAmountAfterFeesCryptoBaseUnit } = lastHop ?? {}


### PR DESCRIPTION
## Description

- Adds a 0.3 min surplus heuristic for displaying the surplus line
- Show as percentage instead of fiat (since displaying both the crypto, fiat, and percentage amount would be too much in one line)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9193

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a CoW trade 
- You will most likely not see the surplus line because of smol surplus, but if you do, it should only be a surplus greater than 0.3%
- Percentage surplus is displayed in surplus line

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Do a CoW trade
- If you see the surplus line, refer to testing steps above
- If you don't, comment out the min guard and let hot reload do its magic
- Comment it back and notice surplus line is gone again

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

- ^

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

- This diff

<img width="568" alt="Screenshot 2025-04-04 at 00 00 06" src="https://github.com/user-attachments/assets/e5c9200a-0486-4188-a74f-65accfa4727c" />


- This diff, but with min surplus guard commented out

<img width="582" alt="Screenshot 2025-04-03 at 23 59 48" src="https://github.com/user-attachments/assets/d4bd119c-abe1-43d8-88fe-5aedf48b800d" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
