### PR TITLE
perf: remove disabled rule

### DIFF
--- a/src/pages/RFOX/components/RFOXHeader.tsx
+++ b/src/pages/RFOX/components/RFOXHeader.tsx
@@ -16,6 +16,8 @@ import { Text } from '@/components/Text'
 import { selectAccountIdsByChainIdFilter } from '@/state/slices/portfolioSlice/selectors'
 import { useAppSelector } from '@/state/store'
 
+const buttonProps = { variant: 'solid', width: 'full' }
+
 export const RFOXHeader = () => {
   const translate = useTranslate()
   const navigate = useNavigate()
@@ -63,9 +65,7 @@ export const RFOXHeader = () => {
             defaultAccountId={selectedAssetAccountId}
             assetId={stakingAssetId}
             onChange={handleChange}
-            // dis already memoized
-            // eslint-disable-next-line react-memo/require-usememo
-            buttonProps={{ variant: 'solid', width: 'full' }}
+            buttonProps={buttonProps}
           />
         </InlineCopyButton>
       </Flex>


### PR DESCRIPTION
## Description

Nitpicky perf thing, spotted whilst reviewing [another PR](https://github.com/shapeshift/web/pull/9384#discussion_r2057580959) that copied this pattern.

Disabling the `react-memo/require-usememo` is incorrect in this context.

Having an object inside the memoization context means we unnecessarily recreate that object on every render of `activeAccountDropdown` (whenever any of  `accountIds.length`, `handleChange`, `selectedAssetAccountId`, `stakingAssetAccountId`, or `stakingAssetId` changes).

Tackling this nitpick so the pattern doesn't spread 🙏

## Issue (if applicable)

N/A

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

If we want to be pedantic, the rFOX header styles should show no regressions.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A