### PR TITLE
fix: asset generation

### DIFF
--- a/.env
+++ b/.env
@@ -102,6 +102,7 @@ VITE_TOKEMAK_STATS_URL=https://stats.tokemaklabs.com/
 
 # market data
 VITE_COINGECKO_API_KEY=CG-we5Z4KbdYMCgMUVAqDjQMWfc
+VITE_COINCAP_API_KEY=dab646843b251ce2d28864982989c335e1f0d32fa14e4ecc6b40cd057ec87f06
 
 # fiat currencies data
 VITE_EXCHANGERATEHOST_BASE_URL=https://api.exchangerate.host

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Generate all assets
         env:
           ZERION_API_KEY: ${{ secrets.ZERION_API_KEY }}
+          COINCAP_API_KEY: ${{ secrets.COINCAP_API_KEY }}
         run: yarn run generate:all
 
       - name: Create new feature branch

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout develop
         uses: actions/checkout@v3
         with:
-          ref: fix-asset-gen
+          ref: develop
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout develop
         uses: actions/checkout@v3
         with:
-          ref: develop
+          ref: fix-asset-gen
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v3

--- a/docs/asset-generation.md
+++ b/docs/asset-generation.md
@@ -4,10 +4,11 @@ Our asset data is generated periodically using a yarn script, with the result co
 
 ### Before you start
 
-The script requires a private Zerion API key. Request the key from the engineering team and set it as an environment variable:
+The script requires private Zerion and CoinCap API keys. Request the keys from the engineering team and set it as an environment variable:
 
 ```bash
 export ZERION_API_KEY=<zerion api key>
+export COINCAP_API_KEY=<coincap api key>
 ```
 
 ### Running the script

--- a/headers/csps/marketService/coincap.ts
+++ b/headers/csps/marketService/coincap.ts
@@ -3,9 +3,9 @@ import type { Csp } from '../../types'
 export const csp: Csp = {
   'connect-src': [
     // @shapeshiftoss/caip@1.7.0: https://github.com/shapeshift/lib/blob/5a378b186bf943c9f5e5342e1333b9fbc7c0deaf/packages/caip/src/adapters/coincap/index.ts#L5
-    'https://api.coincap.io/v2/assets',
+    'https://rest.coincap.io/v3/assets',
     // lib/market-service/src/coincap/coincap.ts
-    'https://api.coincap.io/v2/assets/',
+    'https://rest.coincap.io/v3/assets/',
   ],
   'img-src': ['https://assets.coincap.io/assets/icons/', 'https://static.coincap.io/assets/icons/'],
 }

--- a/packages/caip/src/adapters/coincap/generate.ts
+++ b/packages/caip/src/adapters/coincap/generate.ts
@@ -1,8 +1,8 @@
-import { coincapUrl } from './index'
+import { coincapAssetUrl } from './index'
 import { fetchData, parseData, writeFiles } from './utils'
 
 const main = async () => {
-  const data = await fetchData(coincapUrl)
+  const data = await fetchData(coincapAssetUrl)
   const output = parseData(data)
   await writeFiles(output)
 }

--- a/packages/caip/src/adapters/coincap/index.ts
+++ b/packages/caip/src/adapters/coincap/index.ts
@@ -3,8 +3,9 @@ import toLower from 'lodash/toLower'
 
 import * as adapters from './generated'
 
+export const baseUrl = 'https://rest.coincap.io/v3'
 const apiKey = '478b07654ff6dd0716b52e63cb2ad27c2b6aa7b7679d56eda0ea250d8b27dfcd'
