### PR TITLE
fix: you saved negative amounts

### DIFF
--- a/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
@@ -176,6 +176,25 @@ export const SpotTradeSuccess = ({
       .toFixed()
   }, [lastHop, totalUpsideCryptoPrecision, buyAmountBeforeFeesCryptoPrecision])
 
+  const feesOrTotalUpsideCryptoPrecision = useMemo(() => {
+    // Total upside should never be negative, if it is, it means that there was a *downside* in terms of delta, but there may still
+    // be a fees "upside" (or lack of downside, rather)
+    if (bnOrZero(totalUpsideCryptoPrecision).lte(0) && bnOrZero(feesUpsideCryptoPrecision).gt(0))
+      return bnOrZero(feesUpsideCryptoPrecision).toFixed()
+
+    return totalUpsideCryptoPrecision
+  }, [totalUpsideCryptoPrecision, feesUpsideCryptoPrecision])
+
+  const feesOrTotalUpsidePercentage = useMemo(() => {
+    if (bnOrZero(totalUpsidePercentage).lte(0) && bnOrZero(feesUpsideCryptoPrecision).gt(0))
+      return bnOrZero(feesUpsideCryptoPrecision)
+        .dividedBy(buyAmountBeforeFeesCryptoPrecision ?? 0)
+        .times(100)
+        .toFixed()
+
+    return totalUpsidePercentage
+  }, [totalUpsidePercentage, feesUpsideCryptoPrecision, buyAmountBeforeFeesCryptoPrecision])
+
   const relatedAssetIdsFilter = useMemo(
     () => ({
       assetId: foxAssetId,
@@ -310,16 +329,18 @@ export const SpotTradeSuccess = ({
             </Stack>
             <AmountsLine />
             <SurplusLine />
-            {enableFoxDiscountSummary && hasFeeSaving && (
-              <Box px={8}>
-                <YouSaved
-                  totalUpsidePercentage={totalUpsidePercentage}
-                  totalUpsideCryptoPrecision={totalUpsideCryptoPrecision ?? '0'}
-                  sellAsset={sellAsset}
-                  buyAsset={buyAsset}
-                />
-              </Box>
-            )}
+            {enableFoxDiscountSummary &&
+              hasFeeSaving &&
+              bnOrZero(feesOrTotalUpsideCryptoPrecision).gt(0) && (
+                <Box px={8}>
+                  <YouSaved
+                    totalUpsidePercentage={feesOrTotalUpsidePercentage}
+                    totalUpsideCryptoPrecision={feesOrTotalUpsideCryptoPrecision}
+                    sellAsset={sellAsset}
+                    buyAsset={buyAsset}
+                  />
+                </Box>
+              )}
             {couldHaveReducedFee && affiliateFeeUserCurrency && (
               <Box px={8}>
                 <YouCouldHaveSaved affiliateFeeUserCurrency={affiliateFeeUserCurrency} />


### PR DESCRIPTION
## Description

This PR ensures there is never a negative amount in `<YouSaved />`. If you do have a FOX savings, but a negative surplus delta, then the total amount can currently be negative.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9322

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- See eng/ops testing steps

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Hard to test as it requires real-world conditions, but can monkey patch things somehow e.g in `<SpotTradeSuccess`, monkey patching these, and playing around with values to ensure you have no/fee savings and no/extra delta:

```typescript
const buyAmountBeforeFeesCryptoPrecision = '47000000'
const buyAmountAfterFeesCryptoPrecision = '46000000'
const actualBuyAmountCryptoPrecision = '10000000'
const feeSavingUserCurrency = '10'
const quoteBuyAmountCryptoPrecision = '46000000'
```

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Retest https://github.com/shapeshift/web/issues/9322 and ensure we're now gucci

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->

- FOX savings and negative total delta 

<img width="614" alt="Screenshot 2025-04-15 at 19 12 24" src="https://github.com/user-attachments/assets/f23c587f-fbda-4512-910e-11615c0114bf" />

- FOX savings and positive total delta

<img width="727" alt="Screenshot 2025-04-15 at 19 12 34" src="https://github.com/user-attachments/assets/fc282df9-0a86-4b4a-9b09-f3888b8fe03b" />
