### PR TITLE
fix: show empty state when no providers available

### DIFF
--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -168,6 +168,19 @@ export const Overview: React.FC<OverviewProps> = ({
     setShownOnDisplay(shownOnDisplay)
   }, [accountId, accountMetadata, address, wallet])
 
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  const fiatRampsTitleTranslation: TextPropTypes['translation'] = useMemo(
+    () => [
+      'fiatRamps.titleMessage',
+      {
+        action: translate(`fiatRamps.${fiatRampAction}`).toLocaleLowerCase(),
+        asset: asset?.symbol ?? '',
+      },
+    ],
+    [asset?.symbol, fiatRampAction, translate],
+  )
+
   const handlePopupClick = useCallback(
     ({ rampId, address }: { rampId: FiatRamp; address: string }) => {
       const ramp = supportedFiatRamps[rampId]
@@ -211,36 +224,45 @@ export const Overview: React.FC<OverviewProps> = ({
             <FaCreditCard />
           </IconCircle>
           <Text fontWeight='medium' translation='fiatRamps.noProvidersAvailable' fontSize='lg' />
-          <Text translation='fiatRamps.noProvidersBody' color='text.subtle' />
+          <Text translation='fiatRamps.noProvidersBody' color='text.subtle' textAlign='center' />
         </Center>
       )
 
-    return filteredRamps
-      .sort((a, b) => supportedFiatRamps[a].order - supportedFiatRamps[b].order)
-      .map(rampId => {
-        const ramp = supportedFiatRamps[rampId]
-        const passedAddress = address
-        return (
-          <FiatRampButton
-            key={rampId}
-            // this whole render method is already memoized
-            // eslint-disable-next-line react-memo/require-usememo
-            onClick={() => handlePopupClick({ rampId, address: passedAddress })}
-            accountFiatBalance={accountUserCurrencyBalance}
-            action={fiatRampAction}
-            {...ramp}
-          />
-        )
-      })
+    return (
+      <Stack spacing={4}>
+        <Box>
+          <Text fontWeight='medium' translation='fiatRamps.availableProviders' />
+          <Text color='text.subtle' translation={fiatRampsTitleTranslation} />
+        </Box>
+        {filteredRamps
+          .sort((a, b) => supportedFiatRamps[a].order - supportedFiatRamps[b].order)
+          .map(rampId => {
+            const ramp = supportedFiatRamps[rampId]
+            const passedAddress = address
+            return (
+              <FiatRampButton
+                key={rampId}
+                // this whole render method is already memoized
+                // eslint-disable-next-line react-memo/require-usememo
+                onClick={() => handlePopupClick({ rampId, address: passedAddress })}
+                accountFiatBalance={accountUserCurrencyBalance}
+                action={fiatRampAction}
+                {...ramp}
+              />
+            )
+          })}
+      </Stack>
+    )
   }, [
-    accountUserCurrencyBalance,
-    address,
     assetId,
-    fiatCurrency,
-    fiatRampAction,
-    handlePopupClick,
     isRampsLoading,
     ramps,
+    fiatRampAction,
+    fiatCurrency,
+    fiatRampsTitleTranslation,
+    address,
+    handlePopupClick,
+    accountUserCurrencyBalance,
   ])
 
   const { isOpen: isFiatRampsModalOpen } = useModal('fiatRamps')
@@ -262,18 +284,6 @@ export const Overview: React.FC<OverviewProps> = ({
       </option>
     ))
   }, [])
-  const asset = useAppSelector(state => selectAssetById(state, assetId))
-
-  const fiatRampsTitleTranslation: TextPropTypes['translation'] = useMemo(
-    () => [
-      'fiatRamps.titleMessage',
-      {
-        action: translate(`fiatRamps.${fiatRampAction}`).toLocaleLowerCase(),
-        asset: asset?.symbol ?? '',
-      },
-    ],
-    [asset?.symbol, fiatRampAction, translate],
-  )
 
   const description: string | [string, InterpolationOptions] | undefined = useMemo(() => {
     if (!asset) return
@@ -399,19 +409,13 @@ export const Overview: React.FC<OverviewProps> = ({
           </Flex>
         </Stack>
         <Stack spacing={4}>
-          {ramps && (
-            <Box>
-              <Text fontWeight='medium' translation='fiatRamps.availableProviders' />
-              <Text color='text.subtle' translation={fiatRampsTitleTranslation} />
-            </Box>
-          )}
           <Box minHeight='170px'>
             {isRampsLoading ? (
               <Center minHeight='150px'>
                 <CircularProgress />
               </Center>
             ) : (
-              <Stack>{renderProviders}</Stack>
+              renderProviders
             )}
           </Box>
         </Stack>

--- a/src/components/Modals/FiatRamps/views/Overview.tsx
+++ b/src/components/Modals/FiatRamps/views/Overview.tsx
@@ -198,7 +198,13 @@ export const Overview: React.FC<OverviewProps> = ({
     if (isRampsLoading) return null
     if (!ramps) return null
     const rampIdsForAssetIdAndAction = ramps.byAssetId?.[assetId]?.[fiatRampAction] ?? []
-    if (!rampIdsForAssetIdAndAction.length)
+
+    const filteredRamps = [...rampIdsForAssetIdAndAction].filter(rampId => {
+      const list = supportedFiatRamps[rampId].getSupportedFiatList()
+      return list.includes(fiatCurrency)
+    })
+
+    if (!filteredRamps.length)
       return (
         <Center display='flex' flexDir='column' minHeight='150px'>
           <IconCircle mb={4}>
@@ -208,12 +214,8 @@ export const Overview: React.FC<OverviewProps> = ({
           <Text translation='fiatRamps.noProvidersBody' color='text.subtle' />
         </Center>
       )
-    const listOfRamps = [...rampIdsForAssetIdAndAction]
-    return listOfRamps
-      .filter(rampId => {
-        const list = supportedFiatRamps[rampId].getSupportedFiatList()
-        return list.includes(fiatCurrency)
-      })
+
+    return filteredRamps
       .sort((a, b) => supportedFiatRamps[a].order - supportedFiatRamps[b].order)
       .map(rampId => {
         const ramp = supportedFiatRamps[rampId]


### PR DESCRIPTION
## Description

This fixes the not showing the empty state when there are no providers

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/9288

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

low risk

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>
Go to the buy page, and select a currency other than USD. And if there are no providers you should see an empty state.

## Screenshots (if applicable)
![Screenshot 2025-04-08 at 11 13 04 AM](https://github.com/user-attachments/assets/0b6b3cd6-54e6-421d-adbc-9dbb12d94247)
