### PR TITLE
feat: utxobaseadapter cleanup useless senderAddress/receiverAddress and dupe validation checks

### DIFF
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -478,7 +478,6 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
   }
 
   async signAndBroadcastTransaction({
-    senderAddress,
     receiverAddress,
     signTxInput,
   }: SignAndBroadcastTransactionInput<T>): Promise<string> {
@@ -493,7 +492,7 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
 
       const hex = await this.signTransaction(signTxInput)
 
-      return this.broadcastTransaction({ senderAddress, receiverAddress, hex })
+      return this.broadcastTransaction({ hex })
     } catch (err) {
       return ErrorHandler(err, {
         translation: 'chainAdapters.errors.signAndBroadcastTransaction',
@@ -527,12 +526,8 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     }
   }
 
-  async broadcastTransaction({ receiverAddress, hex }: BroadcastTransactionInput): Promise<string> {
+  async broadcastTransaction({ hex }: Pick<BroadcastTransactionInput, 'hex'>): Promise<string> {
     try {
-      if (receiverAddress !== CONTRACT_INTERACTION) {
-        await assertAddressNotSanctioned(receiverAddress)
-      }
-
       const txHash = await this.providers.http.sendTx({ sendTxBody: { hex } })
 
       return txHash

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -1179,8 +1179,6 @@ describe('BitcoinChainAdapter', () => {
       const adapter = new bitcoin.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        senderAddress: '0x1234',
-        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -327,8 +327,6 @@ describe('BitcoinCashChainAdapter', () => {
       const adapter = new bitcoincash.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        senderAddress: '0x1234',
-        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -315,8 +315,6 @@ describe('DogecoinChainAdapter', () => {
       const adapter = new dogecoin.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        senderAddress: '0x1234',
-        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -314,8 +314,6 @@ describe('LitecoinChainAdapter', () => {
       const adapter = new litecoin.ChainAdapter(args)
       const mockTx = '0x123'
       const result = await adapter.broadcastTransaction({
-        senderAddress: '0x1234',
-        receiverAddress: '0x1234',
         hex: mockTx,
       })
       expect(args.providers.http.sendTx).toHaveBeenCalledWith<any>({ sendTxBody: { hex: mockTx } })

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeExecution.tsx
@@ -243,7 +243,6 @@ export const useTradeExecution = (
       const { accountType, bip44Params } = accountMetadata
       const accountNumber = bip44Params.accountNumber
       const stepSellAssetChainId = hop.sellAsset.chainId
-      const stepSellAssetAssetId = hop.sellAsset.assetId
       const stepBuyAssetAssetId = hop.buyAsset.assetId
 
       if (!isExecutableTradeQuote(tradeQuote)) throw new Error('Unable to execute trade')
@@ -329,10 +328,6 @@ export const useTradeExecution = (
           const adapter = assertGetUtxoChainAdapter(stepSellAssetChainId)
           const { xpub } = await adapter.getPublicKey(wallet, accountNumber, accountType)
           const _senderAddress = await adapter.getAddress({ accountNumber, accountType, wallet })
-          const senderAddress =
-            stepSellAssetAssetId === bchAssetId
-              ? _senderAddress.replace('bitcoincash:', '')
-              : _senderAddress
 
           const output = await execution.execUtxoTransaction({
             swapperName,
@@ -349,8 +344,6 @@ export const useTradeExecution = (
               })
 
               const output = await adapter.broadcastTransaction({
-                senderAddress,
-                receiverAddress,
                 hex: signedTx,
               })
 


### PR DESCRIPTION
## Description

- Cleanup `senderAddress` from UTXOBaseAdapter (unused)
- Cleanup `receiverAddress` from UTXOBaseAdapter, used in `broadcastTransaction`, but wrong twofolds:
  - only used for validation and with a single receive address (no change, and there may well be some weird UTXOs with many non-change output addresses, not technically impossible)
  - the validation is useless, as all inputs/outputs are already validated in `buildSendApiTransaction`

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9351

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none, this was blatantly wrong

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure /api/v1/validate is still hit with Txs input and output when making a UTXO Tx

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/25684315-3edb-4292-a8b1-cfc07a76c37f


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
