### PR TITLE
feat: lp deposit remove dupe disabled visual indicator

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1407,8 +1407,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     if (isChainHalted) return translate('common.chainHalted')
     if (isTradingActive === false) return translate('common.poolHalted')
     if (!walletSupportsOpportunity) return translate('common.unsupportedNetwork')
-    if (!isThorchainLpDepositEnabled || isThorchainLpDepositEnabledForPool === false)
-      return translate('common.poolDisabled')
+    if (!isThorchainLpDepositEnabled) return translate('common.poolDisabled')
+    if (isThorchainLpDepositEnabledForPool === false) return translate('pools.depositsDisabled')
     if (isSmartContractAccountAddress === true)
       return translate('trade.errors.smartContractWalletNotSupported')
     if (poolAsset && notEnoughPoolAssetError) return translate('common.insufficientFunds')
@@ -1611,13 +1611,6 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         {incompleteAlert}
         {maybeOpportunityNotSupportedExplainer}
         {maybeAlert}
-        {isThorchainLpDepositEnabledForPool === false ? (
-          <Alert status='error' variant='subtle' mx={-2} width='auto'>
-            <AlertIcon />
-            <AlertDescription>{translate('pools.depositsDisabled')}</AlertDescription>
-          </Alert>
-        ) : null}
-
         <ButtonWalletPredicate
           isValidWallet={Boolean(walletSupportsOpportunity)}
           mx={-2}


### PR DESCRIPTION
## Description

Does precisely what it says on the box, this is a duplicate visual indicator, as spotted by @kaladinlight 10x product review in https://github.com/shapeshift/web/pull/9537#issuecomment-2873313374:

> not blocking since it is conforming to previous behavior, but feels weird having the button be Pool Disabled for the deposit disabled check and then having the extra status error when it would/should be redundant if the button just said what it actually was disabled for.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Disabled pool says "Pool Disabled" in add liquidity button copy
- There is no redundant messaging

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

- this diff


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
