### PR TITLE
feat: tcy reusable status components

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2818,7 +2818,7 @@
       "failedSubtitle": "Your claim has failed. Please try again."
     },
     "claimConfirm": {
-      "confirmTitle": "Confirm",
+      "confirmTitle": "Confirm Claim",
       "networkFee": "Network Fee",
       "confirmAndClaim": "Confirm & Claim"
     },

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2864,7 +2864,17 @@
       "viewTransaction": "View Transaction",
       "successSubtitle": "You have successfully staked %{amount} TCY",
       "goBack": "Go Back"
+    },
+    "claimStatus": {
+      "pendingTitle": "Claim is pending",
+      "pendingSubtitle": "We are processing your claim for %{amount} TCY",
+      "successTitle": "Claim is successful",
+      "failedTitle": "Something went wrong",
+      "failedSubtitle": "Your claim has failed. Please try again.",
+      "successSubtitle": "You have successfully claimed %{amount} TCY",
+      "goBack": "Go Back"
     }
+
   },
   "markets": {
     "recommended": "Recommended",

--- a/src/pages/TCY/components/Claim/ClaimStatus.tsx
+++ b/src/pages/TCY/components/Claim/ClaimStatus.tsx
@@ -7,6 +7,7 @@ import { ReusableStatus } from '../ReusableStatus'
 import type { Claim } from './types'
 
 import { DialogHeader } from '@/components/Modal/components/DialogHeader'
+import { Text } from '@/components/Text'
 import { fromBaseUnit } from '@/lib/math'
 import { THOR_PRECISION } from '@/lib/utils/thorchain/constants'
 
@@ -41,17 +42,20 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
         <DialogHeader.Right>
           <ModalCloseButton onClick={handleGoBack} />
         </DialogHeader.Right>
+        <DialogHeader.Middle>
+          <Text translation='TCY.claimConfirm.confirmTitle' />
+        </DialogHeader.Middle>
       </DialogHeader>
       <Stack>
         <ReusableStatus
           txId={txId}
           setTxId={setClaimTxid}
           onTxConfirmed={handleTxConfirmed}
-          initialRoute={TCYClaimRoute.Select}
           translationPrefix='claim'
           accountId={claim.accountId}
           amountCryptoPrecision={amountCryptoPrecision}
           isDialog={false}
+          displayGoBack={false}
         />
       </Stack>
     </>

--- a/src/pages/TCY/components/Claim/ClaimStatus.tsx
+++ b/src/pages/TCY/components/Claim/ClaimStatus.tsx
@@ -7,7 +7,6 @@ import { ReusableStatus } from '../ReusableStatus'
 import type { Claim } from './types'
 
 import { DialogHeader } from '@/components/Modal/components/DialogHeader'
-import { SlideTransition } from '@/components/SlideTransition'
 import { fromBaseUnit } from '@/lib/math'
 import { THOR_PRECISION } from '@/lib/utils/thorchain/constants'
 

--- a/src/pages/TCY/components/Claim/ClaimStatus.tsx
+++ b/src/pages/TCY/components/Claim/ClaimStatus.tsx
@@ -1,24 +1,15 @@
-import { CheckCircleIcon, WarningIcon } from '@chakra-ui/icons'
 import { ModalCloseButton, Stack } from '@chakra-ui/react'
-import { SwapperName } from '@shapeshiftoss/swapper'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
-import React, { useCallback, useMemo } from 'react'
-import { useTranslate } from 'react-polyglot'
+import { useCallback, useMemo } from 'react'
 import { useNavigate } from 'react-router'
 
 import { TCYClaimRoute } from '../../types'
+import { ReusableStatus } from '../ReusableStatus'
 import type { Claim } from './types'
 
 import { DialogHeader } from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
-import { TransactionStatusDisplay } from '@/components/TransactionStatusDisplay/TransactionStatusDisplay'
-import { useSafeTxQuery } from '@/hooks/queries/useSafeTx'
-import { useTxStatus } from '@/hooks/useTxStatus/useTxStatus'
-import { bnOrZero } from '@/lib/bignumber/bignumber'
-import { getTxLink } from '@/lib/getTxLink'
 import { fromBaseUnit } from '@/lib/math'
-import { selectAssetById } from '@/state/slices/selectors'
-import { useAppSelector } from '@/state/store'
+import { THOR_PRECISION } from '@/lib/utils/thorchain/constants'
 
 type ClaimStatusProps = {
   claim: Claim | undefined
@@ -34,122 +25,36 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({
   onTxConfirmed: handleTxConfirmed,
 }) => {
   const navigate = useNavigate()
-  const translate = useTranslate()
-  const txStatus = useTxStatus({
-    accountId: claim?.accountId ?? null,
-    txHash: txId,
-    onTxStatusConfirmed: handleTxConfirmed,
-  })
+  const amountCryptoPrecision = useMemo(
+    () => fromBaseUnit(claim?.amountThorBaseUnit ?? '0', THOR_PRECISION),
+    [claim?.amountThorBaseUnit],
+  )
 
   const handleGoBack = useCallback(() => {
     navigate(TCYClaimRoute.Select)
   }, [navigate])
 
-  const asset = useAppSelector(state => selectAssetById(state, claim?.assetId ?? ''))
-  const amountCryptoPrecision = useMemo(
-    () => fromBaseUnit(claim?.amountThorBaseUnit ?? '0', asset?.precision ?? 0),
-    [claim?.amountThorBaseUnit, asset?.precision],
-  )
-
-  const { data: maybeSafeTx } = useSafeTxQuery({
-    maybeSafeTxHash: txId ?? undefined,
-    accountId: claim?.accountId,
-  })
-
-  const txLink = useMemo(
-    () =>
-      getTxLink({
-        txId,
-        defaultExplorerBaseUrl: asset?.explorerTxLink ?? '',
-        accountId: claim?.accountId,
-        maybeSafeTx,
-        stepSource: SwapperName.Thorchain,
-      }),
-    [claim?.accountId, maybeSafeTx, asset?.explorerTxLink, txId],
-  )
-
-  const handleViewTransaction = useCallback(() => {
-    if (txLink) window.open(txLink, '_blank')
-  }, [txLink])
-
-  const renderStatus = () => {
-    if (!asset) return null
-
-    if (maybeSafeTx?.isQueuedSafeTx) {
-      return (
-        <TransactionStatusDisplay
-          isLoading
-          title={translate('common.safeProposalQueued', {
-            currentConfirmations: maybeSafeTx?.transaction?.confirmations?.length,
-            confirmationsRequired: maybeSafeTx?.transaction?.confirmationsRequired,
-          })}
-          subtitle={translate('TCY.claimPending', {
-            amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-            symbol: asset.symbol,
-          })}
-          primaryButtonText={translate('trade.viewTransaction')}
-          onPrimaryClick={handleViewTransaction}
-        />
-      )
-    }
-
-    if (maybeSafeTx?.isExecutedSafeTx && maybeSafeTx?.transaction?.transactionHash) {
-      setClaimTxid(maybeSafeTx.transaction.transactionHash)
-    }
-
-    switch (txStatus) {
-      case undefined:
-      case TxStatus.Pending:
-        return (
-          <TransactionStatusDisplay
-            isLoading
-            title={translate('pools.waitingForConfirmation')}
-            subtitle={translate('TCY.claimStatus.pendingTitle', {
-              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-              symbol: asset.symbol,
-            })}
-            primaryButtonText={translate('trade.viewTransaction')}
-            onPrimaryClick={handleViewTransaction}
-          />
-        )
-      case TxStatus.Confirmed:
-        return (
-          <TransactionStatusDisplay
-            icon={CheckCircleIcon}
-            iconColor='green.500'
-            title={translate('common.success')}
-            subtitle={translate('TCY.claimStatus.successTitle', {
-              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-              symbol: asset.symbol,
-            })}
-            primaryButtonText={translate('trade.viewTransaction')}
-            onPrimaryClick={handleViewTransaction}
-          />
-        )
-      case TxStatus.Failed:
-        return (
-          <TransactionStatusDisplay
-            icon={WarningIcon}
-            iconColor='red.500'
-            title={translate('common.somethingWentWrong')}
-            subtitle={translate('common.somethingWentWrongBody')}
-            primaryButtonText={translate('trade.viewTransaction')}
-            onPrimaryClick={handleViewTransaction}
-          />
-        )
-      default:
-        return null
-    }
-  }
+  if (!claim) return null
 
   return (
-    <SlideTransition>
+    <>
       <DialogHeader>
         <DialogHeader.Right>
           <ModalCloseButton onClick={handleGoBack} />
         </DialogHeader.Right>
       </DialogHeader>
-      <Stack>{renderStatus()}</Stack>
-    </SlideTransition>
+      <Stack>
+        <ReusableStatus
+          txId={txId}
+          setTxId={setClaimTxid}
+          onTxConfirmed={handleTxConfirmed}
+          initialRoute={TCYClaimRoute.Select}
+          translationPrefix='claim'
+          accountId={claim.accountId}
+          amountCryptoPrecision={amountCryptoPrecision}
+          isDialog={false}
+        />
+      </Stack>
+    </>
   )
 }

--- a/src/pages/TCY/components/ReusableStatus.tsx
+++ b/src/pages/TCY/components/ReusableStatus.tsx
@@ -1,0 +1,180 @@
+import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
+import { tcyAssetId } from '@shapeshiftoss/caip'
+import { SwapperName } from '@shapeshiftoss/swapper'
+import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { useCallback, useMemo } from 'react'
+import { useTranslate } from 'react-polyglot'
+import { useNavigate } from 'react-router'
+
+import { DialogBackButton } from '@/components/Modal/components/DialogBackButton'
+import { DialogHeader } from '@/components/Modal/components/DialogHeader'
+import { SlideTransition } from '@/components/SlideTransition'
+import { RawText } from '@/components/Text'
+import { TransactionStatusDisplay } from '@/components/TransactionStatusDisplay/TransactionStatusDisplay'
+import { useSafeTxQuery } from '@/hooks/queries/useSafeTx'
+import { useTxStatus } from '@/hooks/useTxStatus/useTxStatus'
+import { bnOrZero } from '@/lib/bignumber/bignumber'
+import { getTxLink } from '@/lib/getTxLink'
+import { selectAssetById } from '@/state/slices/selectors'
+import { useAppSelector } from '@/state/store'
+
+type TransactionStatusProps = {
+  txId: string
+  setTxId: (txId: string) => void
+  onTxConfirmed: () => Promise<void>
+  initialRoute: string
+  translationPrefix: 'stake' | 'unstake' | 'claim'
+  accountId: string
+  amountCryptoPrecision: string
+  isDialog: boolean
+  headerText?: string
+}
+
+export const ReusableStatus = ({
+  txId,
+  setTxId,
+  onTxConfirmed: handleTxConfirmed,
+  initialRoute,
+  translationPrefix,
+  accountId,
+  amountCryptoPrecision,
+  isDialog,
+  headerText,
+}: TransactionStatusProps) => {
+  const translate = useTranslate()
+  const navigate = useNavigate()
+  const tcyAsset = useAppSelector(state => selectAssetById(state, tcyAssetId))
+
+  const txStatus = useTxStatus({
+    accountId: accountId ?? '',
+    txHash: txId,
+    onTxStatusConfirmed: handleTxConfirmed,
+  })
+
+  const { data: maybeSafeTx } = useSafeTxQuery({
+    maybeSafeTxHash: txId ?? undefined,
+    accountId,
+  })
+
+  const txLink = useMemo(
+    () =>
+      getTxLink({
+        txId,
+        defaultExplorerBaseUrl: tcyAsset?.explorerTxLink ?? '',
+        accountId,
+        maybeSafeTx,
+        stepSource: SwapperName.Thorchain,
+      }),
+    [accountId, maybeSafeTx, tcyAsset?.explorerTxLink, txId],
+  )
+
+  const handleViewTransaction = useCallback(() => {
+    if (txLink) window.open(txLink, '_blank')
+  }, [txLink])
+
+  const handleGoBack = useCallback(() => {
+    navigate(initialRoute)
+  }, [navigate, initialRoute])
+
+  const statusContent = useMemo(() => {
+    if (!tcyAsset) return null
+
+    if (maybeSafeTx?.isQueuedSafeTx) {
+      return (
+        <TransactionStatusDisplay
+          isLoading
+          title={translate('common.safeProposalQueued', {
+            currentConfirmations: maybeSafeTx?.transaction?.confirmations?.length,
+            confirmationsRequired: maybeSafeTx?.transaction?.confirmationsRequired,
+          })}
+          subtitle={translate(`TCY.${translationPrefix}Pending`, {
+            amount: bnOrZero(amountCryptoPrecision).toFixed(8),
+            symbol: tcyAsset.symbol,
+          })}
+          primaryButtonText={translate('trade.viewTransaction')}
+          onPrimaryClick={handleViewTransaction}
+        />
+      )
+    }
+
+    if (maybeSafeTx?.isExecutedSafeTx && maybeSafeTx?.transaction?.transactionHash) {
+      setTxId(maybeSafeTx.transaction.transactionHash)
+    }
+
+    switch (txStatus) {
+      case undefined:
+      case TxStatus.Pending:
+        return (
+          <TransactionStatusDisplay
+            isLoading
+            title={translate('pools.waitingForConfirmation')}
+            subtitle={translate(`TCY.${translationPrefix}Status.pendingSubtitle`, {
+              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
+              symbol: tcyAsset.symbol,
+            })}
+            primaryButtonText={translate('trade.viewTransaction')}
+            onPrimaryClick={handleViewTransaction}
+          />
+        )
+      case TxStatus.Confirmed:
+        return (
+          <TransactionStatusDisplay
+            icon={CheckCircleIcon}
+            iconColor='green.500'
+            title={translate(`TCY.${translationPrefix}Status.successTitle`)}
+            subtitle={translate(`TCY.${translationPrefix}Status.successSubtitle`, {
+              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
+              symbol: tcyAsset.symbol,
+            })}
+            secondaryButtonText={translate('trade.viewTransaction')}
+            onSecondaryClick={handleViewTransaction}
+            primaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
+            onPrimaryClick={handleGoBack}
+          />
+        )
+      case TxStatus.Failed:
+        return (
+          <TransactionStatusDisplay
+            icon={WarningTwoIcon}
+            iconColor='red.500'
+            title={translate(`TCY.${translationPrefix}Status.failedTitle`)}
+            subtitle={translate(`TCY.${translationPrefix}Status.failedSubtitle`)}
+            primaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
+            onPrimaryClick={handleGoBack}
+          />
+        )
+      default:
+        return null
+    }
+  }, [
+    tcyAsset,
+    txStatus,
+    maybeSafeTx,
+    amountCryptoPrecision,
+    handleViewTransaction,
+    handleGoBack,
+    setTxId,
+    translationPrefix,
+    translate,
+  ])
+
+  const handleBack = useCallback(() => {
+    navigate(-1)
+  }, [navigate])
+
+  const headerLeftComponent = useMemo(() => <DialogBackButton onClick={handleBack} />, [handleBack])
+
+  if (!isDialog) return <SlideTransition>{statusContent}</SlideTransition>
+
+  return (
+    <SlideTransition>
+      <DialogHeader>
+        {headerLeftComponent && <DialogHeader.Left>{headerLeftComponent}</DialogHeader.Left>}
+        <DialogHeader.Middle>
+          <RawText>{headerText}</RawText>
+        </DialogHeader.Middle>
+      </DialogHeader>
+      {statusContent}
+    </SlideTransition>
+  )
+}

--- a/src/pages/TCY/components/ReusableStatus.tsx
+++ b/src/pages/TCY/components/ReusableStatus.tsx
@@ -21,24 +21,26 @@ type TransactionStatusProps = {
   txId: string
   setTxId: (txId: string) => void
   onTxConfirmed: () => Promise<void>
-  initialRoute: string
   translationPrefix: 'stake' | 'unstake' | 'claim'
   accountId: string
   amountCryptoPrecision: string
   isDialog: boolean
   headerText?: string
+  displayGoBack: boolean
+  initialRoute?: string
 }
 
 export const ReusableStatus = ({
   txId,
   setTxId,
   onTxConfirmed: handleTxConfirmed,
-  initialRoute,
   translationPrefix,
   accountId,
   amountCryptoPrecision,
   isDialog,
   headerText,
+  displayGoBack,
+  initialRoute,
 }: TransactionStatusProps) => {
   const translate = useTranslate()
   const navigate = useNavigate()
@@ -72,6 +74,8 @@ export const ReusableStatus = ({
   }, [txLink])
 
   const handleGoBack = useCallback(() => {
+    if (!initialRoute) return
+
     navigate(initialRoute)
   }, [navigate, initialRoute])
 
@@ -112,9 +116,11 @@ export const ReusableStatus = ({
               symbol: tcyAsset.symbol,
             })}
             primaryButtonText={translate('trade.viewTransaction')}
-            secondaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
             onPrimaryClick={handleViewTransaction}
-            onSecondaryClick={handleGoBack}
+            secondaryButtonText={
+              displayGoBack ? translate(`TCY.${translationPrefix}Status.goBack`) : undefined
+            }
+            onSecondaryClick={displayGoBack ? handleGoBack : undefined}
           />
         )
       case TxStatus.Confirmed:
@@ -128,9 +134,11 @@ export const ReusableStatus = ({
               symbol: tcyAsset.symbol,
             })}
             primaryButtonText={translate('trade.viewTransaction')}
