### PR TITLE
chore: only fire RatesReceived once

### DIFF
--- a/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
+++ b/src/components/MultiHopTrade/hooks/useGetTradeQuotes/useGetTradeRates.tsx
@@ -318,6 +318,11 @@ export const useGetTradeRates = () => {
     dispatch(tradeQuoteSlice.actions.setActiveQuote(bestQuote))
   }, [activeQuoteMeta, isAnyTradeQuoteLoading, dispatch])
 
+  // If the trade input changes, we need to reset the tracking flag
+  useEffect(() => {
+    hasTrackedInitialRatesReceived.current = false
+  }, [tradeRateInput])
+
   // TODO: move to separate hook so we don't need to pull quote data into here
   useEffect(() => {
     if (isAnyTradeQuoteLoading) return


### PR DESCRIPTION
## Description

Only fire the `RatesReceived` MixPanel event once for a certain trade input. 
Reporting-wise we don't want to clog the data with refreshes.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/9297

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

Stick a debugger on `mixpanel.track(MixPanelEvent.RatesReceived, quoteData)` and confirm it fires only once for a rate input.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Nothing required.

## Screenshots (if applicable)

N/A