### PR TITLE
fix: add not available to price when we have no market data

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -197,7 +197,8 @@
     "installed": "Installed",
     "others": "Others",
     "hardwareWallets": "Hardware Wallets",
-    "dustAmount": "Dust Amount"
+    "dustAmount": "Dust Amount",
+    "marketDataUnavailable": "Market data is temporarily unavailable for %{asset}"
   },
   "consentBanner": {
     "body": "Our dApp uses anonymized click tracking to analyze performance and improve your experience. By using app.shapeshift.com, you agree to our tracking. Visit %{privateLink} if you don't want to be anonymously tracked. See our %{privacyPolicyLink} for more details.",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -198,7 +198,7 @@
     "others": "Others",
     "hardwareWallets": "Hardware Wallets",
     "dustAmount": "Dust Amount",
-    "marketDataUnavailable": "Market data is temporarily unavailable for %{asset}"
+    "marketDataUnavailable": "Market data is unavailable for %{asset}"
   },
   "consentBanner": {
     "body": "Our dApp uses anonymized click tracking to analyze performance and improve your experience. By using app.shapeshift.com, you agree to our tracking. Visit %{privateLink} if you don't want to be anonymously tracked. See our %{privacyPolicyLink} for more details.",

--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -86,8 +86,8 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
     selectCryptoHumanBalanceFilter(s, opportunitiesFilter),
   )
 
-  const renderPrice = useMemo(() => {
-    if (!marketData?.price)
+  const priceContent = useMemo(() => {
+    if (!marketData)
       return (
         <Flex>
           <Tooltip label={translate('common.marketDataUnavailable', { asset: asset?.name })}>
@@ -103,7 +103,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
         isNumericString={true}
       />
     )
-  }, [asset?.name, assetPrice, marketData?.price, translate])
+  }, [asset?.name, assetPrice, marketData, translate])
 
   return (
     <Card variant='dashboard'>
@@ -119,7 +119,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
             {asset?.symbol} {translate('assets.assetDetails.assetHeader.price')}
           </RawText>
           <Heading fontSize='4xl' lineHeight={1} mb={2}>
-            <Skeleton isLoaded={isLoaded}>{renderPrice}</Skeleton>
+            <Skeleton isLoaded={isLoaded}>{priceContent}</Skeleton>
           </Heading>
           <Skeleton isLoaded={isLoaded}>
             <Flex

--- a/src/components/Equity/Equity.tsx
+++ b/src/components/Equity/Equity.tsx
@@ -11,7 +11,7 @@ import {
   useColorModeValue,
 } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 
@@ -134,12 +134,6 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
       )
     return <Amount.Fiat fontSize='xl' value={totalFiatBalance} lineHeight={1} />
   }, [asset?.name, marketData, totalFiatBalance, translate])
-
-  useEffect(() => {
-    if (marketData?.price) {
-      console.log('marketData', marketData)
-    }
-  }, [marketData])
 
   if (!asset || !isConnected) return null
 

--- a/src/components/Equity/Equity.tsx
+++ b/src/components/Equity/Equity.tsx
@@ -121,8 +121,8 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
     [borderColor],
   )
 
