### PR TITLE
chore: enable op to op on lifi

### DIFF
--- a/packages/swapper/src/swappers/LifiSwapper/LifiSwapper.ts
+++ b/packages/swapper/src/swappers/LifiSwapper/LifiSwapper.ts
@@ -1,14 +1,10 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { optimismChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 
 import type { BuyAssetBySellIdInput, Swapper } from '../../types'
 import { executeEvmTransaction } from '../../utils'
 import { filterEvmAssetIdsBySellable } from '../utils/filterAssetIdsBySellable/filterAssetIdsBySellable'
-import {
-  filterCrossChainEvmBuyAssetsBySellAssetId,
-  filterSameChainEvmBuyAssetsBySellAssetId,
-} from '../utils/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId'
+import { filterCrossChainEvmBuyAssetsBySellAssetId } from '../utils/filterBuyAssetsBySellAssetId/filterBuyAssetsBySellAssetId'
 
 export const LIFI_TRADE_POLL_INTERVAL_MILLISECONDS = 30_000
 export const LIFI_GET_TRADE_QUOTE_POLLING_INTERVAL = 60_000
@@ -22,15 +18,7 @@ export const lifiSwapper: Swapper = {
 
   filterBuyAssetsBySellAssetId: (input: BuyAssetBySellIdInput): Promise<AssetId[]> => {
     return Promise.resolve(
-      [
-        ...filterCrossChainEvmBuyAssetsBySellAssetId(input),
-        // TODO(gomes): This is weird but a temporary product compromise to accommodate for the fact that OP rewards have weird heuristics
-        // and would detect same-chain swaps on Li.Fi as cross-chain swaps, making the rewards gameable by same-chain swaps
-        // Remove me when OP rewards ends
-        ...filterSameChainEvmBuyAssetsBySellAssetId(input).filter(
-          asset => asset.chainId !== optimismChainId,
-        ),
-      ].map(asset => asset.assetId),
+      filterCrossChainEvmBuyAssetsBySellAssetId(input).map(asset => asset.assetId),
     )
   },
 }


### PR DESCRIPTION
## Description

Re-supports Optimism to Optimism swaps on LiFi via the `filterBuyAssetsBySellAssetId` method, effectively reverting https://github.com/shapeshift/web/pull/4919/files.

Note that this currently has no effect at runtime, see https://github.com/shapeshift/web/issues/9243 for context on why.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/8177

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

This code path is not consumed at runtime, so nothing outside the general sanity checks.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A