### PR TITLE
fix: thorfi UTXO addies bits

### DIFF
--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -229,7 +229,7 @@ export const getThorfiUtxoFromAddresses = async ({
       getThorchainLpUtxoFromAddresses({ accountId, assetId }),
     ])
 
-    if (!saverPosition && !lendingPosition)
+    if (!saverPosition && !lendingPosition && !lpUtxoFromAddresses.length)
       throw new Error(`No position found for assetId: ${assetId}, defaulting to 0 account_index`)
 
     // Unique addies set, to avoid view-layer dupes since addies are most likely the same over savers and lending

--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -206,7 +206,7 @@ export const getThorchainFromAddress = async ({
   }
 }
 
-// Gets all the unique UTXO positions for a given position across all THORFi
+// Gets all unique UTXO addresses for a given accountId across all THORFi
 export const getThorfiUtxoFromAddresses = async ({
   accountId,
   assetId,

--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -10,7 +10,12 @@ import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import type { MidgardActionsResponse, ThornodeStatusResponse } from '@shapeshiftoss/swapper'
 import { thorService } from '@shapeshiftoss/swapper'
-import type { AccountMetadata, Asset, KnownChainIds } from '@shapeshiftoss/types'
+import type {
+  AccountMetadata,
+  AccountMetadataById,
+  Asset,
+  KnownChainIds,
+} from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import axios from 'axios'
 import dayjs from 'dayjs'
@@ -19,7 +24,7 @@ import memoize from 'lodash/memoize'
 import { getSupportedEvmChainIds } from '../evm'
 import { assertGetUtxoChainAdapter, isUtxoAccountId, isUtxoChainId } from '../utxo'
 import { THOR_PRECISION } from './constants'
-import type { getThorchainLendingPosition } from './lending'
+import { getThorchainLendingPosition } from './lending'
 
 import { getConfig } from '@/config'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
@@ -27,7 +32,8 @@ import type { BigNumber, BN } from '@/lib/bignumber/bignumber'
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { poll } from '@/lib/poll/poll'
 import type { getThorchainLpPosition } from '@/pages/ThorChainLP/queries/queries'
-import type { getThorchainSaversPosition } from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
+import { getThorchainLpUtxoFromAddresses } from '@/pages/ThorChainLP/queries/queries'
+import { getThorchainSaversPosition } from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 
 export const getThorchainTransactionStatus = async ({
   txHash,
@@ -239,4 +245,63 @@ export const getThorchainTransactionType = (chainId: ChainId) => {
   }
 
   throw new Error(`Unsupported ChainId ${chainId}`)
+}
+
+export const getThorfiFromAddresses = async ({
+  accountId,
+  assetId,
+  wallet,
+  accountMetadata,
+}: {
+  accountId: AccountId
+  assetId: AssetId
+  wallet: HDWallet
+  accountMetadata: AccountMetadataById[AccountId]
+}): Promise<string[]> => {
+  const { chainId } = fromAccountId(accountId)
+
+  try {
+    const [saverPosition, lendingPosition, lpUtxoFromAddresses] = await Promise.all([
+      getThorchainSaversPosition({ accountId, assetId }),
+      getThorchainLendingPosition({ accountId, assetId }),
+      getThorchainLpUtxoFromAddresses({ accountId, assetId }),
+    ])
+
+    if (!saverPosition && !lendingPosition)
+      throw new Error(`No position found for assetId: ${assetId}, defaulting to 0 account_index`)
+
+    // Unique addies set, to avoid view-layer dupes since addies are most likely the same over savers and lending
+    const addresses = new Set<string>()
+
+    if (saverPosition?.asset_address) {
+      addresses.add(saverPosition.asset_address)
+    }
+
+    if (lendingPosition?.owner) {
+      addresses.add(lendingPosition.owner)
+    }
+
+    lpUtxoFromAddresses.forEach(address => {
+      addresses.add(address)
+    })
+
+    return Array.from(addresses)
+  } catch {
+    const chainAdapter = getChainAdapterManager().get(chainId)
+
+    if (!accountMetadata) throw new Error('No account metadata found')
+    if (!chainAdapter) throw new Error(`No chain adapter found for chainId: ${chainId}`)
+
+    const { accountType, bip44Params } = accountMetadata
+
+    const firstReceiveAddress = await chainAdapter.getAddress({
+      wallet,
+      accountNumber: bip44Params.accountNumber,
+      accountType,
+      addressIndex: 0,
+      pubKey: isLedger(wallet) && accountId ? fromAccountId(accountId).account : undefined,
+    })
+
+    return [firstReceiveAddress]
+  }
 }

--- a/src/pages/TCY/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/TCY/components/Claim/ClaimConfirm.tsx
@@ -1,6 +1,6 @@
 import { Alert, AlertIcon, ModalCloseButton } from '@chakra-ui/react'
 import { fromAssetId, tcyAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
-import { skipToken, useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation } from '@tanstack/react-query'
 import { useCallback, useMemo, useState } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
@@ -15,17 +15,11 @@ import { RawText } from '@/components/Text'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { bn } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
-import { getThorchainFromAddress } from '@/lib/utils/thorchain'
 import { THOR_PRECISION } from '@/lib/utils/thorchain/constants'
 import { useSendThorTx } from '@/lib/utils/thorchain/hooks/useSendThorTx'
 import { isUtxoChainId } from '@/lib/utils/utxo'
 import { useIsSweepNeededQuery } from '@/pages/Lending/hooks/useIsSweepNeededQuery'
-import { getThorchainSaversPosition } from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
-import {
-  selectAssetById,
-  selectMarketDataByAssetIdUserCurrency,
-  selectPortfolioAccountMetadataByAccountId,
-} from '@/state/slices/selectors'
+import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
 type ClaimConfirmProps = {
@@ -43,7 +37,7 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
   const navigate = useNavigate()
   const translate = useTranslate()
   const {
-    state: { wallet, isConnected },
+    state: { isConnected },
   } = useWallet()
   const [runeAddress, setRuneAddress] = useState<string>()
   const methods = useForm<AddressFormValues>()
@@ -62,26 +56,6 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
     return bn(amountCryptoPrecision).times(tcyMarketData.price).toFixed(2)
   }, [tcyMarketData.price, amountCryptoPrecision])
 
-  const accountFilter = useMemo(() => ({ accountId: claim.accountId }), [claim.accountId])
-  const accountMetadata = useAppSelector(state =>
-    selectPortfolioAccountMetadataByAccountId(state, accountFilter),
-  )
-
-  const { data: fromAddress } = useQuery({
-    queryKey: ['thorchainFromAddress', claim.accountId, claim.assetId],
-    queryFn:
-      wallet && accountMetadata
-        ? () =>
-            getThorchainFromAddress({
-              accountId: claim.accountId,
-              assetId: claim.assetId,
-              getPosition: getThorchainSaversPosition,
-              accountMetadata,
-              wallet,
-            })
-        : skipToken,
-  })
-
   const {
     dustAmountCryptoBaseUnit,
     isEstimatedFeesDataLoading,
@@ -92,7 +66,7 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
     action: 'claimTcy',
     amountCryptoBaseUnit: '0',
     assetId: claim.assetId,
-    fromAddress: fromAddress ?? null,
+    fromAddress: claim.l1_address,
     memo: runeAddress ? `tcy:${runeAddress}` : '',
     enableEstimateFees: Boolean(runeAddress && claim.accountId),
   })
@@ -100,17 +74,17 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
   const isSweepNeededArgs = useMemo(
     () => ({
       assetId: claim.assetId,
-      address: fromAddress ?? '',
+      address: claim.l1_address ?? '',
       amountCryptoBaseUnit: dustAmountCryptoBaseUnit,
       txFeeCryptoBaseUnit: estimatedFeesData?.txFeeCryptoBaseUnit,
       enabled: Boolean(
         isUtxoChainId(fromAssetId(claim.assetId).chainId) &&
-          fromAddress &&
+          claim.l1_address &&
           estimatedFeesData &&
           runeAddress,
       ),
     }),
-    [claim.assetId, fromAddress, estimatedFeesData, runeAddress, dustAmountCryptoBaseUnit],
+    [claim.assetId, claim.l1_address, estimatedFeesData, runeAddress, dustAmountCryptoBaseUnit],
   )
 
   const { data: isSweepNeeded, isFetching: isSweepNeededFeching } =

--- a/src/pages/TCY/components/Claim/ClaimRoutes.tsx
+++ b/src/pages/TCY/components/Claim/ClaimRoutes.tsx
@@ -90,7 +90,8 @@ const ClaimRoutes = ({
     )
   }, [claim, txId, setClaimTxid, handleTxConfirmed])
 
-  const handleSweepSeen = useCallback(() => {
+  const handleSweepSeen = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: ['isSweepNeeded'] })
     navigate(TCYClaimRoute.Confirm)
   }, [navigate])
 

