### PR TITLE
fix: always set native wallet state on re/connect

### DIFF
--- a/src/context/WalletProvider/NewWalletViews/sections/SavedWalletsSection.tsx
+++ b/src/context/WalletProvider/NewWalletViews/sections/SavedWalletsSection.tsx
@@ -92,26 +92,29 @@ export const SavedWalletsSection = ({
           const walletInstance = await adapter.pairDevice(deviceId)
           if (!(await walletInstance?.isInitialized())) {
             await walletInstance?.initialize()
-          } else {
-            dispatch({
-              type: WalletActions.SET_WALLET,
-              payload: {
-                wallet: walletInstance,
-                name,
-                icon,
-                deviceId,
-                meta: { label: wallet.name },
-                connectedType: KeyManager.Native,
-              },
-            })
-            dispatch({
-              type: WalletActions.SET_IS_CONNECTED,
-              payload: true,
-            })
-            dispatch({ type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID })
-            dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
           }
 
+          dispatch({
+            type: WalletActions.SET_WALLET,
+            payload: {
+              wallet: walletInstance,
+              name,
+              icon,
+              deviceId,
+              meta: { label: wallet.name },
+              connectedType: KeyManager.Native,
+            },
+          })
+          dispatch({
+            type: WalletActions.SET_CONNECTOR_TYPE,
+            payload: { modalType: KeyManager.Native, isMipdProvider: false },
+          })
+          dispatch({
+            type: WalletActions.SET_IS_CONNECTED,
+            payload: true,
+          })
+          dispatch({ type: WalletActions.RESET_NATIVE_PENDING_DEVICE_ID })
+          dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
           localWallet.setLocalWallet({ type: KeyManager.Native, deviceId })
           localWallet.setLocalNativeWalletName(wallet.name)
         } catch (e) {


### PR DESCRIPTION
## Description

Aligns native with other wallets, where we `SET_WALLET` (and similar actions) on connect, regardless of first connection. Wallet state should always be set or re-set on connect, and we're currently missing on hitting a bunch of required state setters because of the `if (!initialized) initialize() else stateSetters()` logic.
This effectively fixes the backup passphrase modal early returning null, and a bunch of state issues that may exist but we may not know about with re: native and empty states.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9340

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium, touches wallet state, but really is just a logic alignment with other wallets, nothing fancy here

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Play around with various mixes of the below and ensure backup passphrase never renders empty
  - connecting native and refreshing then going to backup passphrase 
  - connecting MM-like wallets then switching to native and going to backup passphrase 
  - refreshing MM then switching to native and going to backup paspshrase

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/49639d74-c3f4-4562-88c7-54e4687e52a0

- this diff

https://jam.dev/c/2af5bd25-f47a-4d8c-8b2d-84c4956b410c


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
