### PR TITLE
fix: user menu dead click on mobile

### DIFF
--- a/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
+++ b/src/components/Layout/Header/NavBar/WalletConnectedMenu.tsx
@@ -3,7 +3,8 @@ import { Flex, MenuDivider, MenuGroup, MenuItem } from '@chakra-ui/react'
 import { AnimatePresence } from 'framer-motion'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { Route, Routes } from 'react-router-dom'
+import { useLocation } from 'react-router-dom'
+import { Route, Switch } from 'wouter'
 
 import {
   useMenuRoutes,
@@ -106,41 +107,35 @@ export const WalletConnectedMenu = ({
     [connectedType],
   )
 
+  const location = useLocation()
+
   const renderRoute = useCallback((route: WalletProviderRouteProps, i: number) => {
     const Component = route.component
     return (
-      <Route
-        key={`walletConnectedMenuRoute_${i}`}
-        path={route.path || ''}
-        // eslint-disable-next-line react-memo/require-usememo
-        element={<Component />}
-      />
+      <Route key={`walletConnectedMenuRoute_${i}`} path={route.path || ''}>
+        <Component />
+      </Route>
     )
   }, [])
 
   return (
     <AnimatePresence mode='wait' initial={false}>
-      <Routes>
-        <Route
-          path={WalletConnectedRoutes.Connected}
-          // This is already a memo()'d component
-          // eslint-disable-next-line react-memo/require-usememo
-          element={
-            <SubMenuContainer>
-              <ConnectedMenu
-                connectedWalletMenuRoutes={!!connectedWalletMenuRoutes}
-                isConnected={isConnected}
-                connectedType={connectedType}
-                walletInfo={walletInfo}
-                onDisconnect={onDisconnect}
-                onSwitchProvider={onSwitchProvider}
-                onClose={onClose}
-              />
-            </SubMenuContainer>
-          }
-        />
+      <Switch location={location.pathname}>
+        <Route path={WalletConnectedRoutes.Connected}>
+          <SubMenuContainer>
+            <ConnectedMenu
+              connectedWalletMenuRoutes={!!connectedWalletMenuRoutes}
+              isConnected={isConnected}
+              connectedType={connectedType}
+              walletInfo={walletInfo}
+              onDisconnect={onDisconnect}
+              onSwitchProvider={onSwitchProvider}
+              onClose={onClose}
+            />
+          </SubMenuContainer>
+        </Route>
         {connectedWalletMenuRoutes?.map((route, index) => renderRoute(route, index))}
-      </Routes>
+      </Switch>
     </AnimatePresence>
   )
 }


### PR DESCRIPTION
## Description

No idea how this works on desktop, but this definitely doesn't on mobile - this PR fixes wouting.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted by ops in release thread



## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/medium, risk of borked user menu, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- User menu is happy on desktop and still opens
- User menu routes are still happy (test me with native and its many routes - note https://github.com/shapeshift/web/issues/9340 is still borked, fix pending merge in https://github.com/shapeshift/web/pull/9341)
- User menu is happy again on mobile

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Desktop

https://jam.dev/c/3789e620-b99d-42b5-83fe-4bdfafccccc5

- Mobile

https://jam.dev/c/5d61831b-e866-4a16-ac13-a108284840c4


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
