### PR TITLE
revert: "fix: mm snap flash of "Provide receive Address" (#9257)"

### DIFF
--- a/src/components/MultiHopTrade/hooks/useIsManualReceiveAddressRequired.tsx
+++ b/src/components/MultiHopTrade/hooks/useIsManualReceiveAddressRequired.tsx
@@ -49,7 +49,7 @@ export const useIsManualReceiveAddressRequired = ({
     if (isAccountsMetadataLoading && !sellAccountId) return false
     if (manualReceiveAddress) return false
     if (!walletReceiveAddress) return true
-    if (walletSupportsBuyAssetChain === false) return true
+    if (!walletSupportsBuyAssetChain) return true
     // If the wallet supports the chian at runtime, display the manual address entry if there are no
     // accounts connected for the buy asset
     if (walletSupportsBuyAssetChainAtRuntime) return !buyAssetAccountIds.length

--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -164,8 +164,6 @@ export const useWalletSupportsChain = (
     })
   }, [chainAccountIds, chainId, isSnapInstalled, wallet])
 
-  if (!isSnapInstalled) return null
-
   return result
 }
 


### PR DESCRIPTION
This reverts commit 358a2af816c24520122b2bc12ecb035512bca368 merged in https://github.com/shapeshift/web/pull/9257.

https://discord.com/channels/554694662431178782/1358707166449500211/1358932611761700936

This breaks rFOX staking, and probably a bunch of other things:

![image](https://github.com/user-attachments/assets/c1d7f2ba-53fa-47a4-86b9-79b878a18cdb)

I also get no EVMs on Mobile:

![image](https://github.com/user-attachments/assets/5e16390f-06a4-454a-b89d-039cf8bed752)

@gomesalexandre this line is super scary looking:

```ts
if (!isSnapInstalled) return null
```

What happens when the snap is not installed? We return `null` for any chain passed into `useWalletSupportsChain`?