### PR TITLE
fix: jupiter getSolanaTransactionFees not working and fee estimation to signing time

### DIFF
--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -143,12 +143,6 @@ export type QuoteFeeData = {
   chainSpecific?: UtxoFeeData | CosmosSdkFeeData | SolanaFeeData
 }
 
-export const isSolanaFeeData = (
-  chainSpecific: QuoteFeeData['chainSpecific'],
-): chainSpecific is SolanaFeeData => {
-  return Boolean(chainSpecific && 'priorityFee' in chainSpecific)
-}
-
 export type BuyAssetBySellIdInput = {
   sellAsset: Asset
   assets: Asset[]


### PR DESCRIPTION
## Description

Jupiter fee estimation handler is not working
The signing tx is using the fees at quote time (that might be a reason why it was flaky at some point)

Now the fee estimation handler is working properly, returning gas fees estimations
We estimate fees again at signing time so it's closer to the TX, meaning it uses proper data (not outdated)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Caught while implementing relay

## Risk
High but medium considering it was not working before

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to do some swap: SOL to any solana token, any solana token to SOL, SOL to solana tokens you never traded before...
- Fee estimations should be good at confirm time (often higher than at rate time)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://explorer.solana.com/tx/2hnoBVKDevpwjS68JKKhWoSeeLhuTUaHKBiKMwrGjen1dXYnW53AUAmnDqvjmMHzJKTWa7FG1BvJipPaJNc5TmJN
https://explorer.solana.com/tx/4vx74TW2t5MUyfMTL9orAPBWeX3EMMWQikcWyE41Dpaq8DnC4R6oMs4ZBnbrVgqdPo19UHdrLWDJPtKVfVpJdo7V