### PR TITLE
fix: truncate large asset balances

### DIFF
--- a/src/pages/Dashboard/components/AccountList/AccountTable.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
@@ -10,7 +10,6 @@ import {
 import type { Property } from 'csstype'
 import { range, truncate } from 'lodash'
 import { memo, useCallback, useMemo } from 'react'
-import { isMobile } from 'react-device-detect'
 import { useSelector } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import type { Column, Row } from 'react-table'

--- a/src/pages/Dashboard/components/AccountList/AccountTable.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
@@ -78,7 +78,7 @@ export const AccountTable = memo(() => {
               data-test={`account-row-asset-crypto-${row.original.symbol}`}
               value={row.original.cryptoAmount}
               symbol={truncate(row.original.symbol, { length: 6 })}
-              truncateLargeNumbers={isMobile ? true : false}
+              truncateLargeNumbers={true}
             />
           </Stack>
         ),


### PR DESCRIPTION
## Description

Truncates large asset balances to prevent the asset table's x-axis from growing unbounded.

Note we already have this on mobile, this adds it to the desktop view, too.

Before:

<img width="1184" alt="Screenshot 2025-05-02 at 12 00 16 pm" src="https://github.com/user-attachments/assets/a3726506-12af-4001-9f7a-87295e1febc1" />

After:

<img width="935" alt="Screenshot 2025-05-02 at 12 02 03 pm" src="https://github.com/user-attachments/assets/18efa5a5-2010-4dd2-bfb2-a482a18f57c3" />

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/9289

## Risk

Small 

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

Monkey patch:

```diff
diff --git a/src/pages/Dashboard/components/AccountList/AccountTable.tsx b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
index 925f96ce13..6e8f3dd044 100644
--- a/src/pages/Dashboard/components/AccountList/AccountTable.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
@@ -75,7 +75,9 @@ export const AccountTable = memo(() => {
               fontSize='sm'
               whiteSpace='nowrap'
               data-test={`account-row-asset-crypto-${row.original.symbol}`}
-              value={row.original.cryptoAmount}
+              value={
+                '999999999999999999999999999999999999999999999999999999999999999999999999999999999'
+              }
               symbol={truncate(row.original.symbol, { length: 6 })}
               truncateLargeNumbers={true}
             />
```

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

This one is a bit tricky unless you have a scam asset with a stupidly high balance.

## Screenshots (if applicable)

N/A