### PR TITLE
chore: remove auto-close copy for import modals

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1644,7 +1644,7 @@
       },
       "success": {
         "header": "Ledger Connected",
-        "success": "You can now close this window or it will auto-close shortly",
+        "success": "You can now close this window.",
         "error": "There was an error connecting your wallet"
       },
       "errors": {
@@ -1829,7 +1829,7 @@
       "success": {
         "encryptingWallet": "Encrypting your wallet... if your browser asks to store data in persistent storage, please click 'Allow'.",
         "header": "Wallet Connected",
-        "success": "You can now close this window or it will auto-close shortly",
+        "success": "You can now close this window.",
         "error": "There was an error connecting your wallet"
       },
       "testPhrase": {


### PR DESCRIPTION
## Description

Removes the mention of the window auto-closing after importing a wallet (including for Ledger) as this feature is not used **on Mobile** and might confuse users. The user has to click the "View Wallet" button or close the modal to move on. On Desktop the modal usually displays so quickly that you can't read this, and if somehow it doesn't auto-close the instruction are still clear.

Translations will be invalidated during the next sync, the current translatons aren't harmful.

Approved/Requested by Product here: https://discord.com/channels/554694662431178782/1357702656227016887/1357773121553305672

## Risk

> High Risk PRs Require 2 approvals

None. Only English copies.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

Import a wallet / Ledger wallet, check the message.

### Engineering

☝️ 

### Operations

☝️ 

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