--- a/src/pages/TCY/components/Claim/ClaimRoutes.tsx
+++ b/src/pages/TCY/components/Claim/ClaimRoutes.tsx
@@ -93,7 +93,7 @@ const ClaimRoutes = ({
   const handleSweepSeen = useCallback(async () => {
     await queryClient.invalidateQueries({ queryKey: ['isSweepNeeded'] })
     navigate(TCYClaimRoute.Confirm)
-  }, [navigate])
+  }, [navigate, queryClient])
 
   const handleSweepBack = useCallback(() => {
     navigate(-1)

--- a/src/pages/TCY/components/Claim/ClaimSweep.tsx
+++ b/src/pages/TCY/components/Claim/ClaimSweep.tsx
@@ -1,18 +1,11 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
 import { CardBody, CardHeader, Flex, IconButton } from '@chakra-ui/react'
-import { skipToken, useQuery } from '@tanstack/react-query'
-import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
 import type { Claim } from './types'
 
 import { SlideTransition } from '@/components/SlideTransition'
 import { Sweep } from '@/components/Sweep'
-import { useWallet } from '@/hooks/useWallet/useWallet'
-import { getThorchainFromAddress } from '@/lib/utils/thorchain'
-import { getThorchainSaversPosition } from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
-import { selectPortfolioAccountMetadataByAccountId } from '@/state/slices/selectors'
-import { useAppSelector } from '@/state/store'
 
 type ClaimSweepProps = {
   claim: Claim
@@ -28,29 +21,7 @@ export const ClaimSweep: React.FC<ClaimSweepProps> = ({
   onSweepSeen: handleSweepSeen,
 }) => {
   const translate = useTranslate()
-  const {
-    state: { wallet },
-  } = useWallet()
 
-  const accountFilter = useMemo(() => ({ accountId: claim.accountId }), [claim.accountId])
-  const accountMetadata = useAppSelector(state =>
-    selectPortfolioAccountMetadataByAccountId(state, accountFilter),
-  )
-
-  const { data: fromAddress } = useQuery({
-    queryKey: ['thorchainFromAddress', claim.accountId, claim.assetId],
-    queryFn:
-      wallet && accountMetadata
-        ? () =>
-            getThorchainFromAddress({
-              accountId: claim.accountId,
-              assetId: claim.assetId,
-              getPosition: getThorchainSaversPosition,
-              accountMetadata,
-              wallet,
-            })
-        : skipToken,
-  })
   return (
     <SlideTransition>
       <CardHeader display='flex' alignItems='center' gap={2}>
@@ -63,7 +34,7 @@ export const ClaimSweep: React.FC<ClaimSweepProps> = ({
       <CardBody pt={0}>
         <Sweep
           assetId={claim.assetId}
-          fromAddress={fromAddress ?? null}
+          fromAddress={claim.l1_address ?? null}
           accountId={claim.accountId}
           onBack={handleBack}
           onSweepSeen={handleSweepSeen}

--- a/src/pages/TCY/queries/useTcyClaims.tsx
+++ b/src/pages/TCY/queries/useTcyClaims.tsx
@@ -1,5 +1,5 @@
 import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
-import { poolAssetIdToAssetId } from '@shapeshiftoss/swapper'
+import { isRune, poolAssetIdToAssetId } from '@shapeshiftoss/swapper'
 import { isUtxoChainId } from '@shapeshiftoss/utils'
 import { useSuspenseQueries } from '@tanstack/react-query'
 import axios from 'axios'
@@ -9,19 +9,24 @@ import type { Claim, TcyClaimer } from '../components/Claim/types'
 
 import { getConfig } from '@/config'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
+import { useWallet } from '@/hooks/useWallet/useWallet'
 import { isSome } from '@/lib/utils'
+import { getThorfiFromAddresses } from '@/lib/utils/thorchain'
+import { isSupportedThorchainSaversAssetId } from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import {
-  getThorchainSaversPosition,
-  isSupportedThorchainSaversAssetId,
-} from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
-import { selectAccountIdsByAccountNumberAndChainId } from '@/state/slices/selectors'
-import { useAppSelector } from '@/state/store'
+  selectAccountIdsByAccountNumberAndChainId,
+  selectPortfolioAccountMetadataByAccountId,
+} from '@/state/slices/selectors'
+import { store, useAppSelector } from '@/state/store'
 
 export const useTCYClaims = (accountNumber: number) => {
+  const {
+    state: { isConnected, wallet },
+  } = useWallet()
+
   const accountIdsByAccountNumberAndChainId = useAppSelector(
     selectAccountIdsByAccountNumberAndChainId,
   )
-
   const accountIds = useMemo(
     () =>
       Object.values(accountIdsByAccountNumberAndChainId[accountNumber] || {})
@@ -32,33 +37,55 @@ export const useTCYClaims = (accountNumber: number) => {
 
   return useSuspenseQueries({
     queries: accountIds.map(accountId => ({
-      queryKey: ['tcy-claims', accountId],
+      queryKey: ['tcy-claims', accountId, isConnected],
       queryFn: async (): Promise<Claim[]> => {
-        const activeAddress = await (async () => {
-          // UTXO-based chains are the odd ones, for all address-based, we can simply use the `account` caip-10 part
-          if (!isUtxoChainId(fromAccountId(accountId).chainId))
-            return fromAccountId(accountId).account
+        if (!isConnected) return []
 
-          const chainId = fromAccountId(accountId).chainId
-          const assetId = getChainAdapterManager().get(chainId)?.getFeeAssetId()
+        const activeAddresses = (
+          await (() => {
+            const chainId = fromAccountId(accountId).chainId
+            const assetId = getChainAdapterManager().get(chainId)?.getFeeAssetId()
+            if (!assetId) return []
+            if (!isSupportedThorchainSaversAssetId(assetId)) return []
+            if (isRune(assetId)) return []
 
-          if (!assetId) return
-          if (!isSupportedThorchainSaversAssetId(assetId)) return
+            // UTXO-based chains are the odd ones, for all address-based, we can simply use the `account` caip-10 part
+            if (!isUtxoChainId(fromAccountId(accountId).chainId))
+              return [fromAccountId(accountId).account]
 
-          const position = await getThorchainSaversPosition({ accountId, assetId })
+            const accountMetadata = selectPortfolioAccountMetadataByAccountId(store.getState(), {
+              accountId,
+            })
+            if (!accountMetadata) return []
+            if (!wallet) return []
 
-          if (!position) return
+            // Introspects THORChain savers to get the active address for a given xpub AccountId
+            // Defaults to 0 if none found
+            // We do not duplicate this for LP and Lending, as those users should all be on a 0th account_index, only savers is the exception
+            // as some users may have historical non-zero account_index active address
+            return getThorfiFromAddresses({
+              accountId,
+              assetId,
+              accountMetadata,
+              wallet,
+            })
+          })()
+        ).filter(isSome)
 
-          return position.asset_address
-        })()
-
-        if (!activeAddress) return []
+        if (!activeAddresses) return []
 
         try {
-          const { data } = await axios.get<{ tcy_claimer: TcyClaimer[] }>(
-            `${getConfig().VITE_THORCHAIN_NODE_URL}/thorchain/tcy_claimer/${activeAddress}`,
+          const tcyClaimers = await Promise.all(
+            activeAddresses.map(address =>
+              axios.get<{ tcy_claimer: TcyClaimer[] }>(
+                `${getConfig().VITE_THORCHAIN_NODE_URL}/thorchain/tcy_claimer/${address}`,
+              ),
+            ),
           )
-          return data.tcy_claimer
+
+          return tcyClaimers
+            .map(response => response.data.tcy_claimer)
+            .flat()
             .filter(claimer => {
               const assetId = poolAssetIdToAssetId(claimer.asset)
               if (!assetId) return false

--- a/src/pages/TCY/queries/useTcyClaims.tsx
+++ b/src/pages/TCY/queries/useTcyClaims.tsx
@@ -11,7 +11,7 @@ import { getConfig } from '@/config'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { isSome } from '@/lib/utils'
-import { getThorfiFromAddresses } from '@/lib/utils/thorchain'
+import { getThorfiUtxoFromAddresses } from '@/lib/utils/thorchain'
 import { isSupportedThorchainSaversAssetId } from '@/state/slices/opportunitiesSlice/resolvers/thorchainsavers/utils'
 import {
   selectAccountIdsByAccountNumberAndChainId,
@@ -63,7 +63,7 @@ export const useTCYClaims = (accountNumber: number) => {
             // Defaults to 0 if none found
             // We do not duplicate this for LP and Lending, as those users should all be on a 0th account_index, only savers is the exception
             // as some users may have historical non-zero account_index active address
-            return getThorfiFromAddresses({
+            return getThorfiUtxoFromAddresses({
               accountId,
               assetId,
               accountMetadata,

--- a/src/pages/ThorChainLP/queries/queries.ts
+++ b/src/pages/ThorChainLP/queries/queries.ts
@@ -2,6 +2,7 @@ import { createQueryKeys } from '@lukemorales/query-key-factory'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import { assetIdToPoolAssetId } from '@shapeshiftoss/swapper'
+import { isSome } from '@shapeshiftoss/utils'
 import type { AxiosError } from 'axios'
 import axios from 'axios'
 import { getAddress, isAddress } from 'viem'
@@ -153,4 +154,28 @@ export const getThorchainLpPosition = async ({
     assetAddress: position.assetAddress,
     opportunityId,
   }
+}
+
+export const getThorchainLpUtxoFromAddresses = async ({
+  accountId,
+  assetId: poolAssetId,
+}: {
+  accountId: AccountId
+  assetId: AssetId
+}) => {
+  const { chainId } = fromAssetId(poolAssetId)
+
+  if (!isUtxoChainId(chainId)) throw new Error(`Not a UTXO chain: ${chainId}`)
+
+  const lpPositions = await queryClient.fetchQuery({
+    ...thorchainLp.liquidityProviderPosition({ accountId, assetId: poolAssetId }),
+    // @lukemorales/query-key-factory only returns queryFn and queryKey - all others will be ignored in the returned object
+    // Since this isn't a query per se but rather a fetching util deriving from multiple queries, we want data to be considered stale immediately
+    // Note however that the two underlying liquidityMember and liquidityMembers queries in this query *have* an Infinity staleTime themselves
+    staleTime: 0,
+  })
+
+  if (!lpPositions) return []
+
+  return lpPositions.map(position => position.assetAddress).filter(isSome)
 }


### PR DESCRIPTION
## Description

This PR fixes missing claims for TCY claims with UTXOs twofolds:

1. Uses `getThorchainFromAddress` instead of `getThorchainSaversPosition`. The former is a superset of the latter, which passing in either savers position getter (`getThorchainFromAddress`), or its lending or LP variant to find an active address.
Most importantly, the former defaults to 0th address in case of no active position found, which we should *not* need since we're only interested in active ones, but accidentally needed since we were only introspecting savers, not lending.
2. Adds lending position getter too. That, alongside defaulting to 0th account_index addies should ensure that all claims are detected

I'm unable to test this one at runtime, since this affects users which don't have savers, but have *only* liquidity in either/both of lending

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/9485

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Note, this doesn't affect Ledger only, it affects addresses which are not active in savers but only in lending

- If you have one of these, excellent, you can actually test e2e that you see your claim and are able to well, claim it
- Regardless of whether or not you do, the same claims should be displayed here as in develop (with potential additions, if you do have addresses with liquidity in lending but not savers)
- UTXO claims should still perform as before (assuming enough balance for dust + fees, since balance checks are not yet implemented still) - note @shapeshift/operations, since this has been tested in this PR (see Jams) not sure it's worth exhausting a UTXO claim for that matter
- There are no dupe UTXO positions


### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

### Claims list is sane against develop

https://jam.dev/c/a5b02e2d-f636-47ed-87df-bdab015a5920

### UTXO claims are happy

https://jam.dev/c/9fde5fe2-90f1-4b2e-9904-c9fee3ba9c6b

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
