### PR TITLE
fix: remove start earning button when empty positions

### DIFF
--- a/src/components/StakingVaults/PositionTable.tsx
+++ b/src/components/StakingVaults/PositionTable.tsx
@@ -233,7 +233,7 @@ export const PositionTable: React.FC<PositionTableProps> = ({ chainId, searchQue
     return searchQuery ? (
       <SearchEmpty searchQuery={searchQuery} />
     ) : (
-      <ResultsEmpty ctaText='defi.startEarning' icon={emptyIcon} />
+      <ResultsEmpty icon={emptyIcon} />
     )
   }, [searchQuery])
 


### PR DESCRIPTION
## Description

This button is displayed but we don't have any route anymore to redirect the user too, this is a deadclick currently, removing the button but keeping the API to display a button so in the future we could use it for something else

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Found by polishing things, no tickets

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Use a brand new wallet empty of positions
- Go to the defi tab in wallet page
- No button anymore!
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="207" alt="image" src="https://github.com/user-attachments/assets/f14fc40f-fbca-4db5-bd3f-62db7f4a1d9b" />