-  const renderTotalFiatBalance = useMemo(() => {
-    if (!marketData?.price)
+  const balanceContent = useMemo(() => {
+    if (!marketData)
       return (
         <Flex>
           <Tooltip label={translate('common.marketDataUnavailable', { asset: asset?.name })}>
@@ -148,7 +148,7 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
         <Flex flexDir='column' flex={1}>
           <Heading as='h5'>{translate('common.yourBalance')}</Heading>
           <Flex flexDir='column' gap={1}>
-            <Skeleton isLoaded={!isLoading}>{renderTotalFiatBalance}</Skeleton>
+            <Skeleton isLoaded={!isLoading}>{balanceContent}</Skeleton>
             <Skeleton isLoaded={!isLoading}>
               <Amount.Crypto
                 variant='sub-text'

--- a/src/components/Equity/Equity.tsx
+++ b/src/components/Equity/Equity.tsx
@@ -7,13 +7,15 @@ import {
   Skeleton,
   Stack,
   StackDivider,
+  Tooltip,
   useColorModeValue,
 } from '@chakra-ui/react'
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { useSelector } from 'react-redux'
 
+import { RawText } from '../Text'
 import { EquityAccountRow } from './EquityAccountRow'
 import { EquityRowLoading } from './EquityRow'
 import { UnderlyingAsset } from './UnderlyingAsset'
@@ -27,6 +29,7 @@ import {
   selectEquityTotalBalance,
   selectIsAnyOpportunitiesApiQueryPending,
   selectIsPortfolioLoading,
+  selectMarketDataNullableByFilter,
   selectUnderlyingLpAssetsWithBalancesAndIcons,
 } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -56,6 +59,7 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
     }
   }, [accountId, assetId])
 
+  const marketData = useAppSelector(state => selectMarketDataNullableByFilter(state, filter))
   const totalEquityBalance = useAppSelector(state => selectEquityTotalBalance(state, filter))
   const equityRows = useAppSelector(state => selectAssetEquityItemsByFilter(state, filter))
 
@@ -117,6 +121,26 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
     [borderColor],
   )
 
+  const renderTotalFiatBalance = useMemo(() => {
+    if (!marketData?.price)
+      return (
+        <Flex>
+          <Tooltip label={translate('common.marketDataUnavailable', { asset: asset?.name })}>
+            <RawText fontSize='xl' lineHeight={1} color='text.subtle'>
+              N/A
+            </RawText>
+          </Tooltip>
+        </Flex>
+      )
+    return <Amount.Fiat fontSize='xl' value={totalFiatBalance} lineHeight={1} />
+  }, [asset?.name, marketData, totalFiatBalance, translate])
+
+  useEffect(() => {
+    if (marketData?.price) {
+      console.log('marketData', marketData)
+    }
+  }, [marketData])
+
   if (!asset || !isConnected) return null
 
   return (
@@ -130,9 +154,7 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
         <Flex flexDir='column' flex={1}>
           <Heading as='h5'>{translate('common.yourBalance')}</Heading>
           <Flex flexDir='column' gap={1}>
-            <Skeleton isLoaded={!isLoading}>
-              <Amount.Fiat fontSize='xl' value={totalFiatBalance} lineHeight={1} />
-            </Skeleton>
+            <Skeleton isLoaded={!isLoading}>{renderTotalFiatBalance}</Skeleton>
             <Skeleton isLoaded={!isLoading}>
               <Amount.Crypto
                 variant='sub-text'

--- a/src/pages/Accounts/AccountToken/AccountBalance.tsx
+++ b/src/pages/Accounts/AccountToken/AccountBalance.tsx
@@ -39,24 +39,24 @@ export const AccountBalance: React.FC<AccountBalanceProps> = ({
   const navigate = useNavigate()
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
-  const opportunitiesFilter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
+  const assetAccountFilter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
   const marketData = useAppSelector(state =>
-    selectMarketDataNullableByFilter(state, opportunitiesFilter),
+    selectMarketDataNullableByFilter(state, assetAccountFilter),
   )
   // Add back in once we add the performance stuff in
   // const footerBg = useColorModeValue('white.100', 'rgba(255,255,255,.02)')
 
   const userCurrencyBalance = useAppSelector(s =>
-    selectUserCurrencyBalanceByFilter(s, opportunitiesFilter),
+    selectUserCurrencyBalanceByFilter(s, assetAccountFilter),
   )
   const cryptoHumanBalance = useAppSelector(s =>
-    selectCryptoHumanBalanceFilter(s, opportunitiesFilter),
+    selectCryptoHumanBalanceFilter(s, assetAccountFilter),
   )
   const handleClick = useCallback(
     () => navigate(backPath ?? `/wallet/accounts/${accountId}`),
     [navigate, backPath, accountId],
   )
-  const renderTotalFiatBalance = useMemo(() => {
+  const balanceContent = useMemo(() => {
     if (!marketData)
       return (
         <Tooltip label={translate('common.marketDataUnavailable', { asset: asset?.name })}>
@@ -95,7 +95,7 @@ export const AccountBalance: React.FC<AccountBalanceProps> = ({
             symbol={asset.symbol}
             lineHeight='shorter'
           />
-          {renderTotalFiatBalance}
+          {balanceContent}
         </Flex>
         <AssetActions assetId={assetId} accountId={accountId} cryptoBalance={cryptoHumanBalance} />
       </CardBody>

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -78,6 +78,14 @@ export const selectMarketDataByFilter = createCachedSelector(
   },
 )((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
+export const selectMarketDataNullableByFilter = createCachedSelector(
+  selectMarketDataUserCurrency,
+  selectAssetIdParamFromFilter,
+  (marketData, assetId): MarketData | undefined => {
+    return marketData[assetId ?? '']
+  },
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
+
 const selectTimeframeParam = (_state: ReduxState, timeframe: HistoryTimeframe) => timeframe
 
 export const selectCryptoPriceHistoryTimeframe = createSelector(


### PR DESCRIPTION
## Description

- When we have no market data for an asset instead of displaying $0.00 we will display N/A with a tooltip telling the user that the market data is unavailable.
- Adds a new selector that returns null for market data if unavailable.

Note:
This only touches the account and asset details balance a price sections of the app. We could leverage this to all rows that display fiat value but that should be a follow up if needed.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8686 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>
low risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

Go to an asset that we have no market data for, instead of $0.00 for the price and balance you should see N/A. If you hover over this value, you should see a tooltip that explains that this market data is unavailable.

If you click on the account for that asset, on the account details page you should also see the same N/A for the price and balance with the same tooltip behavior.

## Screenshots (if applicable)
![Screenshot 2025-05-19 at 1 46 49 PM](https://github.com/user-attachments/assets/ec6b30d9-f9dc-4c6a-9907-e1bbcb3d830f)
![Screenshot 2025-05-19 at 1 46 57 PM](https://github.com/user-attachments/assets/ffe00b10-9d6d-40c9-a017-a797e2dd6ef8)
