### PR TITLE
fix: handle positive price impact

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
@@ -67,7 +67,7 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
   const lastHopBuyAsset = useAppSelector(selectLastHopBuyAsset)
   const confirmedTradeExecutionState = useAppSelector(selectConfirmedTradeExecutionState)
   const activeQuote = useAppSelector(selectActiveQuote)
-  const { isModeratePriceImpact, priceImpactPercentage } = usePriceImpact(activeQuote)
+  const { isModeratePriceImpact, priceImpactPercentageAbsolute } = usePriceImpact(activeQuote)
   const firstHopMetadata = useSelectorWithArgs(selectHopExecutionMetadata, {
     tradeId: activeQuote?.id ?? '',
     hopIndex: 0,
@@ -249,7 +249,7 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
     <>
       <WarningAcknowledgement
         message={translate('warningAcknowledgement.highSlippageTrade', {
-          slippagePercentage: bnOrZero(priceImpactPercentage).toFixed(2).toString(),
+          slippagePercentage: bnOrZero(priceImpactPercentageAbsolute).toFixed(2).toString(),
         })}
         onAcknowledge={handleSubmit}
         shouldShowAcknowledgement={shouldShowWarningAcknowledgement}

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/TradeConfirmSummary.tsx
@@ -56,7 +56,7 @@ export const TradeConfirmSummary = () => {
   const secondHopNetworkFeeCryptoBaseUnit = useAppSelector(selectSecondHopNetworkFeeCryptoBaseUnit)
   const tradeQuoteFirstHop = useAppSelector(selectFirstHop)
   const translate = useTranslate()
-  const { priceImpactPercentage } = usePriceImpact(activeQuote)
+  const { priceImpactPercentageAbsolute } = usePriceImpact(activeQuote)
   const { isLoading } = useIsApprovalInitiallyNeeded()
   const receiveAddress = activeQuote?.receiveAddress
   const rate = tradeQuoteFirstHop?.rate
@@ -157,7 +157,9 @@ export const TradeConfirmSummary = () => {
           hasIntermediaryTransactionOutputs={hasIntermediaryTransactionOutputs}
           intermediaryTransactionOutputs={intermediaryTransactionOutputs}
         />
-        {priceImpactPercentage && <PriceImpact priceImpactPercentage={priceImpactPercentage} />}
+        {priceImpactPercentageAbsolute && (
+          <PriceImpact priceImpactPercentage={priceImpactPercentageAbsolute} />
+        )}
         <Divider />
         <RecipientAddressRow
           explorerAddressLink={sellAsset.explorerAddressLink}

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -105,7 +105,7 @@ export const ConfirmSummary = ({
     selectTradeQuoteAffiliateFeeAfterDiscountUserCurrency,
   )
 
-  const { priceImpactPercentage } = usePriceImpact(activeQuote)
+  const { priceImpactPercentageAbsolute } = usePriceImpact(activeQuote)
 
   const { data: _isSmartContractReceiveAddress, isLoading: isReceiveAddressByteCodeLoading } =
     useIsSmartContractAddress(receiveAddress ?? '', buyAsset.chainId)
@@ -330,14 +330,16 @@ export const ConfirmSummary = ({
           intermediaryTransactionOutputs={intermediaryTransactionOutputs}
         />
 
-        {priceImpactPercentage && <PriceImpact priceImpactPercentage={priceImpactPercentage} />}
+        {priceImpactPercentageAbsolute && (
+          <PriceImpact priceImpactPercentage={priceImpactPercentageAbsolute} />
+        )}
       </>
     )
   }, [
     buyAmountAfterFeesCryptoPrecision,
     buyAsset.symbol,
     isLoading,
-    priceImpactPercentage,
+    priceImpactPercentageAbsolute,
     slippagePercentageDecimal,
     tradeQuoteStep?.intermediaryTransactionOutputs,
     tradeQuoteStep?.source,

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteContent.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteContent.tsx
@@ -44,8 +44,12 @@ export const TradeQuoteContent = ({
   tradeQuote,
 }: TradeQuoteContentProps) => {
   const translate = useTranslate()
-  const { isModeratePriceImpact, isHighPriceImpact, priceImpactPercentage } =
-    usePriceImpact(tradeQuote)
+  const {
+    isModeratePriceImpact,
+    isHighPriceImpact,
+    priceImpactPercentageAbsolute,
+    isPositivePriceImpact,
+  } = usePriceImpact(tradeQuote)
 
   const {
     number: { toPercent },
@@ -76,21 +80,23 @@ export const TradeQuoteContent = ({
         return 'text.error'
       case isModeratePriceImpact:
         return 'text.warning'
+      case isPositivePriceImpact:
+        return 'text.success'
       default:
         return undefined
     }
-  }, [isHighPriceImpact, isModeratePriceImpact])
+  }, [isHighPriceImpact, isModeratePriceImpact, isPositivePriceImpact])
 
   const priceImpactDecimalPercentage = useMemo(
-    () => priceImpactPercentage?.div(100),
-    [priceImpactPercentage],
+    () => priceImpactPercentageAbsolute?.div(100),
+    [priceImpactPercentageAbsolute],
   )
 
   const priceImpactTooltipText = useMemo(() => {
-    if (!priceImpactPercentage) return
+    if (!priceImpactPercentageAbsolute) return
 
     const defaultText = translate('trade.tooltip.priceImpactLabel', {
-      priceImpactPercentage: priceImpactPercentage.toFixed(2),
+      priceImpactPercentage: priceImpactPercentageAbsolute.toFixed(2),
     })
     switch (true) {
       case isHighPriceImpact:
@@ -99,7 +105,7 @@ export const TradeQuoteContent = ({
       default:
         return defaultText
     }
-  }, [isHighPriceImpact, isModeratePriceImpact, priceImpactPercentage, translate])
+  }, [isHighPriceImpact, isModeratePriceImpact, priceImpactPercentageAbsolute, translate])
 
   const eta = useMemo(() => {
     if (totalEstimatedExecutionTimeMs === undefined) return null


### PR DESCRIPTION
## Description

Positive price impact is a good thing - let's communicate that.

## Issue (if applicable)

N/A, a quick fix of something that was bugging me.

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

We show positive price impact (in the quotes list on the right) in green:

<img width="772" alt="Screenshot 2025-05-06 at 12 25 01 pm" src="https://github.com/user-attachments/assets/3041c041-f46f-4c37-97d1-5be66227cf9f" />

We show negative price impact in red/yellow (depending on severity), as we currently do:

<img width="779" alt="Screenshot 2025-05-06 at 12 24 53 pm" src="https://github.com/user-attachments/assets/cf8d52dd-fe2e-43db-8c70-482d68047294" />

Ensure all other price impact UI shows no regressions (trade confirm footer/summary etc).

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See testing section above.