-            secondaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
             onPrimaryClick={handleViewTransaction}
-            onSecondaryClick={handleGoBack}
+            secondaryButtonText={
+              displayGoBack ? translate(`TCY.${translationPrefix}Status.goBack`) : undefined
+            }
+            onSecondaryClick={displayGoBack ? handleGoBack : undefined}
           />
         )
       case TxStatus.Failed:
@@ -141,9 +149,11 @@ export const ReusableStatus = ({
             title={translate(`TCY.${translationPrefix}Status.failedTitle`)}
             subtitle={translate(`TCY.${translationPrefix}Status.failedSubtitle`)}
             primaryButtonText={translate('trade.viewTransaction')}
-            secondaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
             onPrimaryClick={handleViewTransaction}
-            onSecondaryClick={handleGoBack}
+            secondaryButtonText={
+              displayGoBack ? translate(`TCY.${translationPrefix}Status.goBack`) : undefined
+            }
+            onSecondaryClick={displayGoBack ? handleGoBack : undefined}
           />
         )
       default:
@@ -159,6 +169,7 @@ export const ReusableStatus = ({
     setTxId,
     translationPrefix,
     translate,
+    displayGoBack,
   ])
 
   if (!isDialog) return <SlideTransition>{statusContent}</SlideTransition>

--- a/src/pages/TCY/components/ReusableStatus.tsx
+++ b/src/pages/TCY/components/ReusableStatus.tsx
@@ -1,6 +1,6 @@
 import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
 import { tcyAssetId } from '@shapeshiftoss/caip'
-import { SwapperName } from '@shapeshiftoss/swapper'
+import { SwapperName, THOR_PRECISION } from '@shapeshiftoss/swapper'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -88,7 +88,7 @@ export const ReusableStatus = ({
             confirmationsRequired: maybeSafeTx?.transaction?.confirmationsRequired,
           })}
           subtitle={translate(`TCY.${translationPrefix}Pending`, {
-            amount: bnOrZero(amountCryptoPrecision).toFixed(8),
+            amount: bnOrZero(amountCryptoPrecision).toFixed(THOR_PRECISION),
             symbol: tcyAsset.symbol,
           })}
           primaryButtonText={translate('trade.viewTransaction')}