-export const coincapUrl = `https://rest.coincap.io/v3/assets?limit=2000&apiKey=${apiKey}`
+export const coincapAssetUrl = `${baseUrl}/assets?limit=2000&apiKey=${apiKey}`
 
 const generatedAssetIdToCoinCapMap = Object.values(adapters).reduce((acc, cur) => ({
   ...acc,

--- a/packages/caip/src/adapters/coincap/index.ts
+++ b/packages/caip/src/adapters/coincap/index.ts
@@ -4,7 +4,7 @@ import toLower from 'lodash/toLower'
 import * as adapters from './generated'
 
 export const baseUrl = 'https://rest.coincap.io/v3'
-const apiKey = '478b07654ff6dd0716b52e63cb2ad27c2b6aa7b7679d56eda0ea250d8b27dfcd'
+const apiKey = process.env.COINCAP_API_KEY || ''
 export const coincapAssetUrl = `${baseUrl}/assets?limit=2000&apiKey=${apiKey}`
 
 const generatedAssetIdToCoinCapMap = Object.values(adapters).reduce((acc, cur) => ({

--- a/packages/caip/src/adapters/coincap/index.ts
+++ b/packages/caip/src/adapters/coincap/index.ts
@@ -3,7 +3,8 @@ import toLower from 'lodash/toLower'
 
 import * as adapters from './generated'
 
-export const coincapUrl = 'https://api.coincap.io/v2/assets?limit=2000'
+const apiKey = '478b07654ff6dd0716b52e63cb2ad27c2b6aa7b7679d56eda0ea250d8b27dfcd'
+export const coincapUrl = `https://rest.coincap.io/v3/assets?limit=2000&apiKey=${apiKey}`
 
 const generatedAssetIdToCoinCapMap = Object.values(adapters).reduce((acc, cur) => ({
   ...acc,

--- a/src/config.ts
+++ b/src/config.ts
@@ -183,6 +183,7 @@ const validators = {
   VITE_FEATURE_SWAPPER_RELAY: bool({ default: false }),
   VITE_FEATURE_NOTIFICATION_CENTER: bool({ default: false }),
   VITE_RELAY_API_URL: url(),
+  VITE_COINCAP_API_KEY: str(),
 }
 
 function reporter<T>({ errors }: envalid.ReporterOptions<T>) {

--- a/src/lib/market-service/coincap/coincap.test.ts
+++ b/src/lib/market-service/coincap/coincap.test.ts
@@ -115,7 +115,7 @@ describe('coincap market service', () => {
       mocks.get.mockResolvedValue({ data: [btc] })
       await coinMarketService.findAll({ count: 10 })
       expect(mocks.get).toHaveBeenCalledTimes(1)
-      const url = 'https://api.coincap.io/v2/assets?limit=10&offset=1'
+      const url = 'https://rest.coincap.io/v3/assets?limit=10&offset=1'
       expect(mocks.get).toBeCalledWith(url)
     })
 

--- a/src/lib/market-service/coincap/coincap.ts
+++ b/src/lib/market-service/coincap/coincap.ts
@@ -20,10 +20,18 @@ import type { CoinCapMarketCap } from './coincap-types'
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { assertUnreachable, getTimeFrameBounds } from '@/lib/utils'
 
-const axios = setupCache(Axios.create(), { ttl: DEFAULT_CACHE_TTL_MS, cacheTakeover: false })
+const apiKey = '478b07654ff6dd0716b52e63cb2ad27c2b6aa7b7679d56eda0ea250d8b27dfcd'
+const axios = setupCache(
+  Axios.create({
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }),
+  { ttl: DEFAULT_CACHE_TTL_MS, cacheTakeover: false },
+)
 
 export class CoinCapMarketService implements MarketService {
-  baseUrl = 'https://api.coincap.io/v2'
+  baseUrl = 'https://rest.coincap.io/v3'
 
   private readonly defaultGetByMarketCapArgs: FindAllMarketArgs = {
     count: 2500,

--- a/src/lib/market-service/coincap/coincap.ts
+++ b/src/lib/market-service/coincap/coincap.ts
@@ -17,10 +17,11 @@ import { DEFAULT_CACHE_TTL_MS } from '../config'
 import { isValidDate } from '../utils/isValidDate'
 import type { CoinCapMarketCap } from './coincap-types'
 
+import { getConfig } from '@/config'
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { assertUnreachable, getTimeFrameBounds } from '@/lib/utils'
 
-const apiKey = '478b07654ff6dd0716b52e63cb2ad27c2b6aa7b7679d56eda0ea250d8b27dfcd'
+const apiKey = getConfig().VITE_COINCAP_API_KEY
 const axios = setupCache(
   Axios.create({
     headers: {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -80,6 +80,7 @@ interface ImportMetaEnv {
   readonly VITE_ALCHEMY_POLYGON_URL: string
   readonly VITE_TOKEMAK_STATS_URL: string
   readonly VITE_COINGECKO_API_KEY: string
+  readonly VITE_COINCAP_API_KEY: string
   readonly VITE_EXCHANGERATEHOST_BASE_URL: string
   readonly VITE_EXCHANGERATEHOST_API_KEY: string
   readonly VITE_ALCHEMY_API_KEY: string


### PR DESCRIPTION
## Description

Updates the CoinCap implementation to use the new V3 API.

This API now requires an API key for all requests.

CLI run off this branch: https://github.com/shapeshift/web/actions/runs/14590765192/job/40925285964

Asset generation PR from this branch: https://github.com/shapeshift/web/pull/9375

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/9374

## Risk

Low, no runtime code.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Asset generation should be great again, and CI should pass.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A