### PR TITLE
fix: show mayachain and thorchain as popular assets

### DIFF
--- a/src/components/TradeAssetSearch/hooks/useGetPopularAssetsQuery.tsx
+++ b/src/components/TradeAssetSearch/hooks/useGetPopularAssetsQuery.tsx
@@ -1,8 +1,10 @@
 import type { ChainId } from '@shapeshiftoss/caip'
+import { mayachainAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { useQuery } from '@tanstack/react-query'
 
 import { getMarketServiceManager } from '@/state/slices/marketDataSlice/marketServiceManagerSingleton'
+import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
 import { selectAssets } from '@/state/slices/selectors'
 import { store } from '@/state/store'
 
@@ -15,6 +17,11 @@ export const queryFn = async () => {
   }
 
   const assets = selectAssets(store.getState())
+  const enabledFlags = preferences.selectors.selectFeatureFlags(store.getState())
+
+  // add thorchain and mayachain to popular assets for discoverability on wallets without existing balances
+  assetIds.push(thorchainAssetId)
+  if (enabledFlags.Mayachain) assetIds.push(mayachainAssetId)
 
   for (const assetId of assetIds) {
     const asset = assets[assetId]


### PR DESCRIPTION
## Description

Thorchain and Mayachain are not in the top 100 market cap chains resulting in the asset not being discoverable on a wallet that has funds, but does not have a balance on those chains. This adds these assets to the popular assets so they are visible as the only asset on those chains at all times when filtering by chain.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://discord.com/channels/554694662431178782/1366251876013576282/1366252257271746643
https://discord.com/channels/554694662431178782/1366251876013576282/1366254886710415360

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Create a new wallet
- All assets should be shown by default
- Send an asset to the new wallet that is not rune or cacao
- Verify rune and cacao are shown in the asset search from send/receive modals now (default list, filter by search term, and filter by chain)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/f8246804-3058-42c9-8ae9-ad9845e069cb)
![image](https://github.com/user-attachments/assets/855afbe2-eec8-450f-85de-5df7446d991b)
![image](https://github.com/user-attachments/assets/582483c0-49c2-4dcc-9251-c246937aa29f)
![image](https://github.com/user-attachments/assets/16bcb79c-3c84-4a6c-92d6-8b767f153df6)
![image](https://github.com/user-attachments/assets/5b6bb197-32eb-4f43-b089-0531efbf92c2)
