### PR TITLE
fix: address validation inversion

### DIFF
--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -68,7 +68,7 @@ export const AddressInput = ({
         data-1p-ignore
         // Because the InputRightElement is hover the input, we need to let this space free
         pe={pe}
-        isInvalid={!isInvalid && isDirty}
+        isInvalid={isInvalid && isDirty}
         // This is already a `useCallback()`
         // eslint-disable-next-line react-memo/require-usememo
       />


### PR DESCRIPTION
## Description

Unblocks release by fixing an address validation boolean inversion caused by a bad merge of https://github.com/shapeshift/web/pull/9207.

## Issue (if applicable)

Unblocks release https://discord.com/channels/554694662431178782/1357207369330982982/1357267075118403624 and closes https://github.com/shapeshift/web/issues/9251

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Address validation in send and manual reiceve address.

## Testing

See ticket, valid address should not go red.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

<img width="378" alt="Screenshot 2025-04-04 at 11 22 23 am" src="https://github.com/user-attachments/assets/6cc79a0f-56f1-4e4e-8f4e-6511aa1c76e9" />
