### PR TITLE
fix: make tcy claim account selection work

### DIFF
--- a/src/pages/TCY/components/Claim/components/ClaimAddressInput.tsx
+++ b/src/pages/TCY/components/Claim/components/ClaimAddressInput.tsx
@@ -1,4 +1,5 @@
 import { Button, FormControl, FormHelperText, FormLabel, HStack, Input } from '@chakra-ui/react'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId, thorchainAssetId, thorchainChainId } from '@shapeshiftoss/caip'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useForm, useFormContext } from 'react-hook-form'
@@ -43,6 +44,8 @@ export const ClaimAddressInput = ({ onActiveAddressChange, address }: ClaimAddre
     selectAccountIdsByAssetId(state, { assetId: thorchainAssetId }),
   )
 
+  const [defaultAccountId, setDefaultAccountId] = useState<AccountId | undefined>(runeAccountIds[0])
+
   // Local controller in case consumers don't have a form context
   const _methods = useForm<AddressFormValues>({
     mode: 'onChange',
@@ -80,9 +83,10 @@ export const ClaimAddressInput = ({ onActiveAddressChange, address }: ClaimAddre
   const handleRuneAccountIdChange = useCallback(
     (accountId: string) => {
       const address = fromAccountId(accountId).account
+      setDefaultAccountId(accountId)
       onActiveAddressChange(address)
     },
-    [onActiveAddressChange],
+    [onActiveAddressChange, setDefaultAccountId],
   )
 
   const handleToggleCustomAddress = useCallback(() => {
@@ -151,6 +155,7 @@ export const ClaimAddressInput = ({ onActiveAddressChange, address }: ClaimAddre
           onChange={handleRuneAccountIdChange}
           boxProps={boxProps}
           buttonProps={buttonProps}
+          defaultAccountId={defaultAccountId}
         />
       </InlineCopyButton>
     )
@@ -162,6 +167,7 @@ export const ClaimAddressInput = ({ onActiveAddressChange, address }: ClaimAddre
     translate,
     validateRuneAddress,
     handleCustomAddressInputChange,
+    defaultAccountId,
   ])
 
   return (

--- a/src/pages/TCY/components/Claim/components/ClaimAddressInput.tsx
+++ b/src/pages/TCY/components/Claim/components/ClaimAddressInput.tsx
@@ -151,7 +151,6 @@ export const ClaimAddressInput = ({ onActiveAddressChange, address }: ClaimAddre
           onChange={handleRuneAccountIdChange}
           boxProps={boxProps}
           buttonProps={buttonProps}
-          defaultAccountId={address}
         />
       </InlineCopyButton>
     )


### PR DESCRIPTION
## Description

Fixes TCY claim account selection. 

The issue is caused by us passing an _address_ to the `defaultAccountId` property (this should be an _account ID_).

Because the `defaultAccountId` is always invalid, the `AccountDropdown` component internally resets to the first index account ID on any property change, resulting in an account dropdown that will always reset to index 0.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/9508

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

THORChain account selection for TCY claims.

## Testing

When multiple THORChain accounts are available they should be selectable.

<img width="374" alt="Screenshot 2025-05-08 at 2 32 44 pm" src="https://github.com/user-attachments/assets/c8cf4381-21a1-4cdb-b46c-e2569475e87c" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.