--- a/src/pages/TCY/components/ReusableStatus.tsx
+++ b/src/pages/TCY/components/ReusableStatus.tsx
@@ -6,7 +6,6 @@ import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useNavigate } from 'react-router'
 
-import { DialogBackButton } from '@/components/Modal/components/DialogBackButton'
 import { DialogHeader } from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
 import { RawText } from '@/components/Text'
@@ -113,7 +112,9 @@ export const ReusableStatus = ({
               symbol: tcyAsset.symbol,
             })}
             primaryButtonText={translate('trade.viewTransaction')}
+            secondaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
             onPrimaryClick={handleViewTransaction}
+            onSecondaryClick={handleGoBack}
           />
         )
       case TxStatus.Confirmed:
@@ -126,10 +127,10 @@ export const ReusableStatus = ({
               amount: bnOrZero(amountCryptoPrecision).toFixed(8),
               symbol: tcyAsset.symbol,
             })}
-            secondaryButtonText={translate('trade.viewTransaction')}
-            onSecondaryClick={handleViewTransaction}
-            primaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
-            onPrimaryClick={handleGoBack}
+            primaryButtonText={translate('trade.viewTransaction')}
+            secondaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
+            onPrimaryClick={handleViewTransaction}
+            onSecondaryClick={handleGoBack}
           />
         )
       case TxStatus.Failed:
