### PR TITLE
fix: tcy properly controlled account dropdown

### DIFF
--- a/src/pages/TCY/components/TCYHeader.tsx
+++ b/src/pages/TCY/components/TCYHeader.tsx
@@ -1,6 +1,7 @@
 import { Flex, Heading } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { thorchainAssetId, thorchainChainId } from '@shapeshiftoss/caip'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useNavigate } from 'react-router-dom'
 
@@ -37,8 +38,11 @@ export const TCYHeader = ({ onAccountNumberChange }: TCYHeaderProps) => {
     selectAccountIdsByChainIdFilter(state, { chainId: thorchainChainId }),
   )
 
+  const [defaultAccountId, setDefaultAccountId] = useState<AccountId | undefined>(accountIds[0])
+
   const handleChange = useCallback(
     (accountId: string) => {
+      setDefaultAccountId(accountId)
       const accountNumber = selectAccountNumberByAccountId(store.getState(), { accountId })
       if (accountNumber === undefined) throw new Error('Account number not found')
       onAccountNumberChange(accountNumber)
@@ -55,14 +59,14 @@ export const TCYHeader = ({ onAccountNumberChange }: TCYHeaderProps) => {
 
         <InlineCopyButton value={''} />
         <AccountDropdown
-          defaultAccountId={accountIds[0]}
+          defaultAccountId={defaultAccountId}
           assetId={thorchainAssetId}
           onChange={handleChange}
           buttonProps={buttonProps}
         />
       </Flex>
     )
-  }, [accountIds, handleChange])
+  }, [accountIds, handleChange, defaultAccountId])
 
   return (
     <>


### PR DESCRIPTION
## Description

Fixes buggy account selection component not properly controlling `<AccountDropdown />` and only working once, but then resetting back to account 0.
Fixed by properly making it controlled, passing `defaultAccountId`.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted while testing

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Account selection works properly in TCY account dropdown, even after selecting multiple diff ROON accoonts in a roo

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/4027e0cf-b3b5-4e20-850a-264e19f26a6d


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
