### PR TITLE
fix: getDeviceId() spew for non-keepkey wallets

### DIFF
--- a/src/context/WalletProvider/KeepKey/hooks/useKeepKeyVersions.ts
+++ b/src/context/WalletProvider/KeepKey/hooks/useKeepKeyVersions.ts
@@ -62,7 +62,7 @@ export const useKeepKeyVersions = ({ wallet }: { wallet: HDWallet | null }) => {
   const isKeepKey = !!wallet && isKeepKeyHDWallet(wallet)
 
   const featuresQuery = useQuery({
-    queryKey: ['keepKeyFeatures', wallet?.getDeviceID()],
+    queryKey: ['keepKeyFeatures', isKeepKey ? wallet?.getDeviceID() : undefined],
     queryFn: async () => {
       if (!wallet) throw new Error('Wallet not available')
       return await wallet.getFeatures()
@@ -73,7 +73,7 @@ export const useKeepKeyVersions = ({ wallet }: { wallet: HDWallet | null }) => {
   })
 
   const deviceFirmwareQuery = useQuery({
-    queryKey: ['keepKeyFirmware', wallet?.getDeviceID()],
+    queryKey: ['keepKeyFirmware', isKeepKey ? wallet?.getDeviceID() : undefined],
     queryFn: async () => {
       if (!wallet) throw new Error('Wallet not available')
       return await wallet.getFirmwareVersion()


### PR DESCRIPTION
## Description

As we spew this guy inline on every render of `useKeepKeyVersions()`, it means that every hook render will call `sol_connect`, making Phantom "rate-limit" itself, despite `sol_connect` being an internal JSON-RPC call.
The reason is that `getDeviceId()` for PhantomHdWallet actually makes a `solanaGetAddress()` call to get a compooosite deviceId.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted by hpayne

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect Phantom 
- Phantom accounts are derived

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- This diff 

<img width="863" alt="Screenshot 2025-04-25 at 20 53 55" src="https://github.com/user-attachments/assets/564a543f-4fcb-4cf3-8fa4-34d9c0a93168" />


- Prod

<img width="1433" alt="image" src="https://github.com/user-attachments/assets/560f7a02-f68c-480a-a73a-d1caa33200cd" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