@@ -139,8 +140,10 @@ export const ReusableStatus = ({
             iconColor='red.500'
             title={translate(`TCY.${translationPrefix}Status.failedTitle`)}
             subtitle={translate(`TCY.${translationPrefix}Status.failedSubtitle`)}
-            primaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
-            onPrimaryClick={handleGoBack}
+            primaryButtonText={translate('trade.viewTransaction')}
+            secondaryButtonText={translate(`TCY.${translationPrefix}Status.goBack`)}
+            onPrimaryClick={handleViewTransaction}
+            onSecondaryClick={handleGoBack}
           />
         )
       default:
@@ -158,18 +161,11 @@ export const ReusableStatus = ({
     translate,
   ])
 
-  const handleBack = useCallback(() => {
-    navigate(-1)
-  }, [navigate])
-
-  const headerLeftComponent = useMemo(() => <DialogBackButton onClick={handleBack} />, [handleBack])
-
   if (!isDialog) return <SlideTransition>{statusContent}</SlideTransition>
 
   return (
     <SlideTransition>
       <DialogHeader>
-        {headerLeftComponent && <DialogHeader.Left>{headerLeftComponent}</DialogHeader.Left>}
         <DialogHeader.Middle>
           <RawText>{headerText}</RawText>
         </DialogHeader.Middle>

--- a/src/pages/TCY/components/Stake/StakeStatus.tsx
+++ b/src/pages/TCY/components/Stake/StakeStatus.tsx
@@ -28,12 +28,13 @@ export const StakeStatus: React.FC<StakeStatusProps> = ({
       txId={txId}
       setTxId={setStakeTxid}
       onTxConfirmed={handleTxConfirmed}
-      initialRoute={TCYStakeRoute.Input}
       translationPrefix='stake'
       accountId={formValues.accountId}
       amountCryptoPrecision={formValues.amountCryptoPrecision}
       isDialog
       headerText={translate('TCY.stakeConfirm.confirmTitle')}
+      initialRoute={TCYStakeRoute.Input}
+      displayGoBack
     />
   )
 }

--- a/src/pages/TCY/components/Stake/StakeStatus.tsx
+++ b/src/pages/TCY/components/Stake/StakeStatus.tsx
@@ -1,23 +1,9 @@
-import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
-import { tcyAssetId } from '@shapeshiftoss/caip'
-import { SwapperName } from '@shapeshiftoss/swapper'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useMemo } from 'react'
 import { useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
-import { useNavigate } from 'react-router'
 
 import { TCYStakeRoute } from '../../types'
+import { ReusableStatus } from '../ReusableStatus'
 import type { StakeFormValues } from './Stake'
-
-import { SlideTransition } from '@/components/SlideTransition'
-import { TransactionStatusDisplay } from '@/components/TransactionStatusDisplay/TransactionStatusDisplay'
-import { useSafeTxQuery } from '@/hooks/queries/useSafeTx'
-import { useTxStatus } from '@/hooks/useTxStatus/useTxStatus'
-import { bnOrZero } from '@/lib/bignumber/bignumber'
-import { getTxLink } from '@/lib/getTxLink'
-import { selectAssetById } from '@/state/slices/selectors'
-import { useAppSelector } from '@/state/store'
 
 type StakeStatusProps = {
   txId: string
@@ -31,112 +17,23 @@ export const StakeStatus: React.FC<StakeStatusProps> = ({
   onTxConfirmed: handleTxConfirmed,
 }) => {
   const translate = useTranslate()
-  const navigate = useNavigate()
-  const tcyAsset = useAppSelector(state => selectAssetById(state, tcyAssetId))
+  const formValues = useWatch<StakeFormValues>()
 
-  const { amountCryptoPrecision, accountId } = useWatch<StakeFormValues>()
-
-  const txStatus = useTxStatus({
-    accountId: accountId ?? '',
-    txHash: txId,
-    onTxStatusConfirmed: handleTxConfirmed,
-  })
-
-  const { data: maybeSafeTx } = useSafeTxQuery({
-    maybeSafeTxHash: txId ?? undefined,
-    accountId,
-  })
-
-  const txLink = useMemo(
-    () =>
-      getTxLink({
-        txId,
-        defaultExplorerBaseUrl: tcyAsset?.explorerTxLink ?? '',
-        accountId,
-        maybeSafeTx,
-        stepSource: SwapperName.Thorchain,
-      }),
-    [accountId, maybeSafeTx, tcyAsset?.explorerTxLink, txId],
-  )
-
-  const handleViewTransaction = useCallback(() => {
-    if (txLink) window.open(txLink, '_blank')
-  }, [txLink])
-
-  const handleGoBack = useCallback(() => {
-    navigate(TCYStakeRoute.Input)
-  }, [navigate])
-
-  const renderStatus = () => {
-    if (!tcyAsset) return null
-
-    if (maybeSafeTx?.isQueuedSafeTx) {
-      return (
-        <TransactionStatusDisplay
-          isLoading
-          title={translate('common.safeProposalQueued', {
-            currentConfirmations: maybeSafeTx?.transaction?.confirmations?.length,
-            confirmationsRequired: maybeSafeTx?.transaction?.confirmationsRequired,
-          })}
-          subtitle={translate('TCY.stakePending', {
-            amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-            symbol: tcyAsset.symbol,
-          })}
-          primaryButtonText={translate('trade.viewTransaction')}
-          onPrimaryClick={handleViewTransaction}
-        />
-      )
-    }
-
-    if (maybeSafeTx?.isExecutedSafeTx && maybeSafeTx?.transaction?.transactionHash) {
-      setStakeTxid(maybeSafeTx.transaction.transactionHash)
-    }
-
-    switch (txStatus) {
-      case undefined:
-      case TxStatus.Pending:
-        return (
-          <TransactionStatusDisplay
-            isLoading
-            title={translate('pools.waitingForConfirmation')}
-            subtitle={translate('TCY.stakeStatus.pendingSubtitle', {
-              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-              symbol: tcyAsset.symbol,
-            })}
-            primaryButtonText={translate('TCY.stakeStatus.viewTransaction')}
-            onPrimaryClick={handleViewTransaction}
-          />
-        )
-      case TxStatus.Confirmed:
-        return (
-          <TransactionStatusDisplay
-            icon={CheckCircleIcon}
-            iconColor='green.500'
-            title={translate('TCY.stakeStatus.successTitle')}
-            subtitle={translate('TCY.stakeStatus.successSubtitle', {
-              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-              symbol: tcyAsset.symbol,
-            })}
-            secondaryButtonText={translate('TCY.stakeStatus.viewTransaction')}
-            onSecondaryClick={handleViewTransaction}
-            primaryButtonText={translate('TCY.stakeStatus.goBack')}
-            onPrimaryClick={handleGoBack}
-          />
-        )
-      case TxStatus.Failed:
-        return (
-          <TransactionStatusDisplay
-            icon={WarningTwoIcon}
-            iconColor='red.500'
-            title={translate('TCY.stakeStatus.failedTitle')}
-            subtitle={translate('TCY.stakeStatus.failedSubtitle')}
-            primaryButtonText={translate('TCY.stakeStatus.goBack')}
-            onPrimaryClick={handleGoBack}
-          />
-        )
-      default:
-        return null
-    }
+  if (!formValues.amountCryptoPrecision || !formValues.accountId) {
+    return null
   }
-  return <SlideTransition>{renderStatus()}</SlideTransition>
+
+  return (
+    <ReusableStatus
+      txId={txId}
+      setTxId={setStakeTxid}
+      onTxConfirmed={handleTxConfirmed}
+      initialRoute={TCYStakeRoute.Input}
+      translationPrefix='stake'
+      accountId={formValues.accountId}
+      amountCryptoPrecision={formValues.amountCryptoPrecision}
+      isDialog
+      headerText={translate('TCY.stakeConfirm.confirmTitle')}
+    />
+  )
 }

--- a/src/pages/TCY/components/Unstake/UnstakeStatus.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeStatus.tsx
@@ -1,23 +1,13 @@
-import { CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
-import { tcyAssetId } from '@shapeshiftoss/caip'
-import { SwapperName } from '@shapeshiftoss/swapper'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useMemo } from 'react'
 import { useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 import { useNavigate } from 'react-router'
 
 import { TCYUnstakeRoute } from '../../types'
+import { ReusableStatus } from '../ReusableStatus'
 import type { UnstakeFormValues } from './Unstake'
 
-import { SlideTransition } from '@/components/SlideTransition'
-import { TransactionStatusDisplay } from '@/components/TransactionStatusDisplay/TransactionStatusDisplay'
-import { useSafeTxQuery } from '@/hooks/queries/useSafeTx'
-import { useTxStatus } from '@/hooks/useTxStatus/useTxStatus'
-import { bnOrZero } from '@/lib/bignumber/bignumber'
-import { getTxLink } from '@/lib/getTxLink'
-import { selectAssetById } from '@/state/slices/selectors'
-import { useAppSelector } from '@/state/store'
+import { DialogBackButton } from '@/components/Modal/components/DialogBackButton'
 
 type UnstakeStatusProps = {
   txId: string
@@ -32,111 +22,23 @@ export const UnstakeStatus: React.FC<UnstakeStatusProps> = ({
 }) => {
   const translate = useTranslate()
   const navigate = useNavigate()
-  const tcyAsset = useAppSelector(state => selectAssetById(state, tcyAssetId))
+  const formValues = useWatch<UnstakeFormValues>()
 
-  const { amountCryptoPrecision, accountId } = useWatch<UnstakeFormValues>()
-
-  const txStatus = useTxStatus({
-    accountId: accountId ?? '',
-    txHash: txId,
-    onTxStatusConfirmed: handleTxConfirmed,
-  })
-
-  const { data: maybeSafeTx } = useSafeTxQuery({
-    maybeSafeTxHash: txId ?? undefined,
-    accountId,
-  })
-
-  const txLink = useMemo(
-    () =>
-      getTxLink({
-        txId,
-        defaultExplorerBaseUrl: tcyAsset?.explorerTxLink ?? '',
-        accountId,
-        maybeSafeTx,
-        stepSource: SwapperName.Thorchain,
-      }),
-    [accountId, maybeSafeTx, tcyAsset?.explorerTxLink, txId],
-  )
-
-  const handleViewTransaction = useCallback(() => {
-    if (txLink) window.open(txLink, '_blank')
-  }, [txLink])
-
-  const handleGoBack = useCallback(() => {
-    navigate(TCYUnstakeRoute.Input)
-  }, [navigate])
-
-  const renderStatus = () => {
-    if (!tcyAsset) return null
-
-    if (maybeSafeTx?.isQueuedSafeTx) {
-      return (
-        <TransactionStatusDisplay
-          isLoading
-          title={translate('common.safeProposalQueued', {
-            currentConfirmations: maybeSafeTx?.transaction?.confirmations?.length,
-            confirmationsRequired: maybeSafeTx?.transaction?.confirmationsRequired,
-          })}
-          subtitle={translate('TCY.unstakePending', {
-            amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-            symbol: tcyAsset.symbol,
-          })}
-          primaryButtonText={translate('trade.viewTransaction')}
-          onPrimaryClick={handleViewTransaction}
-        />
-      )
-    }
-
-    if (maybeSafeTx?.isExecutedSafeTx && maybeSafeTx?.transaction?.transactionHash) {
-      setUnstakeTxid(maybeSafeTx.transaction.transactionHash)
-    }
-
-    switch (txStatus) {
-      case undefined:
-      case TxStatus.Pending:
-        return (
-          <TransactionStatusDisplay
-            isLoading
-            title={translate('pools.waitingForConfirmation')}
-            subtitle={translate('TCY.unstakeStatus.pendingSubtitle', {
-              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-              symbol: tcyAsset.symbol,
-            })}
-            primaryButtonText={translate('trade.viewTransaction')}
-            onPrimaryClick={handleViewTransaction}
-          />
-        )
-      case TxStatus.Confirmed:
-        return (
-          <TransactionStatusDisplay
-            icon={CheckCircleIcon}
-            iconColor='green.500'
-            title={translate('TCY.unstakeStatus.successTitle')}
-            subtitle={translate('TCY.unstakeStatus.successSubtitle', {
-              amount: bnOrZero(amountCryptoPrecision).toFixed(8),
-              symbol: tcyAsset.symbol,
-            })}
-            secondaryButtonText={translate('trade.viewTransaction')}
-            onSecondaryClick={handleViewTransaction}
-            primaryButtonText={translate('TCY.unstakeStatus.goBack')}
-            onPrimaryClick={handleGoBack}
-          />
-        )
-      case TxStatus.Failed:
-        return (
-          <TransactionStatusDisplay
-            icon={WarningTwoIcon}
-            iconColor='red.500'
-            title={translate('TCY.unstakeStatus.failedTitle')}
-            subtitle={translate('TCY.unstakeStatus.failedSubtitle')}
-            primaryButtonText={translate('TCY.unstakeStatus.goBack')}
-            onPrimaryClick={handleGoBack}
-          />
-        )
-      default:
-        return null
-    }
+  if (!formValues.amountCryptoPrecision || !formValues.accountId) {
+    return null
   }
-  return <SlideTransition>{renderStatus()}</SlideTransition>
+
+  return (
+    <ReusableStatus
+      txId={txId}
+      setTxId={setUnstakeTxid}
+      onTxConfirmed={handleTxConfirmed}
+      initialRoute={TCYUnstakeRoute.Input}
+      translationPrefix='unstake'
+      accountId={formValues.accountId}
+      amountCryptoPrecision={formValues.amountCryptoPrecision}
+      headerText={translate('TCY.unstakeConfirm.confirmTitle')}
+      isDialog
+    />
+  )
 }

--- a/src/pages/TCY/components/Unstake/UnstakeStatus.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeStatus.tsx
@@ -28,11 +28,12 @@ export const UnstakeStatus: React.FC<UnstakeStatusProps> = ({
       txId={txId}
       setTxId={setUnstakeTxid}
       onTxConfirmed={handleTxConfirmed}
-      initialRoute={TCYUnstakeRoute.Input}
       translationPrefix='unstake'
       accountId={formValues.accountId}
       amountCryptoPrecision={formValues.amountCryptoPrecision}
       headerText={translate('TCY.unstakeConfirm.confirmTitle')}
+      initialRoute={TCYUnstakeRoute.Input}
+      displayGoBack
       isDialog
     />
   )

--- a/src/pages/TCY/components/Unstake/UnstakeStatus.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeStatus.tsx
@@ -1,13 +1,9 @@
-import { useCallback, useMemo } from 'react'
 import { useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
-import { useNavigate } from 'react-router'
 
 import { TCYUnstakeRoute } from '../../types'
 import { ReusableStatus } from '../ReusableStatus'
 import type { UnstakeFormValues } from './Unstake'
-
-import { DialogBackButton } from '@/components/Modal/components/DialogBackButton'
 
 type UnstakeStatusProps = {
   txId: string
@@ -21,7 +17,6 @@ export const UnstakeStatus: React.FC<UnstakeStatusProps> = ({
   onTxConfirmed: handleTxConfirmed,
 }) => {
   const translate = useTranslate()
-  const navigate = useNavigate()
   const formValues = useWatch<UnstakeFormValues>()
 
   if (!formValues.amountCryptoPrecision || !formValues.accountId) {


### PR DESCRIPTION
## Description

See this component from @0xApotheosis in https://github.com/shapeshift/web/pull/9462#discussion_r2073100404:

> This guy feels like it should become a generic component. We have a very similar src/pages/TCY/components/Stake/StakeStatus.tsx, and an also quite similar src/pages/TCY/components/Claim/ClaimStatus.tsx.

This does precisely that, but also:

- Adds missing dialog and dialog header for stake, unstake and claim status screens
- Adds missing "Go back" for stake and unstake
- Remove "Go back" for status (can't go back since once you claim a given claim, that's it)



## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, components abstraction "only"

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go through the status flow for all components and confirm we're still looking gucci

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/5f88c52e-2196-4ec7-8331-2420e362a7f7

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
