### PR TITLE
feat: 9480 setting icon

### DIFF
--- a/src/pages/Dashboard/components/DashboardHeader/DashboardHeaderTop.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader/DashboardHeaderTop.tsx
@@ -3,7 +3,7 @@ import type { ResponsiveValue } from '@chakra-ui/react'
 import { Button, Container, Flex, IconButton, useDisclosure } from '@chakra-ui/react'
 import type { Property } from 'csstype'
 import { memo, useCallback } from 'react'
-import { FiLogOut } from 'react-icons/fi'
+import { FiSettings } from 'react-icons/fi'
 import { IoEllipsisHorizontal, IoSwapVerticalSharp } from 'react-icons/io5'
 import { useTranslate } from 'react-polyglot'
 import { useNavigate } from 'react-router-dom'
@@ -24,7 +24,7 @@ const qrCodeIcon = <QRCodeIcon />
 const arrowUpIcon = <ArrowUpIcon />
 const arrowDownIcon = <ArrowDownIcon />
 const ioSwapVerticalSharpIcon = <IoSwapVerticalSharp />
-const moreIcon = isMobile ? <FiLogOut /> : <IoEllipsisHorizontal />
+const moreIcon = isMobile ? <FiSettings /> : <IoEllipsisHorizontal />
 
 const ButtonRowDisplay = { base: 'flex', md: 'none' }
 


### PR DESCRIPTION
## Description

Changed the mobile settings icon from a logout icon to a gear (⚙️) icon in the dashboard header. This change improves the UI by using a more intuitive and appropriate icon for the settings menu.

## Issue (if applicable)

closes #9480

## Risk

Low Risk - This is a simple UI change that only affects the icon displayed in the mobile view. No functionality changes were made, and the settings menu behavior remains the same.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?
None - This is a purely visual change to the UI.

## Testing

### Engineering

1. Open the application in mobile view
2. Verify that the settings icon in the dashboard header shows a gear (⚙️) icon instead of the previous logout icon
3. Click the icon to verify it still opens the settings menu as expected
4. Verify the desktop view still shows the ellipsis icon

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

