### PR TITLE
feat: no smartsies on default pairs

### DIFF
--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react'
 import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
-import { memo, useCallback, useEffect, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
 import { AssetRowLoading } from '../AssetRowLoading'
@@ -121,28 +121,6 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
       },
       [isAssetChainIdConnected, isAssetChainIdSupported, onlyConnectedChains],
     )
-
-    // If the currently selected assetId becomes disabled (by switching assets or disconnecting a
-    // chain), switch to the first enabled related assetId
-    useEffect(() => {
-      const isCurrentAssetIdDisabled = assetId ? isAssetChainIdDisabled(assetId) : false
-
-      if (isCurrentAssetIdDisabled) {
-        const firstEnabledAssetId = filteredRelatedAssetIds.find(
-          assetId => !isAssetChainIdDisabled(assetId),
-        )
-        if (firstEnabledAssetId) {
-          onChangeAsset(firstEnabledAssetId)
-        }
-      }
-    }, [
-      filteredRelatedAssetIds,
-      isAssetChainIdConnected,
-      assetId,
-      onChangeAsset,
-      isAssetChainIdSupported,
-      isAssetChainIdDisabled,
-    ])
 
     const renderedChains = useMemo(() => {
       if (!assetId) return null


### PR DESCRIPTION
## Description

Copypasta of message to product which sums up the current insanity pretty well:

> we have a lot of complex and inherently bug-prone logic related to default assets.
> We historically did a bunch of logic to do things like settings default pairs on wallet connect/change/disconnect/chains add and removal.
> This is inherently bug-prone and will produce weird flashes of "default" pairs changing.

> If you think about it, the whole intent of trying to be smart was to make UX better by preselecting them pairs that could be nice to them, but if trying to do that adds so much logic and is detrimental to the UX, then it's a negative value.

> Proposing we stop this madness and KISS by removing all this ugly logic since we're now driven by URL. Whatever you see in the URL (i.e the default pair when you click pair, or whatever was your last selection, kept in the store) should stay as-is, unless you explicitly change assets with a user action. 

Confirmed with product we're good to go with stopping to try and be smart and keep things simple. No more smartsies = no more flashies!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9359

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - just note that this *removes* logic that does default pairs bits. This means that what would be considered a feature previously (although inherently flaky) is now *gone*:

- Auto-switching pairs on supported account add
- Auto-switching pairs on supported account removal
- Auto-switching pairs while accounts are loading (the guts of our issues here)
- Auto-switching pairs on wallet switch

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to trade without a wallet connected and notice the default pair there (also reflected in the URL)
- Connect any wallet and notice even after accounts are loaded, pairs don't change and there's no flash
- Try any combination of switching wallets with diff chains support, un/installing the snap, switching wallet, and clearing your cache, and notice you still don't see the default pair flashing/changing
- Ensure you can still switch assets, and the URL you see still works in incognito (i.e with no cache)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/bc7b0d28-3b9a-4bef-8e62-63face4811df


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
