### PR TITLE
fix: address runs into buttons on the trade form input

### DIFF
--- a/src/components/Modals/Send/AddressInput/AddressInput.tsx
+++ b/src/components/Modals/Send/AddressInput/AddressInput.tsx
@@ -59,7 +59,6 @@ export const AddressInput = ({
         placeholder={placeholder}
         as={ResizeTextarea}
         value={value}
-        pr={12}
         variant='filled'
         minHeight='auto'
         minRows={1}

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -2,7 +2,6 @@ import { Button, FormControl, FormLabel, Stack } from '@chakra-ui/react'
 import { ethChainId } from '@shapeshiftoss/caip'
 import get from 'lodash/get'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { isMobile } from 'react-device-detect'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useHistory } from 'react-router-dom'
@@ -112,7 +111,7 @@ export const Address = () => {
             {translate('modals.send.sendForm.sendTo')}
           </FormLabel>
           <AddressInput
-            pe={isMobile ? 12 : 9.5}
+            pe={16}
             rules={addressInputRules}
             enableQr={true}
             placeholder={translate(

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedRecipientAddress.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedRecipientAddress.tsx
@@ -272,7 +272,7 @@ export const SharedRecipientAddress = ({
             <AddressInput
               rules={rules}
               placeholder={translate('trade.enterCustomRecipientAddress')}
-              pe={16}
+              pe={20}
             />
             <InputRightElement
               width='full'


### PR DESCRIPTION
## Description

We need to adjust the padding for the trade custom address.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9263 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
low risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

When pasting or typing an address into the send modal or the custom recipient address, it should wrap and avoid the buttons to the right.

## Screenshots (if applicable)
![Screenshot 2025-04-04 at 4 16 36 PM](https://github.com/user-attachments/assets/cb0ec81d-2cfe-4178-90d0-00ddbc658f0a)
![Screenshot 2025-04-04 at 4 16 44 PM](https://github.com/user-attachments/assets/3c346abb-02d2-4c49-90f9-2acc68056445)
