### PR TITLE
feat: nullable market-data

### DIFF
--- a/src/components/AssetHeader/AssetChart.tsx
+++ b/src/components/AssetHeader/AssetChart.tsx
@@ -58,7 +58,7 @@ export const AssetChart = ({ accountId, assetId, isLoaded }: AssetChartProps) =>
   const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const assetPrice = useMemo(() => {
     const price = marketData?.price
-    return toFiat(price) ?? 0
+    return toFiat(price ?? '0')
   }, [marketData?.price, toFiat])
 
   const handleTimeframeChange = useCallback(

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -66,7 +66,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const cryptoBalance =
     useAppSelector(state => selectPortfolioCryptoPrecisionBalanceByFilter(state, filter)) ?? '0'
 
-  const formattedPrice = toFiat(marketData?.price)
+  const formattedPrice = toFiat(marketData?.price ?? '0')
 
   const href = (() => {
     const { assetReference } = fromAssetId(asset.assetId)

--- a/src/components/AssetHeader/AssetHeader.tsx
+++ b/src/components/AssetHeader/AssetHeader.tsx
@@ -66,7 +66,7 @@ export const AssetHeader: React.FC<AssetHeaderProps> = ({ assetId, accountId }) 
   const cryptoBalance =
     useAppSelector(state => selectPortfolioCryptoPrecisionBalanceByFilter(state, filter)) ?? '0'
 
-  const formattedPrice = toFiat(marketData.price)
+  const formattedPrice = toFiat(marketData?.price)
 
   const href = (() => {
     const { assetReference } = fromAssetId(asset.assetId)

--- a/src/components/Equity/Equity.tsx
+++ b/src/components/Equity/Equity.tsx
@@ -29,7 +29,7 @@ import {
   selectEquityTotalBalance,
   selectIsAnyOpportunitiesApiQueryPending,
   selectIsPortfolioLoading,
-  selectMarketDataNullableByFilter,
+  selectMarketDataByAssetIdUserCurrency,
   selectUnderlyingLpAssetsWithBalancesAndIcons,
 } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -59,7 +59,7 @@ export const Equity = ({ assetId, accountId }: EquityProps) => {
     }
   }, [accountId, assetId])
 
-  const marketData = useAppSelector(state => selectMarketDataNullableByFilter(state, filter))
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   const totalEquityBalance = useAppSelector(state => selectEquityTotalBalance(state, filter))
   const equityRows = useAppSelector(state => selectAssetEquityItemsByFilter(state, filter))
 

--- a/src/components/Equity/UnderlyingAsset.tsx
+++ b/src/components/Equity/UnderlyingAsset.tsx
@@ -18,9 +18,9 @@ export const UnderlyingAsset: React.FC<AssetWithBalance> = ({
 
   const fiatAmount = useMemo(() => {
     return bnOrZero(cryptoBalancePrecision)
-      .times(marketData.price ?? '0')
+      .times(bnOrZero(marketData?.price))
       .toString()
-  }, [cryptoBalancePrecision, marketData.price])
+  }, [cryptoBalancePrecision, marketData?.price])
 
   return (
     <Flex gap={2} fontSize='sm' alignItems='center' fontWeight='medium'>

--- a/src/components/Modals/QrCode/Form.tsx
+++ b/src/components/Modals/QrCode/Form.tsx
@@ -129,7 +129,9 @@ export const Form: React.FC<QrCodeFormProps> = ({ accountId }) => {
             )
             methods.setValue(
               SendFormFields.FiatAmount,
-              bnOrZero(maybeUrlResult.amountCryptoPrecision).times(marketData.price).toString(),
+              bnOrZero(maybeUrlResult.amountCryptoPrecision)
+                .times(bnOrZero(marketData?.price))
+                .toString(),
             )
           }
 

--- a/src/components/Modals/RateChanged/RateChanged.tsx
+++ b/src/components/Modals/RateChanged/RateChanged.tsx
@@ -63,13 +63,19 @@ export const RateChangedModal = ({ prevAmountCryptoBaseUnit }: RateChangedModalP
   )
 
   const prevAmountUserCurrency = useMemo(
-    () => bn(prevAmountCryptoPrecision).times(buyAssetMarketDataUserCurrency.price).toFixed(2),
-    [buyAssetMarketDataUserCurrency.price, prevAmountCryptoPrecision],
+    () =>
+      bn(prevAmountCryptoPrecision)
+        .times(buyAssetMarketDataUserCurrency?.price)
+        .toFixed(2),
+    [buyAssetMarketDataUserCurrency?.price, prevAmountCryptoPrecision],
   )
 
   const amountUserCurrency = useMemo(
-    () => bn(amountCryptoPrecision).times(buyAssetMarketDataUserCurrency.price).toFixed(2),
-    [amountCryptoPrecision, buyAssetMarketDataUserCurrency.price],
+    () =>
+      bn(amountCryptoPrecision)
+        .times(buyAssetMarketDataUserCurrency?.price)
+        .toFixed(2),
+    [amountCryptoPrecision, buyAssetMarketDataUserCurrency?.price],
   )
 
   const percentageDifferenceHuman = useMemo(() => {

--- a/src/components/Modals/RateChanged/RateChanged.tsx
+++ b/src/components/Modals/RateChanged/RateChanged.tsx
@@ -19,7 +19,7 @@ import { Amount } from '@/components/Amount/Amount'
 import { AssetIcon } from '@/components/AssetIcon'
 import { Text } from '@/components/Text'
 import { useModal } from '@/hooks/useModal/useModal'
-import { bn } from '@/lib/bignumber/bignumber'
+import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
 import { chainIdToChainDisplayName } from '@/lib/utils'
 import { selectMarketDataByAssetIdUserCurrency } from '@/state/slices/marketDataSlice/selectors'
@@ -65,7 +65,7 @@ export const RateChangedModal = ({ prevAmountCryptoBaseUnit }: RateChangedModalP
   const prevAmountUserCurrency = useMemo(
     () =>
       bn(prevAmountCryptoPrecision)
-        .times(buyAssetMarketDataUserCurrency?.price)
+        .times(bnOrZero(buyAssetMarketDataUserCurrency?.price))
         .toFixed(2),
     [buyAssetMarketDataUserCurrency?.price, prevAmountCryptoPrecision],
   )
@@ -73,7 +73,7 @@ export const RateChangedModal = ({ prevAmountCryptoBaseUnit }: RateChangedModalP
   const amountUserCurrency = useMemo(
     () =>
       bn(amountCryptoPrecision)
-        .times(buyAssetMarketDataUserCurrency?.price)
+        .times(bnOrZero(buyAssetMarketDataUserCurrency?.price))
         .toFixed(2),
     [amountCryptoPrecision, buyAssetMarketDataUserCurrency?.price],
   )

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -150,7 +150,9 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
           )
           methods.setValue(
             SendFormFields.FiatAmount,
-            bnOrZero(maybeUrlResult.amountCryptoPrecision).times(marketData.price).toString(),
+            bnOrZero(maybeUrlResult.amountCryptoPrecision)
+              .times(bnOrZero(marketData?.price))
+              .toString(),
           )
         }
 

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -70,7 +70,8 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     name: SendFormFields.SendMax,
   })
 
-  const price = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))?.price
+  const price = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
+    ?.price
 
   const chainAdapterManager = getChainAdapterManager()
   const feeAssetId = chainAdapterManager.get(fromAssetId(assetId).chainId)?.getFeeAssetId()

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -70,7 +70,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     name: SendFormFields.SendMax,
   })
 
-  const price = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId)).price
+  const price = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))?.price
 
   const chainAdapterManager = getChainAdapterManager()
   const feeAssetId = chainAdapterManager.get(fromAssetId(assetId).chainId)?.getFeeAssetId()

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -298,7 +298,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
                 ? fromBaseUnit(solana.SOLANA_MINIMUM_RENT_EXEMPTION_LAMPORTS, feeAsset.precision)
                 : 0,
             )
-    const maxFiat = maxCrypto.times(price)
+    const maxFiat = maxCrypto.times(bnOrZero(price))
 
     const maxCryptoOrZero = maxCrypto.isPositive() ? maxCrypto : bn(0)
     const maxFiatOrZero = maxFiat.isPositive() ? maxFiat : bn(0)
@@ -364,7 +364,7 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     // This is a token send - the max is the absolute max. balance for that asset and no further magic is needed for fees deduction
     if (feeAsset.assetId !== assetId) {
       const maxCrypto = bnOrZero(cryptoHumanBalance)
-      const maxFiat = maxCrypto.times(price)
+      const maxFiat = maxCrypto.times(bnOrZero(price))
 
       setValue(SendFormFields.AmountCryptoPrecision, maxCrypto.toPrecision())
       setValue(SendFormFields.FiatAmount, maxFiat.toFixed(2))
@@ -414,9 +414,9 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
       }
 
       const cryptoAmount =
-        fieldName === SendFormFields.FiatAmount ? bn(inputValue).div(price) : inputValue
+        fieldName === SendFormFields.FiatAmount ? bn(inputValue).div(bnOrZero(price)) : inputValue
       const fiatAmount =
-        fieldName === SendFormFields.FiatAmount ? inputValue : bn(inputValue).times(price)
+        fieldName === SendFormFields.FiatAmount ? inputValue : bn(inputValue).times(bnOrZero(price))
       const otherAmount =
         fieldName === SendFormFields.FiatAmount ? cryptoAmount.toString() : fiatAmount.toString()
 

--- a/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
+++ b/src/components/Modals/Send/hooks/useSendFees/useSendFees.tsx
@@ -33,7 +33,7 @@ export const useSendFees = () => {
   } = useWallet()
 
   const price = bnOrZero(
-    useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, feeAsset.assetId)).price,
+    useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, feeAsset.assetId))?.price,
   )
 
   useEffect(() => {

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -78,7 +78,7 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         if (bnOrZero(sellAmountCryptoPrecision).gt(0)) {
           const cryptoValue = isInputtingFiatSellAmount
             ? bnOrZero(value)
-                .div(marketData?.price)
+                .div(bnOrZero(marketData?.price))
                 .toString()
             : value
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderBuyAsset.tsx
@@ -77,7 +77,9 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
 
         if (bnOrZero(sellAmountCryptoPrecision).gt(0)) {
           const cryptoValue = isInputtingFiatSellAmount
-            ? bnOrZero(value).div(marketData.price).toString()
+            ? bnOrZero(value)
+                .div(marketData?.price)
+                .toString()
             : value
 
           const newRate = bnOrZero(cryptoValue).div(sellAmountCryptoPrecision).toString()
@@ -93,7 +95,7 @@ export const LimitOrderBuyAsset: React.FC<LimitOrderBuyAssetProps> = memo(
         setLimitPrice,
         setLimitPriceMode,
         isInputtingFiatSellAmount,
-        marketData.price,
+        marketData?.price,
       ],
     )
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -154,7 +154,7 @@ export const LimitOrderConfig = ({
       let cryptoValue = value
       if (isInputtingFiatSellAmount || isFiatValue) {
         cryptoValue = bnOrZero(value)
-          .div(priceAssetMarketData?.price)
+          .div(bnOrZero(priceAssetMarketData?.price))
           .toFixed(priceAsset.precision)
       }
 

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderConfig.tsx
@@ -85,8 +85,10 @@ export const LimitOrderConfig = ({
 
   const fiatValue = useMemo(
     () =>
-      bnOrZero(limitPriceForSelectedPriceDirection).times(priceAssetMarketData.price).toString(),
-    [limitPriceForSelectedPriceDirection, priceAssetMarketData.price],
+      bnOrZero(limitPriceForSelectedPriceDirection)
+        .times(bnOrZero(priceAssetMarketData?.price))
+        .toString(),
+    [limitPriceForSelectedPriceDirection, priceAssetMarketData?.price],
   )
 
   const limitPriceCryptoPrecision = useMemo(() => {
@@ -151,7 +153,9 @@ export const LimitOrderConfig = ({
 
       let cryptoValue = value
       if (isInputtingFiatSellAmount || isFiatValue) {
-        cryptoValue = bnOrZero(value).div(priceAssetMarketData.price).toFixed(priceAsset.precision)
+        cryptoValue = bnOrZero(value)
+          .div(priceAssetMarketData?.price)
+          .toFixed(priceAsset.precision)
       }
 
       setLimitPriceMode(LimitPriceMode.CustomValue)
@@ -159,7 +163,7 @@ export const LimitOrderConfig = ({
     },
     [
       isInputtingFiatSellAmount,
-      priceAssetMarketData.price,
+      priceAssetMarketData?.price,
       priceAsset.precision,
       setLimitPrice,
       setLimitPriceMode,

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -266,14 +266,14 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
               if (isFiat) {
                 setValue('amountUserCurrency', value)
                 const _cryptoAmount = bnOrZero(value)
-                  .div(assetMarketDataUserCurrency.price)
+                  .div(assetMarketDataUserCurrency?.price)
                   .toFixed()
                 setValue('amountCryptoPrecision', _cryptoAmount)
               } else {
                 setValue('amountCryptoPrecision', value)
                 setValue(
                   'amountUserCurrency',
-                  bnOrZero(value).times(assetMarketDataUserCurrency.price).toFixed(),
+                  bnOrZero(value).times(assetMarketDataUserCurrency?.price).toFixed(),
                 )
               }
             }}
@@ -285,7 +285,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
       },
       [
         asset,
-        assetMarketDataUserCurrency.price,
+        assetMarketDataUserCurrency?.price,
         fiatAmount,
         formattedCryptoAmount,
         handleOnBlur,

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -266,14 +266,16 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
               if (isFiat) {
                 setValue('amountUserCurrency', value)
                 const _cryptoAmount = bnOrZero(value)
-                  .div(assetMarketDataUserCurrency?.price)
+                  .div(bnOrZero(assetMarketDataUserCurrency?.price))
                   .toFixed()
                 setValue('amountCryptoPrecision', _cryptoAmount)
               } else {
                 setValue('amountCryptoPrecision', value)
                 setValue(
                   'amountUserCurrency',
-                  bnOrZero(value).times(assetMarketDataUserCurrency?.price).toFixed(),
+                  bnOrZero(value)
+                    .times(bnOrZero(assetMarketDataUserCurrency?.price))
+                    .toFixed(),
                 )
               }
             }}

--- a/src/components/MultiHopTrade/components/TradeAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAssetInput.tsx
@@ -45,7 +45,9 @@ const AssetInputWithAsset: React.FC<AssetInputLoadedProps> = memo(props => {
   const balance = useAppSelector(state =>
     selectPortfolioCryptoPrecisionBalanceByFilter(state, filter),
   )
-  const fiatBalance = bnOrZero(balance).times(marketData.price).toString()
+  const fiatBalance = bnOrZero(balance)
+    .times(bnOrZero(marketData?.price))
+    .toString()
 
   const onMaxClick = useCallback(
     (isFiat: boolean) => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -109,8 +109,8 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   }, [networkFeeCryptoBaseUnit, feeAsset?.precision, quoteNetworkFeeCryptoPrecision])
 
   const networkFeeUserCurrency = useMemo(() => {
-    return bnOrZero(networkFeeCryptoPrecision).times(feeAssetUserCurrencyRate.price).toFixed()
-  }, [networkFeeCryptoPrecision, feeAssetUserCurrencyRate.price])
+    return bnOrZero(networkFeeCryptoPrecision).times(feeAssetUserCurrencyRate?.price).toFixed()
+  }, [networkFeeCryptoPrecision, feeAssetUserCurrencyRate?.price])
 
   const allowanceResetNetworkFeeCryptoPrecision = fromBaseUnit(
     allowanceResetNetworkFeeCryptoBaseUnit,
@@ -118,7 +118,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   )
 
   const allowanceResetNetworkFeeUserCurrency = bnOrZero(allowanceResetNetworkFeeCryptoPrecision)
-    .times(feeAssetUserCurrencyRate.price)
+    .times(feeAssetUserCurrencyRate?.price)
     .toFixed()
 
   const approvalNetworkFeeCryptoPrecision = fromBaseUnit(
@@ -127,7 +127,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   )
 
   const approvalNetworkFeeUserCurrency = bnOrZero(approvalNetworkFeeCryptoPrecision)
-    .times(feeAssetUserCurrencyRate.price)
+    .times(feeAssetUserCurrencyRate?.price)
     .toFixed()
 
   const tradeResetStepSummary = useMemo(() => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -109,7 +109,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   }, [networkFeeCryptoBaseUnit, feeAsset?.precision, quoteNetworkFeeCryptoPrecision])
 
   const networkFeeUserCurrency = useMemo(() => {
-    return bnOrZero(networkFeeCryptoPrecision).times(feeAssetUserCurrencyRate?.price).toFixed()
+    return bnOrZero(networkFeeCryptoPrecision).times(bnOrZero(feeAssetUserCurrencyRate?.price)).toFixed()
   }, [networkFeeCryptoPrecision, feeAssetUserCurrencyRate?.price])
 
   const allowanceResetNetworkFeeCryptoPrecision = fromBaseUnit(
@@ -118,7 +118,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   )
 
   const allowanceResetNetworkFeeUserCurrency = bnOrZero(allowanceResetNetworkFeeCryptoPrecision)
-    .times(feeAssetUserCurrencyRate?.price)
+    .times(bnOrZero(feeAssetUserCurrencyRate?.price))
     .toFixed()
 
   const approvalNetworkFeeCryptoPrecision = fromBaseUnit(
@@ -127,7 +127,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   )
 
   const approvalNetworkFeeUserCurrency = bnOrZero(approvalNetworkFeeCryptoPrecision)
-    .times(feeAssetUserCurrencyRate?.price)
+    .times(bnOrZero(feeAssetUserCurrencyRate?.price))
     .toFixed()
 
   const tradeResetStepSummary = useMemo(() => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -109,7 +109,9 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   }, [networkFeeCryptoBaseUnit, feeAsset?.precision, quoteNetworkFeeCryptoPrecision])
 
   const networkFeeUserCurrency = useMemo(() => {
-    return bnOrZero(networkFeeCryptoPrecision).times(bnOrZero(feeAssetUserCurrencyRate?.price)).toFixed()
+    return bnOrZero(networkFeeCryptoPrecision)
+      .times(bnOrZero(feeAssetUserCurrencyRate?.price))
+      .toFixed()
   }, [networkFeeCryptoPrecision, feeAssetUserCurrencyRate?.price])
 
   const allowanceResetNetworkFeeCryptoPrecision = fromBaseUnit(

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
@@ -97,10 +97,9 @@ export const ClaimConfirm: React.FC<ClaimConfirmProps> = ({
   )
 
   const amountUserCurrency = useMemo(() => {
-    const price =
-      destinationAssetMarketDataUserCurrency?.price !== '0'
-        ? destinationAssetMarketDataUserCurrency?.price ?? '0'
-        : assetMarketDataUserCurrency?.price ?? '0'
+    const price = destinationAssetMarketDataUserCurrency?.price
+      ? destinationAssetMarketDataUserCurrency.price
+      : assetMarketDataUserCurrency?.price
 
     return bnOrZero(amountCryptoPrecision).times(bnOrZero(price)).toFixed()
   }, [

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
@@ -98,14 +98,14 @@ export const ClaimConfirm: React.FC<ClaimConfirmProps> = ({
 
   const amountUserCurrency = useMemo(() => {
     const price =
-      destinationAssetMarketDataUserCurrency.price !== '0'
-        ? destinationAssetMarketDataUserCurrency.price
-        : assetMarketDataUserCurrency.price
+      destinationAssetMarketDataUserCurrency?.price !== '0'
+        ? destinationAssetMarketDataUserCurrency?.price
+        : assetMarketDataUserCurrency?.price
 
     return bnOrZero(amountCryptoPrecision).times(price).toFixed()
   }, [
-    assetMarketDataUserCurrency.price,
-    destinationAssetMarketDataUserCurrency.price,
+    assetMarketDataUserCurrency?.price,
+    destinationAssetMarketDataUserCurrency?.price,
     amountCryptoPrecision,
   ])
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/Claim/ClaimConfirm.tsx
@@ -99,10 +99,10 @@ export const ClaimConfirm: React.FC<ClaimConfirmProps> = ({
   const amountUserCurrency = useMemo(() => {
     const price =
       destinationAssetMarketDataUserCurrency?.price !== '0'
-        ? destinationAssetMarketDataUserCurrency?.price
-        : assetMarketDataUserCurrency?.price
+        ? destinationAssetMarketDataUserCurrency?.price ?? '0'
+        : assetMarketDataUserCurrency?.price ?? '0'
 
-    return bnOrZero(amountCryptoPrecision).times(price).toFixed()
+    return bnOrZero(amountCryptoPrecision).times(bnOrZero(price)).toFixed()
   }, [
     assetMarketDataUserCurrency?.price,
     destinationAssetMarketDataUserCurrency?.price,

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -54,7 +54,7 @@ export const SellAssetInput = memo(
 
     const { price: sellAssetUserCurrencyRate } = useAppSelector(state =>
       selectMarketDataByFilter(state, { assetId: asset.assetId }),
-    )
+    ) || {}
 
     // sync local state with redux on mount only
     useEffect(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -77,11 +77,11 @@ export const SellAssetInput = memo(
         const sellAmountCryptoPrecision = isFiat
           ? isRateZero
             ? '0'
-            : bnOrZero(value).div(sellAssetUserCurrencyRate).toFixed()
+            : bnOrZero(value).div(bnOrZero(sellAssetUserCurrencyRate)).toFixed()
           : value
 
         const sellAmountUserCurrency = !isFiat
-          ? bnOrZero(value).times(sellAssetUserCurrencyRate).toFixed()
+          ? bnOrZero(value).times(bnOrZero(sellAssetUserCurrencyRate)).toFixed()
           : value
 
         setRawSellAmountCryptoPrecision(sellAmountCryptoPrecision)

--- a/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/SellAssetInput.tsx
@@ -52,9 +52,8 @@ export const SellAssetInput = memo(
 
     const dispatch = useAppDispatch()
 
-    const { price: sellAssetUserCurrencyRate } = useAppSelector(state =>
-      selectMarketDataByFilter(state, { assetId: asset.assetId }),
-    ) || {}
+    const { price: sellAssetUserCurrencyRate } =
+      useAppSelector(state => selectMarketDataByFilter(state, { assetId: asset.assetId })) || {}
 
     // sync local state with redux on mount only
     useEffect(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -165,9 +165,9 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
         isTradingWithoutMarketData
           ? undefined
           : bn(totalReceiveAmountCryptoPrecision)
-              .times(buyAssetMarketData.price ?? 0)
+              .times(bnOrZero(buyAssetMarketData?.price))
               .toString(),
-      [buyAssetMarketData.price, isTradingWithoutMarketData, totalReceiveAmountCryptoPrecision],
+      [buyAssetMarketData?.price, isTradingWithoutMarketData, totalReceiveAmountCryptoPrecision],
     )
 
     const handleQuoteSelection = useCallback(() => {

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -132,7 +132,7 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
       const getFeeAssetUserCurrencyRate = (feeAssetId: AssetId) =>
         selectMarketDataByFilter(state, {
           assetId: feeAssetId,
-        }).price
+        })?.price
 
       return getTotalNetworkFeeUserCurrencyPrecision(
         quote,

--- a/src/components/PriceChart/PriceChart.tsx
+++ b/src/components/PriceChart/PriceChart.tsx
@@ -10,6 +10,7 @@ import { IconCircle } from '@/components/IconCircle'
 import { Text } from '@/components/Text'
 import { makeBalanceChartData } from '@/hooks/useBalanceChartData/utils'
 import { useFetchPriceHistories } from '@/hooks/useFetchPriceHistories/useFetchPriceHistories'
+import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { calculateFiatChange, calculatePercentChange } from '@/lib/charts'
 import {
   selectPriceHistoriesLoadingByAssetTimeframe,
@@ -20,7 +21,7 @@ import { useAppSelector } from '@/state/store'
 type PriceChartArgs = {
   assetId: AssetId
   timeframe: HistoryTimeframe
-  percentChange: number
+  percentChange: number | undefined
   setPercentChange: (percentChange: number) => void
   setFiatChange?: (fiatChange: number) => void
   chartHeight?: string
@@ -82,7 +83,7 @@ export const PriceChart: React.FC<PriceChartArgs> = props => {
 
   const data = useMemo(() => makeBalanceChartData(priceData), [priceData])
 
-  const color = percentChange > 0 ? 'green.500' : 'red.500'
+  const color = bnOrZero(percentChange).gt(0) ? 'green.500' : 'red.500'
 
   if (!isLoading && !priceData.length)
     return (

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -130,14 +130,18 @@ export const Deposit = ({
   const handleInputChange = useCallback(
     (value: string, isFiat?: boolean) => {
       if (isFiat) {
-        const cryptoAmount = bnOrZero(value).div(marketData.price).toFixed()
+        const cryptoAmount = bnOrZero(value)
+          .div(bnOrZero(marketData?.price))
+          .toFixed()
         setValue(Field.FiatAmount, value, { shouldValidate: true })
         setValue(Field.CryptoAmount, cryptoAmount, {
           shouldValidate: true,
         })
         onChange && onChange({ cryptoAmount, fiatAmount: value })
       } else {
-        const fiatAmount = bnOrZero(value).times(marketData.price).toString()
+        const fiatAmount = bnOrZero(value)
+          .times(bnOrZero(marketData?.price))
+          .toString()
         setValue(Field.FiatAmount, fiatAmount, {
           shouldValidate: true,
         })
@@ -147,7 +151,7 @@ export const Deposit = ({
         onChange && onChange({ fiatAmount, cryptoAmount: value })
       }
     },
-    [marketData.price, onChange, setValue],
+    [marketData?.price, onChange, setValue],
   )
 
   const handlePercentClick = useCallback(
@@ -167,7 +171,9 @@ export const Deposit = ({
         const _percentageCryptoAmount = bnOrZero(cryptoAmountAvailable)
           .times(percent)
           .dp(asset.precision)
-        const _percentageFiatAmount = _percentageCryptoAmount.times(marketData.price).toString()
+        const _percentageFiatAmount = _percentageCryptoAmount
+          .times(bnOrZero(marketData?.price))
+          .toString()
 
         return {
           percentageCryptoAmount: _percentageCryptoAmount,
@@ -187,7 +193,7 @@ export const Deposit = ({
           cryptoAmount: percentageCryptoAmount.toString(),
         })
     },
-    [asset.precision, cryptoAmountAvailable, marketData.price, onChange, onPercentClick, setValue],
+    [asset.precision, cryptoAmountAvailable, marketData?.price, onChange, onPercentClick, setValue],
   )
 
   const onSubmit = useCallback(
@@ -198,7 +204,9 @@ export const Deposit = ({
   )
 
   const cryptoYield = calculateYearlyYield(apy, values.cryptoAmount)
-  const fiatYield = bnOrZero(cryptoYield).times(marketData.price).toFixed(2)
+  const fiatYield = bnOrZero(cryptoYield)
+    .times(bnOrZero(marketData?.price))
+    .toFixed(2)
 
   const handleFormSubmit = useMemo(() => handleSubmit(onSubmit), [handleSubmit, onSubmit])
 

--- a/src/features/defi/components/Deposit/Deposit.tsx
+++ b/src/features/defi/components/Deposit/Deposit.tsx
@@ -34,7 +34,7 @@ type DepositProps = {
   // enables slippage UI (defaults to true)
   enableSlippage?: boolean
   // Asset market data
-  marketData: MarketData
+  marketData: MarketData | undefined
   onAccountIdChange?: AccountDropdownProps['onChange']
   onPercentClick?: (
     percent: number,

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -141,14 +141,18 @@ export const Withdraw: React.FC<WithdrawProps> = ({
   const handleInputChange = useCallback(
     (value: string, isFiat?: boolean) => {
       if (isFiat) {
-        const cryptoAmount = bnOrZero(value).div(marketData.price).toString()
+        const cryptoAmount = bnOrZero(value)
+          .div(bnOrZero(marketData?.price))
+          .toString()
         setValue(Field.FiatAmount, value, { shouldValidate: true })
         setValue(Field.CryptoAmount, cryptoAmount, {
           shouldValidate: true,
         })
         onChange && onChange(value, cryptoAmount)
       } else {
-        const fiatAmount = bnOrZero(value).times(marketData.price).toString()
+        const fiatAmount = bnOrZero(value)
+          .times(bnOrZero(marketData?.price))
+          .toString()
         setValue(Field.FiatAmount, fiatAmount, {
           shouldValidate: true,
         })
@@ -159,7 +163,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       }
       if (onInputChange) onInputChange(value, isFiat)
     },
-    [marketData.price, onChange, onInputChange, setValue],
+    [marketData?.price, onChange, onInputChange, setValue],
   )
 
   const handleSlippageChange = useCallback(

--- a/src/features/defi/components/Withdraw/Withdraw.tsx
+++ b/src/features/defi/components/Withdraw/Withdraw.tsx
@@ -48,7 +48,7 @@ type WithdrawProps = {
   // Validation rules for the fiat input
   fiatInputValidation?: ControllerProps['rules']
   // Asset market data
-  marketData: MarketData
+  marketData: MarketData | undefined
   onAccountIdChange?: AccountDropdownProps['onChange']
   // Array of the % options
   percentOptions: number[]

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -71,8 +71,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const claimAmount = bnOrZero(opportunity?.rewardsCryptoBaseUnit?.amounts[0]).toString()
   const claimFiatAmount = useMemo(
-    () => bnOrZero(claimAmount).times(assetMarketData.price).toString(),
-    [assetMarketData.price, claimAmount],
+    () => bnOrZero(claimAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    [assetMarketData?.price, claimAmount],
   )
 
   if (!feeAsset) throw new Error(`Fee asset not found for AssetId ${feeAssetId}`)
@@ -105,7 +105,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
     chainAdapterManager,
     contractAddress,
     feeAsset.precision,
-    feeMarketData.price,
+    feeMarketData?.price,
     walletState.wallet,
     dispatch,
   ])
@@ -222,7 +222,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             >
               <Stack textAlign='right' spacing={0}>
                 <Amount.Fiat
-                  value={estimatedGasCryptoPrecision.times(feeMarketData.price).toFixed()}
+                  value={estimatedGasCryptoPrecision.times(bnOrZero(feeMarketData?.price)).toFixed()}
                 />
                 <Amount.Crypto
                   color='text.subtle'

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Confirm.tsx
@@ -71,7 +71,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
 
   const claimAmount = bnOrZero(opportunity?.rewardsCryptoBaseUnit?.amounts[0]).toString()
   const claimFiatAmount = useMemo(
-    () => bnOrZero(claimAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    () =>
+      bnOrZero(claimAmount)
+        .times(bnOrZero(assetMarketData?.price))
+        .toString(),
     [assetMarketData?.price, claimAmount],
   )
 
@@ -222,7 +225,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
             >
               <Stack textAlign='right' spacing={0}>
                 <Amount.Fiat
-                  value={estimatedGasCryptoPrecision.times(bnOrZero(feeMarketData?.price)).toFixed()}
+                  value={estimatedGasCryptoPrecision
+                    .times(bnOrZero(feeMarketData?.price))
+                    .toFixed()}
                 />
                 <Amount.Crypto
                   color='text.subtle'

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Status.tsx
@@ -79,7 +79,10 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
     [asset.precision, opportunity?.rewardsCryptoBaseUnit],
   )
   const rewardFiatAmount = useMemo(
-    () => bnOrZero(rewardCryptoAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    () =>
+      bnOrZero(rewardCryptoAmount)
+        .times(bnOrZero(assetMarketData?.price))
+        .toString(),
     [assetMarketData?.price, rewardCryptoAmount],
   )
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Claim/components/Status.tsx
@@ -79,8 +79,8 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
     [asset.precision, opportunity?.rewardsCryptoBaseUnit],
   )
   const rewardFiatAmount = useMemo(
-    () => bnOrZero(rewardCryptoAmount).times(assetMarketData.price).toString(),
-    [assetMarketData.price, rewardCryptoAmount],
+    () => bnOrZero(rewardCryptoAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    [assetMarketData?.price, rewardCryptoAmount],
   )
 
   const txStatus = useMemo(() => {

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -86,7 +86,10 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     [state?.deposit.cryptoAmount],
   )
   const fiatAmount = useMemo(
-    () => bnOrZero(cryptoAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    () =>
+      bnOrZero(cryptoAmount)
+        .times(bnOrZero(assetMarketData?.price))
+        .toString(),
     [assetMarketData?.price, cryptoAmount],
   )
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Confirm.tsx
@@ -86,8 +86,8 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
     [state?.deposit.cryptoAmount],
   )
   const fiatAmount = useMemo(
-    () => bnOrZero(cryptoAmount).times(assetMarketData.price).toString(),
-    [assetMarketData.price, cryptoAmount],
+    () => bnOrZero(cryptoAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    [assetMarketData?.price, cryptoAmount],
   )
 
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
@@ -252,7 +252,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={estimatedGasCryptoPrecision.times(feeMarketData.price).toFixed()}
+                value={estimatedGasCryptoPrecision.times(bnOrZero(feeMarketData?.price)).toFixed()}
               />
               <Amount.Crypto
                 color='text.subtle'

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Deposit.tsx
@@ -85,8 +85,8 @@ export const Deposit: React.FC<DepositProps> = ({
     [asset.precision, balance],
   )
   const fiatAmountAvailable = useMemo(
-    () => bnOrZero(amountAvailableCryptoPrecision).times(marketData.price),
-    [amountAvailableCryptoPrecision, marketData.price],
+    () => bnOrZero(amountAvailableCryptoPrecision).times(bnOrZero(marketData?.price)),
+    [amountAvailableCryptoPrecision, marketData?.price],
   )
 
   const handleMaxClick = useCallback(
@@ -108,7 +108,7 @@ export const Deposit: React.FC<DepositProps> = ({
         .minus(estimatedFees.average.txFee)
         .div(bn(10).pow(asset.precision))
         .toString()
-      const fiatAmount = bnOrZero(cryptoAmountHuman).times(marketData.price)
+      const fiatAmount = bnOrZero(cryptoAmountHuman).times(bnOrZero(marketData?.price))
       setValue(Field.FiatAmount, fiatAmount.toString(), {
         shouldValidate: true,
       })
@@ -116,7 +116,7 @@ export const Deposit: React.FC<DepositProps> = ({
         shouldValidate: true,
       })
     },
-    [accountId, asset.precision, assetId, amountAvailableCryptoPrecision, marketData.price],
+    [accountId, asset.precision, assetId, amountAvailableCryptoPrecision, marketData?.price],
   )
 
   const handleContinue = useCallback(
@@ -174,13 +174,13 @@ export const Deposit: React.FC<DepositProps> = ({
   const validateFiatAmount = useCallback(
     (value: string) => {
       const crypto = bnOrZero(balance).div(`1e+${asset.precision}`)
-      const fiat = crypto.times(marketData.price)
+      const fiat = crypto.times(bnOrZero(marketData?.price))
       const _value = bnOrZero(value)
       const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
       if (_value.isEqualTo(0)) return ''
       return hasValidBalance || 'common.insufficientFunds'
     },
-    [asset.precision, balance, marketData.price],
+    [asset.precision, balance, marketData?.price],
   )
 
   const cryptoInputValidation = useMemo(

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
@@ -62,8 +62,8 @@ export const Status = () => {
     [state?.deposit.cryptoAmount],
   )
   const fiatAmount = useMemo(
-    () => bnOrZero(cryptoAmount).times(assetMarketData.price).toString(),
-    [assetMarketData.price, cryptoAmount],
+    () => bnOrZero(cryptoAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    [assetMarketData?.price, cryptoAmount],
   )
 
   const handleViewPosition = useCallback(() => {

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Deposit/components/Status.tsx
@@ -62,7 +62,10 @@ export const Status = () => {
     [state?.deposit.cryptoAmount],
   )
   const fiatAmount = useMemo(
-    () => bnOrZero(cryptoAmount).times(bnOrZero(assetMarketData?.price)).toString(),
+    () =>
+      bnOrZero(cryptoAmount)
+        .times(bnOrZero(assetMarketData?.price))
+        .toString(),
     [assetMarketData?.price, cryptoAmount],
   )
 

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Overview/CosmosOverview.tsx
@@ -138,7 +138,7 @@ export const CosmosOverview: React.FC<CosmosOverviewProps> = ({
     selectMarketDataByAssetIdUserCurrency(state, stakingAssetId),
   )
   const cryptoAmountAvailable = totalBondings.div(bn(10).pow(stakingAsset.precision))
-  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
+  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(bnOrZero(marketData?.price))
 
   const selectedLocale = useAppSelector(preferences.selectors.selectSelectedLocale)
   const descriptionQuery = useGetAssetDescriptionQuery({ assetId: stakingAssetId, selectedLocale })

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Confirm.tsx
@@ -97,9 +97,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
   const fiatAmount = useMemo(
     () =>
       bnOrZero(state?.withdraw.cryptoAmount)
-        .times(assetMarketData.price)
+        .times(bnOrZero(assetMarketData?.price))
         .toString(),
-    [assetMarketData.price, state?.withdraw.cryptoAmount],
+    [assetMarketData?.price, state?.withdraw.cryptoAmount],
   )
 
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
@@ -260,7 +260,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
             <Box textAlign='right'>
               <Amount.Fiat
                 fontWeight='bold'
-                value={estimatedGasCryptoPrecision.times(feeMarketData.price).toFixed()}
+                value={estimatedGasCryptoPrecision.times(bnOrZero(feeMarketData?.price)).toFixed()}
               />
               <Amount.Crypto
                 color='text.subtle'

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Status.tsx
@@ -77,9 +77,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
   const fiatAmount = useMemo(
     () =>
       bnOrZero(state?.withdraw.cryptoAmount)
-        .times(underlyingAssetMarketData.price)
+        .times(bnOrZero(underlyingAssetMarketData?.price))
         .toString(),
-    [state?.withdraw.cryptoAmount, underlyingAssetMarketData.price],
+    [state?.withdraw.cryptoAmount, underlyingAssetMarketData?.price],
   )
 
   const navigate = useNavigate()

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -100,7 +100,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
     bn(10).pow(asset.precision),
   )
 
-  const fiatStakeAmountHuman = cryptoStakeBalanceHuman.times(bnOrZero(marketData.price)).toString()
+  const fiatStakeAmountHuman = cryptoStakeBalanceHuman.times(bnOrZero(marketData?.price)).toString()
 
   const handleCancel = useCallback(() => {
     navigate(-1)

--- a/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/cosmos/components/CosmosManager/Withdraw/components/Withdraw.tsx
@@ -111,7 +111,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
       const cryptoAmount = bnOrZero(cryptoStakeBalanceHuman)
         .times(percent)
         .dp(asset.precision, BigNumber.ROUND_DOWN)
-      const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
+      const fiatAmount = bnOrZero(cryptoAmount).times(bnOrZero(marketData?.price))
       setValue(Field.FiatAmount, fiatAmount.toString(), {
         shouldValidate: true,
       })
@@ -119,7 +119,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({
         shouldValidate: true,
       })
     },
-    [asset.precision, cryptoStakeBalanceHuman, marketData.price, setValue],
+    [asset.precision, cryptoStakeBalanceHuman, marketData?.price, setValue],
   )
 
   const handleContinue = useCallback(

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
@@ -196,7 +196,7 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
     accountAddress,
     feeAsset.precision,
     feeMarketData,
-    feeMarketData.price,
+    feeMarketData?.price,
     getClaimFees,
     wallet,
     foxFarmingContract,
@@ -286,7 +286,7 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
                 <Stack textAlign='right' spacing={0}>
                   <Amount.Fiat
                     value={bnOrZero(estimatedGas)
-                      .times(feeMarketData?.price)
+                      .times(bnOrZero(feeMarketData?.price))
                       .toFixed(2)}
                   />
                   <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
@@ -108,8 +108,12 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
   )
 
   const claimFiatAmount = useMemo(
-    () => bnOrZero(amount).times(assetMarketData.price).toString(),
-    [amount, assetMarketData.price],
+    () =>
+      bnOrZero(amount)
+        .times(bnOrZero(assetMarketData?.price))
+        .times(bnOrZero(feeMarketData?.price))
+        .toString(),
+    [amount, assetMarketData?.price, feeMarketData?.price],
   )
 
   const toast = useToast()
@@ -281,7 +285,9 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
               >
                 <Stack textAlign='right' spacing={0}>
                   <Amount.Fiat
-                    value={bnOrZero(estimatedGas).times(feeMarketData.price).toFixed(2)}
+                    value={bnOrZero(estimatedGas)
+                      .times(feeMarketData?.price)
+                      .toFixed(2)}
                   />
                   <Amount.Crypto
                     color='text.subtle'

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
@@ -111,9 +111,8 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
     () =>
       bnOrZero(amount)
         .times(bnOrZero(assetMarketData?.price))
-        .times(bnOrZero(feeMarketData?.price))
         .toString(),
-    [amount, assetMarketData?.price, feeMarketData?.price],
+    [amount, assetMarketData?.price],
   )
 
   const toast = useToast()

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
@@ -297,7 +297,7 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
                 <Amount.Fiat
                   fontWeight='bold'
                   value={bnOrZero(status ? estimatedGas : state.usedGasFeeCryptoPrecision)
-                    .times(feeMarketData?.price)
+                    .times(bnOrZero(feeMarketData?.price))
                     .toFixed(2)}
                 />
                 <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
@@ -128,8 +128,12 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
   )
 
   const claimFiatAmount = useMemo(
-    () => bnOrZero(amount).times(assetMarketData.price).toString(),
-    [amount, assetMarketData.price],
+    () =>
+      bnOrZero(amount)
+        .times(bnOrZero(assetMarketData?.price))
+        .times(bnOrZero(feeMarketData?.price))
+        .toString(),
+    [amount, assetMarketData?.price, feeMarketData?.price],
   )
 
   const serializedTxIndex = useMemo(() => {
@@ -293,7 +297,7 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
                 <Amount.Fiat
                   fontWeight='bold'
                   value={bnOrZero(status ? estimatedGas : state.usedGasFeeCryptoPrecision)
-                    .times(feeMarketData.price)
+                    .times(feeMarketData?.price)
                     .toFixed(2)}
                 />
                 <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimStatus.tsx
@@ -131,9 +131,8 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
     () =>
       bnOrZero(amount)
         .times(bnOrZero(assetMarketData?.price))
-        .times(bnOrZero(feeMarketData?.price))
         .toString(),
-    [amount, assetMarketData?.price, feeMarketData?.price],
+    [amount, assetMarketData?.price],
   )
 
   const serializedTxIndex = useMemo(() => {

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -196,7 +196,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
       )}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCryptoPrecision)
-        .times(feeMarketData.price)
+        .times(feeMarketData?.price)
         .toFixed(2)}
       loading={state.loading}
       preFooter={preFooter}

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Approve.tsx
@@ -196,7 +196,7 @@ export const Approve: React.FC<FoxFarmingApproveProps> = ({ accountId, onNext })
       )}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(state.approve.estimatedGasCryptoPrecision)
-        .times(feeMarketData?.price)
+        .times(bnOrZero(feeMarketData?.price))
         .toFixed(2)}
       loading={state.loading}
       preFooter={preFooter}

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -224,7 +224,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(state.deposit.estimatedGasCryptoPrecision)
-                  .times(feeMarketData.price)
+                  .times(feeMarketData?.price)
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -224,7 +224,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(state.deposit.estimatedGasCryptoPrecision)
-                  .times(feeMarketData?.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Deposit.tsx
@@ -227,7 +227,7 @@ export const Deposit: React.FC<DepositProps> = ({
     [asset?.precision, cryptoBalance],
   )
   const fiatAmountAvailable = useMemo(
-    () => bnOrZero(cryptoHumanAmountAvailable).times(marketData?.price),
+    () => bnOrZero(cryptoHumanAmountAvailable).times(bnOrZero(marketData?.price)),
     [cryptoHumanAmountAvailable, marketData?.price],
   )
 
@@ -247,13 +247,13 @@ export const Deposit: React.FC<DepositProps> = ({
     (value: string) => {
       if (!asset) return
       const crypto = bn(fromBaseUnit(cryptoBalance, asset.precision))
-      const fiat = crypto.times(marketData.price)
+      const fiat = crypto.times(bnOrZero(marketData?.price))
       const _value = bnOrZero(value)
       const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
       if (_value.isEqualTo(0)) return ''
       return hasValidBalance || 'common.insufficientFunds'
     },
-    [asset, cryptoBalance, marketData.price],
+    [asset, cryptoBalance, marketData?.price],
   )
 
   const cryptoInputValidation = useMemo(

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
@@ -288,7 +288,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                     ? state.deposit.estimatedGasCryptoPrecision
                     : state.deposit.usedGasFeeCryptoPrecision,
                 )
-                  .times(feeMarketData?.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Status.tsx
@@ -288,7 +288,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                     ? state.deposit.estimatedGasCryptoPrecision
                     : state.deposit.usedGasFeeCryptoPrecision,
                 )
-                  .times(feeMarketData.price)
+                  .times(feeMarketData?.price)
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -201,8 +201,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(state.withdraw.estimatedGasCryptoPrecision)
-                  .times(feeMarketData?.price)
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -201,6 +201,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(state.withdraw.estimatedGasCryptoPrecision)
+                  .times(feeMarketData?.price)
                   .times(feeMarketData.price)
                   .toFixed(2)}
               />

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
@@ -284,7 +284,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                     ? state.withdraw.estimatedGasCryptoPrecision
                     : state.withdraw.usedGasFeeCryptoPrecision,
                 )
-                  .times(feeMarketData.price)
+                  .times(feeMarketData?.price)
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
@@ -283,9 +283,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                   status === TxStatus.Pending
                     ? state.withdraw.estimatedGasCryptoPrecision
                     : state.withdraw.usedGasFeeCryptoPrecision,
-                )
-                  .times(feeMarketData?.price)
-                  .toFixed(2)}
+                ).times(bnOrZero(feeMarketData?.price)).toFixed(2)}
               />
               <Amount.Crypto
                 color='text.subtle'

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Status.tsx
@@ -283,7 +283,9 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                   status === TxStatus.Pending
                     ? state.withdraw.estimatedGasCryptoPrecision
                     : state.withdraw.usedGasFeeCryptoPrecision,
-                ).times(bnOrZero(feeMarketData?.price)).toFixed(2)}
+                )
+                  .times(bnOrZero(feeMarketData?.price))
+                  .toFixed(2)}
               />
               <Amount.Crypto
                 color='text.subtle'

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Approve.tsx
@@ -224,7 +224,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
-        .times(feeMarketData.price)
+        .times(bnOrZero(feeMarketData?.price))
         .toFixed(2)}
       loading={state.loading}
       preFooter={preFooter}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Confirm.tsx
@@ -190,7 +190,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ onNext, accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(state.deposit.estimatedGasCryptoBaseUnit)
                   .div(bn(10).pow(feeAsset.precision))
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Deposit.tsx
@@ -192,13 +192,13 @@ export const Deposit: React.FC<DepositProps> = ({
   const validateFiatAmount = useCallback(
     (value: string) => {
       const crypto = bnOrZero(balance).div(bn(10).pow(asset.precision))
-      const fiat = crypto.times(marketData.price)
+      const fiat = crypto.times(bnOrZero(marketData?.price))
       const _value = bnOrZero(value)
       const hasValidBalance = fiat.gt(0) && _value.gt(0) && fiat.gte(value)
       if (_value.isEqualTo(0)) return ''
       return hasValidBalance || 'common.insufficientFunds'
     },
-    [asset.precision, balance, marketData.price],
+    [asset.precision, balance, marketData?.price],
   )
 
   const cryptoInputValidation = useMemo(
@@ -218,7 +218,7 @@ export const Deposit: React.FC<DepositProps> = ({
   )
 
   const cryptoAmountAvailable = bnOrZero(balance).div(bn(10).pow(asset.precision))
-  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(marketData.price)
+  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailable).times(bnOrZero(marketData?.price))
 
   if (!state || !dispatch) return null
 

--- a/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Deposit/components/Status.tsx
@@ -179,7 +179,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(usedGasOrEstimateCryptoPrecision)
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimConfirm.tsx
@@ -218,7 +218,7 @@ export const ClaimConfirm = ({
     chainAdapterManager,
     contractAddress,
     feeAsset.precision,
-    feeMarketData.price,
+    feeMarketData?.price,
     foxyApi,
     walletState.wallet,
   ])
@@ -238,7 +238,7 @@ export const ClaimConfirm = ({
             />
           </Stack>
           <Amount.Fiat
-            value={cryptoHumanBalance.times(assetMarketData.price).toString()}
+            value={cryptoHumanBalance.times(bnOrZero(assetMarketData?.price)).toString()}
             color='text.subtle'
             prefix='≈'
           />
@@ -281,7 +281,7 @@ export const ClaimConfirm = ({
                   <Amount.Fiat
                     value={bnOrZero(estimatedGas)
                       .div(`1e+${feeAsset.precision}`)
-                      .times(feeMarketData.price)
+                      .times(bnOrZero(feeMarketData?.price))
                       .toFixed(2)}
                   />
                   <Amount.Crypto

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/Claim/ClaimStatus.tsx
@@ -255,7 +255,7 @@ export const ClaimStatus: React.FC<ClaimStatusProps> = ({ accountId }) => {
                       : state.usedGasFeeCryptoBaseUnit,
                   )
                     .div(`1e+${feeAsset.precision}`)
-                    .times(feeMarketData.price)
+                    .times(bnOrZero(feeMarketData?.price))
                     .toFixed(2)}
                 />
                 <Amount.Crypto

--- a/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Overview/FoxyOverview.tsx
@@ -121,7 +121,9 @@ export const FoxyOverview: React.FC<FoxyOverviewProps> = ({
   const cryptoAmountAvailablePrecision = bnOrZero(
     foxyEarnOpportunityData?.stakedAmountCryptoBaseUnit,
   ).div(bn(10).pow(stakingAsset?.precision ?? 0))
-  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailablePrecision).times(marketData.price)
+  const fiatAmountAvailable = bnOrZero(cryptoAmountAvailablePrecision).times(
+    bnOrZero(marketData?.price),
+  )
 
   const hasPendingUndelegation = Boolean(
     undelegations &&

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Approve.tsx
@@ -225,7 +225,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext }) => {
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoBaseUnit)
         .div(bn(10).pow(feeAsset.precision))
-        .times(feeMarketData.price)
+        .times(bnOrZero(feeMarketData?.price))
         .toFixed(2)}
       loading={state.loading}
       preFooter={preFooter}

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Confirm.tsx
@@ -206,7 +206,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId?: AccountId | un
                 fontWeight='bold'
                 value={bnOrZero(state.withdraw.estimatedGasCryptoBaseUnit)
                   .div(bn(10).pow(feeAsset.precision))
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Status.tsx
@@ -199,7 +199,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
               <Amount.Fiat
                 fontWeight='bold'
                 value={bnOrZero(usedGasOrEstimateCryptoPrecision)
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed(2)}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/foxy/components/FoxyManager/Withdraw/components/Withdraw.tsx
@@ -74,7 +74,7 @@ export const Withdraw: React.FC<
       const cryptoAmount = bnOrZero(cryptoAmountAvailable)
         .times(percent)
         .dp(asset.precision, BigNumber.ROUND_DOWN)
-      const fiatAmount = bnOrZero(cryptoAmount).times(marketData.price)
+      const fiatAmount = bnOrZero(cryptoAmount).times(bnOrZero(marketData?.price))
       setValue(Field.FiatAmount, fiatAmount.toString(), {
         shouldValidate: true,
       })
@@ -82,7 +82,7 @@ export const Withdraw: React.FC<
         shouldValidate: true,
       })
     },
-    [asset.precision, cryptoAmountAvailable, marketData.price, setValue],
+    [asset.precision, cryptoAmountAvailable, marketData?.price, setValue],
   )
 
   const accountAddress = useMemo(

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/ThorchainSaversDeposit.tsx
@@ -224,7 +224,7 @@ export const ThorchainSaversDeposit: React.FC<ThorchainSaversDepositProps> = ({
 
   const value = useMemo(() => ({ state, dispatch }), [state])
 
-  if (loading || !asset || !marketData) {
+  if (loading || !asset || !marketData?.price) {
     return (
       <Center minW='350px' minH='350px'>
         <CircularProgress />

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Approve.tsx
@@ -272,7 +272,7 @@ export const Approve: React.FC<ApproveProps> = ({ accountId, onNext, isReset }) 
       estimatedGasFeeCryptoPrecision={bnOrZero(estimatedGasCryptoPrecision).toFixed(5)}
       disabled={!hasEnoughBalanceForGas}
       fiatEstimatedGasFee={bnOrZero(estimatedGasCryptoPrecision)
-        .times(feeMarketData.price)
+        .times(bnOrZero(feeMarketData?.price))
         .toFixed(2)}
       isReset={isReset}
       loading={state.loading}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -541,7 +541,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               <Box textAlign='right'>
                 <Amount.Fiat
                   fontWeight='bold'
-                  value={bnOrZero(estimatedGasCryptoPrecision).times(bnOrZero(feeMarketData?.price)).toFixed()}
+                  value={bnOrZero(estimatedGasCryptoPrecision)
+                    .times(bnOrZero(feeMarketData?.price))
+                    .toFixed()}
                 />
                 <Amount.Crypto
                   color='text.subtle'

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -518,7 +518,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
                   value={bn(
                     fromBaseUnit(quoteData?.protocolFeeCryptoBaseUnit ?? 0, asset.precision),
                   )
-                    .times(marketData.price)
+                    .times(bnOrZero(marketData?.price))
                     .toFixed()}
                 />
                 <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Confirm.tsx
@@ -541,7 +541,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               <Box textAlign='right'>
                 <Amount.Fiat
                   fontWeight='bold'
-                  value={bnOrZero(estimatedGasCryptoPrecision).times(feeMarketData.price).toFixed()}
+                  value={bnOrZero(estimatedGasCryptoPrecision).times(bnOrZero(feeMarketData?.price)).toFixed()}
                 />
                 <Amount.Crypto
                   color='text.subtle'

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -161,8 +161,8 @@ export const Deposit: React.FC<DepositProps> = ({
   )
 
   const assetPriceInFeeAsset = useMemo(() => {
-    return bn(assetMarketData.price).div(feeAssetMarketData.price)
-  }, [assetMarketData.price, feeAssetMarketData.price])
+    return bnOrZero(assetMarketData?.price).div(bnOrZero(feeAssetMarketData?.price))
+  }, [assetMarketData?.price, feeAssetMarketData?.price])
 
   const userAddress: string | undefined = accountId && fromAccountId(accountId).account
   const balanceFilter = useMemo(() => ({ assetId, accountId }), [accountId, assetId])
@@ -431,7 +431,7 @@ export const Deposit: React.FC<DepositProps> = ({
       if (balanceCryptoPrecision.isZero() || balanceCryptoPrecision.lt(value))
         return 'common.insufficientFunds'
 
-      const valueCryptoPrecision = bnOrZero(value)
+      const valueCryptoPrecision = bnOrZero(value).div(bnOrZero(assetMarketData?.price))
       if (valueCryptoPrecision.isEqualTo(0)) return ''
 
       const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
@@ -484,6 +484,7 @@ export const Deposit: React.FC<DepositProps> = ({
       translate,
       chainId,
       fromAddress,
+      assetMarketData?.price,
     ],
   )
 
@@ -508,10 +509,10 @@ export const Deposit: React.FC<DepositProps> = ({
     async (value: string) => {
       if (!accountId) return
       if (state?.loading) return
-      const valueCryptoPrecision = bnOrZero(value).div(assetMarketData.price)
+      const valueCryptoPrecision = bnOrZero(value).div(bnOrZero(assetMarketData?.price))
       const balanceCryptoPrecision = bn(fromBaseUnit(balanceCryptoBaseUnit, asset.precision))
 
-      const fiatBalance = balanceCryptoPrecision.times(assetMarketData.price)
+      const fiatBalance = bnOrZero(balanceCryptoPrecision).times(bnOrZero(assetMarketData?.price))
       if (fiatBalance.isZero() || fiatBalance.lt(value)) return 'common.insufficientFunds'
 
       const valueCryptoBaseUnit = toBaseUnit(valueCryptoPrecision, asset.precision)
@@ -559,7 +560,7 @@ export const Deposit: React.FC<DepositProps> = ({
     [
       accountId,
       state?.loading,
-      assetMarketData.price,
+      assetMarketData?.price,
       balanceCryptoBaseUnit,
       asset,
       assetId,
@@ -592,7 +593,7 @@ export const Deposit: React.FC<DepositProps> = ({
     [balanceCryptoBaseUnit, asset?.precision],
   )
   const fiatAmountAvailable = useMemo(
-    () => bnOrZero(balanceCryptoPrecision).times(assetMarketData.price),
+    () => bnOrZero(balanceCryptoPrecision).times(bnOrZero(assetMarketData?.price)),
     [balanceCryptoPrecision, assetMarketData?.price],
   )
 
@@ -707,7 +708,7 @@ export const Deposit: React.FC<DepositProps> = ({
           .minus(fromBaseUnit(_estimatedSweepFeesData?.txFeeCryptoBaseUnit ?? 0, asset.precision))
 
       const _percentageFiatAmount = _percentageCryptoAmountPrecisionAfterTxFeesAndSweep.times(
-        assetMarketData.price,
+        assetMarketData?.price,
       )
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
       return {
@@ -727,7 +728,7 @@ export const Deposit: React.FC<DepositProps> = ({
       feeAsset,
       feeAssetMarketData,
       queryClient,
-      assetMarketData.price,
+      assetMarketData?.price,
     ],
   )
 
@@ -862,7 +863,7 @@ export const Deposit: React.FC<DepositProps> = ({
         cryptoInputValidation={cryptoInputValidation}
         fiatAmountAvailable={fiatAmountAvailable.toFixed(2)}
         fiatInputValidation={fiatInputValidation}
-        marketData={assetMarketData}
+        marketData={assetMarketData ?? { price: '0', marketCap: '0', volume: '0', changePercent24Hr: 0, supply: '0', maxSupply: '0', name: '', symbol: '', icon: '', assetId: assetId, precision: asset?.precision ?? 8 }}
         onCancel={handleCancel}
         onPercentClick={handlePercentClick}
         onContinue={handleContinueOrAcknowledgement}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Deposit.tsx
@@ -431,7 +431,7 @@ export const Deposit: React.FC<DepositProps> = ({
       if (balanceCryptoPrecision.isZero() || balanceCryptoPrecision.lt(value))
         return 'common.insufficientFunds'
 
-      const valueCryptoPrecision = bnOrZero(value).div(bnOrZero(assetMarketData?.price))
+      const valueCryptoPrecision = bnOrZero(value)
       if (valueCryptoPrecision.isEqualTo(0)) return ''
 
       const isBelowMinSellAmount = !isAboveDepositDustThreshold({ valueCryptoBaseUnit, assetId })
@@ -484,7 +484,6 @@ export const Deposit: React.FC<DepositProps> = ({
       translate,
       chainId,
       fromAddress,
-      assetMarketData?.price,
     ],
   )
 
@@ -512,7 +511,7 @@ export const Deposit: React.FC<DepositProps> = ({
       const valueCryptoPrecision = bnOrZero(value).div(bnOrZero(assetMarketData?.price))
       const balanceCryptoPrecision = bn(fromBaseUnit(balanceCryptoBaseUnit, asset.precision))
 
-      const fiatBalance = bnOrZero(balanceCryptoPrecision).times(bnOrZero(assetMarketData?.price))
+      const fiatBalance = balanceCryptoPrecision.times(bnOrZero(assetMarketData?.price))
       if (fiatBalance.isZero() || fiatBalance.lt(value)) return 'common.insufficientFunds'
 
       const valueCryptoBaseUnit = toBaseUnit(valueCryptoPrecision, asset.precision)
@@ -708,7 +707,7 @@ export const Deposit: React.FC<DepositProps> = ({
           .minus(fromBaseUnit(_estimatedSweepFeesData?.txFeeCryptoBaseUnit ?? 0, asset.precision))
 
       const _percentageFiatAmount = _percentageCryptoAmountPrecisionAfterTxFeesAndSweep.times(
-        assetMarketData?.price,
+        bnOrZero(assetMarketData?.price),
       )
       contextDispatch({ type: ThorchainSaversDepositActionType.SET_LOADING, payload: false })
       return {
@@ -863,7 +862,7 @@ export const Deposit: React.FC<DepositProps> = ({
         cryptoInputValidation={cryptoInputValidation}
         fiatAmountAvailable={fiatAmountAvailable.toFixed(2)}
         fiatInputValidation={fiatInputValidation}
-        marketData={assetMarketData ?? { price: '0', marketCap: '0', volume: '0', changePercent24Hr: 0, supply: '0', maxSupply: '0', name: '', symbol: '', icon: '', assetId: assetId, precision: asset?.precision ?? 8 }}
+        marketData={assetMarketData}
         onCancel={handleCancel}
         onPercentClick={handlePercentClick}
         onContinue={handleContinueOrAcknowledgement}

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
@@ -233,7 +233,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(state.deposit.networkFeeCryptoBaseUnit)
                   .div(bn(10).pow(feeAsset.precision))
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed()}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Deposit/components/Status.tsx
@@ -208,7 +208,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(state.deposit.protocolFeeCryptoBaseUnit)
                   .div(bn(10).pow(asset.precision))
-                  .times(marketData.price)
+                  .times(bnOrZero(marketData?.price))
                   .toFixed()}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Overview/ThorchainSaversOverview.tsx
@@ -195,8 +195,8 @@ export const ThorchainSaversOverview: React.FC<OverviewProps> = ({
       earnOpportunityData?.stakedAmountCryptoBaseUnit ?? '0',
       asset.precision,
     )
-    const price = marketData.price
-    return bnOrZero(cryptoAmount).times(price).toString()
+    const price = marketData?.price
+    return bnOrZero(cryptoAmount).times(bnOrZero(price)).toString()
   }, [
     asset,
     marketData,

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -200,7 +200,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
 
   const value = useMemo(() => ({ state, dispatch }), [state])
 
-  if (!asset || !marketData)
+  if (!asset || !marketData?.price)
     return (
       <Center minW='350px' minH='350px'>
         <CircularProgress />

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/ThorchainSaversWithdraw.tsx
@@ -200,7 +200,7 @@ export const ThorchainSaversWithdraw: React.FC<WithdrawProps> = ({ accountId }) 
 
   const value = useMemo(() => ({ state, dispatch }), [state])
 
-  if (!asset || !marketData?.price)
+  if (!asset || !marketData)
     return (
       <Center minW='350px' minH='350px'>
         <CircularProgress />

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -544,7 +544,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
                 <Amount.Fiat
                   fontWeight='bold'
                   value={bn(fromBaseUnit(protocolFeeCryptoBaseUnit, asset.precision))
-                    .times(marketData.price)
+                    .times(bnOrZero(marketData?.price))
                     .toFixed()}
                 />
                 <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Confirm.tsx
@@ -567,7 +567,9 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
               <Skeleton isLoaded={!quoteLoading}>
                 <Amount.Fiat
                   fontWeight='bold'
-                  value={bnOrZero(estimatedGasCryptoPrecision).times(feeMarketData.price).toFixed()}
+                  value={bnOrZero(estimatedGasCryptoPrecision)
+                    .times(bnOrZero(feeMarketData?.price))
+                    .toFixed()}
                 />
                 <Amount.Crypto
                   color='text.subtle'
@@ -591,7 +593,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
                   <Amount.Fiat
                     fontWeight='bold'
                     value={bn(fromBaseUnit(dustAmountCryptoBaseUnit, feeAsset.precision))
-                      .times(feeMarketData.price)
+                      .times(bnOrZero(feeMarketData?.price))
                       .toFixed(2)}
                   />
                   <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -230,7 +230,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(state.withdraw.networkFeeCryptoBaseUnit)
                   .div(bn(10).pow(feeAsset.precision))
-                  .times(feeMarketData.price)
+                  .times(bnOrZero(feeMarketData?.price))
                   .toFixed()}
               />
               <Amount.Crypto
@@ -256,7 +256,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                   fontWeight='bold'
                   value={bnOrZero(state.withdraw.dustAmountCryptoBaseUnit)
                     .div(bn(10).pow(feeAsset.precision))
-                    .times(feeMarketData.price)
+                    .times(bnOrZero(feeMarketData?.price))
                     .toFixed()}
                 />
                 <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Status.tsx
@@ -205,7 +205,7 @@ export const Status: React.FC<StatusProps> = ({ accountId }) => {
                 fontWeight='bold'
                 value={bnOrZero(state.withdraw.protocolFeeCryptoBaseUnit)
                   .div(bn(10).pow(asset.precision))
-                  .times(marketData.price)
+                  .times(bnOrZero(marketData?.price))
                   .toFixed()}
               />
               <Amount.Crypto

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -502,7 +502,9 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
           amountAvailableCryptoPrecision.toPrecision(),
         )
 
-        const amountAvailableFiat = amountAvailableCryptoPrecisionBn.times(bnOrZero(assetMarketData?.price))
+        const amountAvailableFiat = amountAvailableCryptoPrecisionBn.times(
+          bnOrZero(assetMarketData?.price),
+        )
         const valueCryptoPrecision = bnOrZero(value)
 
         const hasValidStakingBalance =
@@ -595,7 +597,16 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
         cryptoInputValidation={cryptoInputValidation}
         fiatAmountAvailable={fiatAmountAvailable.toString()}
         fiatInputValidation={fiatInputValidation}
-        marketData={assetMarketData ?? { price: '0', marketCap: '0', volume: '0', changePercent24Hr: 0, supply: '0', maxSupply: '0' }}
+        marketData={
+          assetMarketData ?? {
+            price: '0',
+            marketCap: '0',
+            volume: '0',
+            changePercent24Hr: 0,
+            supply: '0',
+            maxSupply: '0',
+          }
+        }
         onCancel={handleCancel}
         onContinue={handleContinue}
         isLoading={

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -143,8 +143,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
   )
 
   const assetPriceInFeeAsset = useMemo(() => {
-    return bn(assetMarketData.price).div(feeAssetMarketData.price)
-  }, [assetMarketData.price, feeAssetMarketData.price])
+    return bnOrZero(assetMarketData?.price).div(bnOrZero(feeAssetMarketData?.price))
+  }, [assetMarketData?.price, feeAssetMarketData?.price])
 
   const fiatAmountAvailable = useMemo(
     () => bnOrZero(amountAvailableCryptoPrecision).times(assetMarketData.price),

--- a/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
+++ b/src/features/defi/providers/thorchain-savers/components/ThorchainSaversManager/Withdraw/components/Withdraw.tsx
@@ -147,8 +147,8 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
   }, [assetMarketData?.price, feeAssetMarketData?.price])
 
   const fiatAmountAvailable = useMemo(
-    () => bnOrZero(amountAvailableCryptoPrecision).times(assetMarketData.price),
-    [amountAvailableCryptoPrecision, assetMarketData.price],
+    () => bnOrZero(amountAvailableCryptoPrecision).times(bnOrZero(assetMarketData?.price)),
+    [amountAvailableCryptoPrecision, assetMarketData?.price],
   )
 
   // TODO(gomes): this will work for UTXO but is invalid for tokens since they use diff. denoms
@@ -318,12 +318,12 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
   const handlePercentClick = useCallback(
     (percent: number) => {
       const cryptoAmount = bnOrZero(amountAvailableCryptoPrecision).times(percent)
-      const fiatAmount = bnOrZero(cryptoAmount).times(assetMarketData.price)
+      const fiatAmount = bnOrZero(cryptoAmount).times(bnOrZero(assetMarketData?.price))
 
       setValue(Field.FiatAmount, fiatAmount.toString(), { shouldValidate: true })
       setValue(Field.CryptoAmount, cryptoAmount.toFixed(asset.precision), { shouldValidate: true })
     },
-    [amountAvailableCryptoPrecision, asset.precision, assetMarketData.price, setValue],
+    [amountAvailableCryptoPrecision, asset.precision, assetMarketData?.price, setValue],
   )
 
   const outboundFeeInAssetCryptoBaseUnit = useMemo(() => {
@@ -496,13 +496,13 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
 
       setMissingFunds(null)
       setQuoteLoading(true)
-      const withdrawAmountCryptoPrecision = bnOrZero(value).div(assetMarketData.price)
+      const withdrawAmountCryptoPrecision = bnOrZero(value).div(bnOrZero(assetMarketData?.price))
       try {
         const amountAvailableCryptoPrecisionBn = bnOrZero(
           amountAvailableCryptoPrecision.toPrecision(),
         )
 
-        const amountAvailableFiat = amountAvailableCryptoPrecisionBn.times(assetMarketData.price)
+        const amountAvailableFiat = amountAvailableCryptoPrecisionBn.times(bnOrZero(assetMarketData?.price))
         const valueCryptoPrecision = bnOrZero(value)
 
         const hasValidStakingBalance =
@@ -543,7 +543,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
       accountId,
       amountAvailableCryptoPrecision,
       asset,
-      assetMarketData.price,
+      assetMarketData?.price,
       chainId,
       dispatch,
       fromAddress,
@@ -595,7 +595,7 @@ export const Withdraw: React.FC<WithdrawProps> = ({ accountId, fromAddress, onNe
         cryptoInputValidation={cryptoInputValidation}
         fiatAmountAvailable={fiatAmountAvailable.toString()}
         fiatInputValidation={fiatInputValidation}
-        marketData={assetMarketData}
+        marketData={assetMarketData ?? { price: '0', marketCap: '0', volume: '0', changePercent24Hr: 0, supply: '0', maxSupply: '0' }}
         onCancel={handleCancel}
         onContinue={handleContinue}
         isLoading={

--- a/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
+++ b/src/features/defi/providers/univ2/hooks/useUniV2LiquidityPool.ts
@@ -73,7 +73,7 @@ export const useUniV2LiquidityPool = ({
   const wallet = useWallet().state.wallet
   const asset0Price = useAppSelector(state =>
     selectMarketDataByAssetIdUserCurrency(state, assetId0OrWeth),
-  ).price
+  )?.price
 
   const adapter = useMemo(() => assertGetEvmChainAdapter(ethChainId), [])
 
@@ -400,7 +400,7 @@ export const useUniV2LiquidityPool = ({
 
     // Total market cap of liquidity pool in usdc.
     // Multiplied by 2 to show equal amount of eth and fox.
-    const totalLiquidity = ethInReserve.times(asset0Price).times(2)
+    const totalLiquidity = ethInReserve.times(bnOrZero(asset0Price)).times(2)
     return totalLiquidity.toString()
   }, [asset0.precision, asset0Price, uniV2LPContract])
 

--- a/src/hooks/queries/useEvmFees.ts
+++ b/src/hooks/queries/useEvmFees.ts
@@ -69,7 +69,10 @@ export const useEvmFees = ({
       isGetFeesWithWalletEIP1559SupportArgs(getFeesWithWalletEIP1559SupportInput) && enabled
         ? () => getFeesWithWalletEIP1559Support(getFeesWithWalletEIP1559SupportInput)
         : skipToken,
-    select: feeAsset ? fees => selectEvmFees(fees, feeAsset, feeAssetMarketData) : undefined,
+    select:
+      feeAsset && feeAssetMarketData
+        ? fees => selectEvmFees(fees, feeAsset, feeAssetMarketData)
+        : undefined,
     staleTime,
     refetchInterval,
     refetchIntervalInBackground,

--- a/src/lib/utils/thorchain/lp/index.ts
+++ b/src/lib/utils/thorchain/lp/index.ts
@@ -181,10 +181,10 @@ export const estimateRemoveThorchainLiquidityPosition = async ({
 export const calculateEarnings = (
   pool: MidgardEarningsHistoryPoolItem,
   userPoolShare: string,
-  runePrice: string,
+  runePrice: string | undefined,
 ) => {
   const totalEarningsRune = fromThorBaseUnit(pool.earnings).times(userPoolShare)
-  const totalEarningsFiat = totalEarningsRune.times(runePrice).toFixed()
+  const totalEarningsFiat = totalEarningsRune.times(bnOrZero(runePrice)).toFixed()
 
   const assetEarningsCryptoPrecision = fromThorBaseUnit(pool.assetLiquidityFees)
     .times(userPoolShare)

--- a/src/pages/Accounts/AccountToken/AccountBalance.tsx
+++ b/src/pages/Accounts/AccountToken/AccountBalance.tsx
@@ -15,7 +15,7 @@ import { accountIdToLabel } from '@/state/slices/portfolioSlice/utils'
 import {
   selectAssetById,
   selectCryptoHumanBalanceFilter,
-  selectMarketDataNullableByFilter,
+  selectMarketDataByAssetIdUserCurrency,
   selectUserCurrencyBalanceByFilter,
 } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -40,9 +40,7 @@ export const AccountBalance: React.FC<AccountBalanceProps> = ({
   const translate = useTranslate()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const assetAccountFilter = useMemo(() => ({ assetId, accountId }), [assetId, accountId])
-  const marketData = useAppSelector(state =>
-    selectMarketDataNullableByFilter(state, assetAccountFilter),
-  )
+  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
   // Add back in once we add the performance stuff in
   // const footerBg = useColorModeValue('white.100', 'rgba(255,255,255,.02)')
 

--- a/src/pages/Fox/components/FoxFarming.tsx
+++ b/src/pages/Fox/components/FoxFarming.tsx
@@ -135,7 +135,7 @@ export const FoxFarming = () => {
   )
 
   const fetchOpportunityData = useCallback(async () => {
-    if (foxEthMarketData.price === '0') return
+    if (foxEthMarketData?.price === '0') return
 
     await appDispatch(
       opportunitiesApi.endpoints.getOpportunityIds.initiate(
@@ -177,7 +177,7 @@ export const FoxFarming = () => {
     }
 
     return true
-  }, [assetAccountId, appDispatch, foxEthMarketData.price, opportunityId])
+  }, [assetAccountId, appDispatch, foxEthMarketData?.price, opportunityId])
 
   useEffect(() => {
     queryClient.invalidateQueries({
@@ -188,7 +188,7 @@ export const FoxFarming = () => {
   const { isLoading: isOpportunityDataLoading, isFetching: isOpportunityDataFetching } = useQuery({
     queryKey: ['fetchOpportunityData', assetAccountId],
     queryFn: fetchOpportunityData,
-    enabled: Boolean(foxEthMarketData.price !== '0'),
+    enabled: Boolean(foxEthMarketData?.price !== '0'),
   })
 
   const isOpportunityLoading = useMemo(

--- a/src/pages/Fox/components/RFOXSection.tsx
+++ b/src/pages/Fox/components/RFOXSection.tsx
@@ -35,7 +35,7 @@ import { Amount } from '@/components/Amount/Amount'
 import { RFOXIcon } from '@/components/Icons/RFOX'
 import { Text } from '@/components/Text'
 import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
-import { bn } from '@/lib/bignumber/bignumber'
+import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
 import { formatSecondsToDuration } from '@/lib/utils/time'
 import { getStakingContract, selectStakingBalance } from '@/pages/RFOX/helpers'
@@ -213,7 +213,7 @@ export const RFOXSection = () => {
     endTimestamp: currentEpochMetadataQuery.data?.epochEndTimestamp,
     select: (totalRevenue: bigint) => {
       return bn(fromBaseUnit(totalRevenue.toString(), runeAsset?.precision ?? 0))
-        .times(runeMarketData.price)
+        .times(bnOrZero(runeMarketData?.price))
         .toFixed(2)
     },
   })

--- a/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
@@ -244,4 +244,3 @@ const BorrowRoutes = memo(
     )
   },
 )
-

--- a/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/Borrow.tsx
@@ -8,7 +8,7 @@ import { Route, Switch } from 'wouter'
 import { BorrowRoutePaths } from './types'
 
 import { useRouteAssetId } from '@/hooks/useRouteAssetId/useRouteAssetId'
-import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
+import { bnOrZero } from '@/lib/bignumber/bignumber'
 import type { LendingQuoteOpen } from '@/lib/utils/thorchain/lending/types'
 import { selectMarketDataByAssetIdUserCurrency } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -69,14 +69,14 @@ export const Borrow = ({
       const crypto = (() => {
         if (!isFiat) return value
         const valueCryptoPrecision = bnOrZero(value)
-          .div(bn(collateralAssetMarketData?.price ?? '0'))
+          .div(bnOrZero(collateralAssetMarketData?.price))
           .toFixed()
         return valueCryptoPrecision
       })()
       const fiat = (() => {
         if (isFiat) return value
         const valueFiatUserCurrency = bnOrZero(value)
-          .times(bn(collateralAssetMarketData?.price ?? '0'))
+          .times(bnOrZero(collateralAssetMarketData?.price))
           .toFixed()
         return valueFiatUserCurrency
       })()
@@ -244,3 +244,4 @@ const BorrowRoutes = memo(
     )
   },
 )
+

--- a/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Borrow/BorrowConfirm.tsx
@@ -454,7 +454,7 @@ export const BorrowConfirm = ({
                     <Amount.Fiat
                       color='text.subtle'
                       value={bnOrZero(depositAmount)
-                        .times(collateralAssetMarketData?.price ?? '0')
+                        .times(bnOrZero(collateralAssetMarketData?.price))
                         .toString()}
                       prefix='≈'
                     />

--- a/src/pages/Lending/hooks/useLendingCloseQuery.ts
+++ b/src/pages/Lending/hooks/useLendingCloseQuery.ts
@@ -58,7 +58,7 @@ const selectLendingCloseQueryData = memoize(
     const quoteLoanCollateralDecreaseFiatUserCurrency = fromThorBaseUnit(
       quote.expected_collateral_withdrawn,
     )
-      .times(collateralAssetMarketData.price)
+      .times(bnOrZero(collateralAssetMarketData?.price))
       .toString()
     const quoteLoanCollateralDecreaseFiatUsd = bn(quoteLoanCollateralDecreaseFiatUserCurrency)
       .div(userCurrencyToUsdRate)
@@ -76,14 +76,14 @@ const selectLendingCloseQueryData = memoize(
     const quoteWithdrawnAmountAfterFeesUserCurrency = bnOrZero(
       quoteWithdrawnAmountAfterFeesCryptoPrecision,
     )
-      .times(collateralAssetMarketData?.price ?? 0)
+      .times(bnOrZero(collateralAssetMarketData?.price))
       .toString()
 
     const quoteSlippagePercentageDecimal = bnOrZero(quote.fees.slippage_bps)
       .div(BASE_BPS_POINTS)
       .toString()
     const quoteTotalFeesFiatUserCurrency = fromThorBaseUnit(quote.fees.total)
-      .times(collateralAssetMarketData?.price ?? 0)
+      .times(bnOrZero(collateralAssetMarketData?.price))
       .toString()
     const quoteTotalFeesFiatUsd = bn(quoteTotalFeesFiatUserCurrency)
       .div(userCurrencyToUsdRate)
@@ -120,7 +120,7 @@ const selectLendingCloseQueryData = memoize(
       repaymentAsset.precision,
     )
     const repaymentAmountFiatUserCurrency = fromThorBaseUnit(safeExpectedAmountIn)
-      .times(repaymentAssetMarketData.price)
+      .times(bnOrZero(repaymentAssetMarketData?.price))
       .toString()
     const repaymentAmountFiatUsd = bn(repaymentAmountFiatUserCurrency)
       .times(userCurrencyToUsdRate)
@@ -240,8 +240,18 @@ export const useLendingQuoteCloseQuery = ({
     select: data =>
       selectLendingCloseQueryData({
         data,
-        collateralAssetMarketData,
-        repaymentAssetMarketData,
+        collateralAssetMarketData: collateralAssetMarketData ?? {
+          price: '0',
+          marketCap: '0',
+          volume: '0',
+          changePercent24Hr: 0,
+        },
+        repaymentAssetMarketData: repaymentAssetMarketData ?? {
+          price: '0',
+          marketCap: '0',
+          volume: '0',
+          changePercent24Hr: 0,
+        },
         repaymentPercent,
         repaymentAsset,
       }),

--- a/src/pages/Lending/hooks/useLendingPositionData.tsx
+++ b/src/pages/Lending/hooks/useLendingPositionData.tsx
@@ -2,6 +2,7 @@ import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
+import { bnOrZero } from '@/lib/utils/bnOrZero'
 import { fromThorBaseUnit } from '@/lib/utils/thorchain'
 import { getThorchainLendingPosition } from '@/lib/utils/thorchain/lending'
 import {
@@ -48,7 +49,8 @@ export const useLendingPositionData = ({ accountId, assetId }: UseLendingPositio
       const collateralBalanceCryptoPrecision = fromThorBaseUnit(data?.collateral_current).toString()
 
       const collateralBalanceFiatUserCurrency = fromThorBaseUnit(data?.collateral_current)
-        .times(poolAssetMarketData.price)
+        .times(bnOrZero(poolAssetMarketData?.price))
+        .times(poolAssetMarketData?.price)
         .toString()
 
       const userCurrencyToUsdRate = selectUserCurrencyToUsdRate(store.getState())
@@ -63,7 +65,7 @@ export const useLendingPositionData = ({ accountId, assetId }: UseLendingPositio
         address: data?.owner,
       }
     },
-    enabled: Boolean(accountId && assetId && poolAssetMarketData.price !== '0'),
+    enabled: Boolean(accountId && assetId && poolAssetMarketData?.price !== '0'),
   })
 
   return lendingPositionData

--- a/src/pages/Lending/hooks/useLendingPositionData.tsx
+++ b/src/pages/Lending/hooks/useLendingPositionData.tsx
@@ -50,7 +50,6 @@ export const useLendingPositionData = ({ accountId, assetId }: UseLendingPositio
 
       const collateralBalanceFiatUserCurrency = fromThorBaseUnit(data?.collateral_current)
         .times(bnOrZero(poolAssetMarketData?.price))
-        .times(bnOrZero(poolAssetMarketData?.price))
         .toString()
 
       const userCurrencyToUsdRate = selectUserCurrencyToUsdRate(store.getState())

--- a/src/pages/Lending/hooks/useLendingPositionData.tsx
+++ b/src/pages/Lending/hooks/useLendingPositionData.tsx
@@ -2,7 +2,7 @@ import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
-import { bnOrZero } from '@/lib/utils/bnOrZero'
+import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromThorBaseUnit } from '@/lib/utils/thorchain'
 import { getThorchainLendingPosition } from '@/lib/utils/thorchain/lending'
 import {
@@ -50,12 +50,12 @@ export const useLendingPositionData = ({ accountId, assetId }: UseLendingPositio
 
       const collateralBalanceFiatUserCurrency = fromThorBaseUnit(data?.collateral_current)
         .times(bnOrZero(poolAssetMarketData?.price))
-        .times(poolAssetMarketData?.price)
+        .times(bnOrZero(poolAssetMarketData?.price))
         .toString()
 
       const userCurrencyToUsdRate = selectUserCurrencyToUsdRate(store.getState())
       const debtBalanceFiatUserCurrency = fromThorBaseUnit(data?.debt_current)
-        .times(userCurrencyToUsdRate)
+        .times(bnOrZero(userCurrencyToUsdRate))
         .toString()
 
       return {

--- a/src/pages/Lending/hooks/useLendingQuoteQuery.ts
+++ b/src/pages/Lending/hooks/useLendingQuoteQuery.ts
@@ -47,8 +47,8 @@ const selectLendingQuoteQuery = memoize(
     borrowAssetMarketData,
   }: {
     data: LendingDepositQuoteResponseSuccess
-    collateralAssetMarketData: MarketData
-    borrowAssetMarketData: MarketData
+    collateralAssetMarketData: MarketData | undefined
+    borrowAssetMarketData: MarketData | undefined
   }): LendingQuoteOpen => {
     const quote = data
     const userCurrencyToUsdRate = selectUserCurrencyToUsdRate(store.getState())
@@ -280,7 +280,7 @@ export const useLendingQuoteOpenQuery = ({
         destinationAccountMetadata &&
         collateralAsset &&
         borrowAssetReceiveAddress &&
-        collateralAssetMarketData.price !== '0',
+        collateralAssetMarketData?.price,
     ),
   })
 

--- a/src/pages/Lending/hooks/useLendingQuoteQuery.ts
+++ b/src/pages/Lending/hooks/useLendingQuoteQuery.ts
@@ -59,7 +59,7 @@ const selectLendingQuoteQuery = memoize(
     const quoteCollateralAmountFiatUserCurrency = fromThorBaseUnit(
       quote.expected_collateral_deposited,
     )
-      .times(collateralAssetMarketData.price)
+      .times(bnOrZero(collateralAssetMarketData?.price))
       .toString()
 
     const quoteCollateralAmountFiatUsd = bn(quoteCollateralAmountFiatUserCurrency)
@@ -74,7 +74,7 @@ const selectLendingQuoteQuery = memoize(
       quote.expected_amount_out,
     ).toString()
     const quoteBorrowedAmountUserCurrency = bnOrZero(quoteBorrowedAmountCryptoPrecision)
-      .times(borrowAssetMarketData?.price ?? 0)
+      .times(bnOrZero(borrowAssetMarketData?.price))
       .toString()
     const quoteBorrowedAmountUsd = bn(quoteBorrowedAmountUserCurrency)
       .div(userCurrencyToUsdRate)
@@ -90,7 +90,7 @@ const selectLendingQuoteQuery = memoize(
       .div(BASE_BPS_POINTS)
       .toString()
     const quoteTotalFeesFiatUserCurrency = fromThorBaseUnit(quote.fees.total)
-      .times(borrowAssetMarketData?.price ?? 0)
+      .times(bnOrZero(borrowAssetMarketData?.price))
       .toString()
     const quoteTotalFeesFiatUsd = bn(quoteTotalFeesFiatUserCurrency)
       .div(userCurrencyToUsdRate)
@@ -104,7 +104,7 @@ const selectLendingQuoteQuery = memoize(
       .toString()
 
     const quoteSlippageBorrowedAssetUsd = bn(quoteSlippageBorrowedAssetCryptoPrecision)
-      .times(borrowAssetMarketData?.price ?? 0)
+      .times(bnOrZero(borrowAssetMarketData?.price))
       .div(userCurrencyToUsdRate)
       .toString()
 

--- a/src/pages/Lending/hooks/usePoolDataQuery.ts
+++ b/src/pages/Lending/hooks/usePoolDataQuery.ts
@@ -89,8 +89,10 @@ export const usePoolDataQuery = ({ poolAssetId }: { poolAssetId: string }) => {
         fromThorBaseUnit(poolInfo.loan_collateral_remaining),
       )
 
-      const tvl = tvlCryptoPrecision.times(poolAssetMarketData.price).toFixed()
-      const maxSupplyFiat = maxSupplyCryptoPrecision.times(poolAssetMarketData.price).toFixed()
+      const tvl = tvlCryptoPrecision.times(bnOrZero(poolAssetMarketData?.price)).toFixed()
+      const maxSupplyFiat = maxSupplyCryptoPrecision
+        .times(bnOrZero(poolAssetMarketData?.price))
+        .toFixed()
 
       return {
         totalBorrowers,

--- a/src/pages/Markets/components/AssetCard.tsx
+++ b/src/pages/Markets/components/AssetCard.tsx
@@ -19,24 +19,24 @@ type AssetCardProps = {
 export const AssetCard: React.FC<AssetCardProps> = ({ assetId, showMarketCap, onClick }) => {
   const asset = useAppSelector(state => selectAssetById(state, assetId))
   const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
-  const changePercent24Hr = marketData.changePercent24Hr
+  const changePercent24Hr = marketData?.changePercent24Hr
   const translate = useTranslate()
 
   const handleClick = useCallback(() => onClick(assetId), [assetId, onClick])
 
-  const priceValue = useMemo(() => <Amount.Fiat value={marketData.price} />, [marketData.price])
+  const priceValue = useMemo(() => <Amount.Fiat value={marketData?.price} />, [marketData?.price])
 
   const priceChange = useMemo(() => {
     return <Amount.Percent autoColor value={bnOrZero(changePercent24Hr).times(0.01).toString()} />
   }, [changePercent24Hr])
 
   const marketCapValue = useMemo(() => {
-    return bnOrZero(marketData.marketCap).isPositive() ? (
-      <Amount.Fiat value={marketData.marketCap} />
+    return bnOrZero(marketData?.marketCap).isPositive() ? (
+      <Amount.Fiat value={marketData?.marketCap} />
     ) : (
       <CText>N/A</CText>
     )
-  }, [marketData.marketCap])
+  }, [marketData?.marketCap])
 
   if (!asset) return null
 

--- a/src/pages/Markets/components/CardWithSparkline.tsx
+++ b/src/pages/Markets/components/CardWithSparkline.tsx
@@ -26,7 +26,7 @@ export const CardWithSparkline: React.FC<{
   useGetAssetDescriptionQuery({ assetId, selectedLocale }, { skip: !!asset?.description })
   const handleClick = useCallback(() => onClick(assetId), [assetId, onClick])
 
-  const changePercent24Hr = marketData.changePercent24Hr
+  const changePercent24Hr = marketData?.changePercent24Hr
 
   if (!asset || !marketData) return null
 
@@ -55,7 +55,7 @@ export const CardWithSparkline: React.FC<{
               <WatchAssetButton assetId={assetId} alignSelf='flex-start' />
             </Flex>
             <Box textAlign='right'>
-              <Amount.Fiat value={marketData.price} fontWeight='bold' fontSize='2xl' mb={1} />
+              <Amount.Fiat value={marketData?.price} fontWeight='bold' fontSize='2xl' mb={1} />
               <Amount.Percent
                 autoColor
                 value={bnOrZero(changePercent24Hr).times(0.01).toString()}

--- a/src/pages/Markets/components/LpCard.tsx
+++ b/src/pages/Markets/components/LpCard.tsx
@@ -18,7 +18,7 @@ import { useAppSelector } from '@/state/store'
 type LpCardProps = {
   assetId: AssetId
   apy: string
-  volume24H: string
+  volume24H: string | undefined
   onClick: (assetId: AssetId) => void
 }
 
@@ -76,7 +76,7 @@ export const LpGridItem = ({
   index: number
 }) => {
   const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
-  const volume24H = volume ?? marketData?.volume ?? 0
+  const volume24H = volume ?? marketData?.volume ?? '0'
 
   // TODO(gomes): remove weird branching between THOR and Portals - Portals assets should be upserted as a DeFi Opportunity, so we can select them from the same slice
   const opportunityMetadataFilter = useMemo(() => ({ assetId }), [assetId])
@@ -92,12 +92,7 @@ export const LpGridItem = ({
 
   return (
     <GridItem key={index}>
-      <LpCard
-        assetId={assetId}
-        apy={apy ?? '0'}
-        volume24H={String(volume24H ?? '0')}
-        onClick={onClick}
-      />
+      <LpCard assetId={assetId} apy={apy ?? '0'} volume24H={volume24H} onClick={onClick} />
     </GridItem>
   )
 }

--- a/src/pages/Markets/components/LpCard.tsx
+++ b/src/pages/Markets/components/LpCard.tsx
@@ -92,7 +92,12 @@ export const LpGridItem = ({
 
   return (
     <GridItem key={index}>
-      <LpCard assetId={assetId} apy={apy ?? '0'} volume24H={volume24H ?? '0'} onClick={onClick} />
+      <LpCard
+        assetId={assetId}
+        apy={apy ?? '0'}
+        volume24H={String(volume24H ?? '0')}
+        onClick={onClick}
+      />
     </GridItem>
   )
 }

--- a/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
@@ -102,7 +102,7 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
   const claimAmountUserCurrency = useMemo(
     () =>
       bnOrZero(stakingAmountCryptoPrecision)
-        .times(claimAssetMarketDataUserCurrency?.price)
+        .times(bnOrZero(claimAssetMarketDataUserCurrency?.price))
         .toFixed(),
     [claimAssetMarketDataUserCurrency?.price, stakingAmountCryptoPrecision],
   )

--- a/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/RFOX/components/Claim/ClaimConfirm.tsx
@@ -102,9 +102,9 @@ export const ClaimConfirm: FC<Pick<ClaimRouteProps, 'headerComponent'> & ClaimCo
   const claimAmountUserCurrency = useMemo(
     () =>
       bnOrZero(stakingAmountCryptoPrecision)
-        .times(claimAssetMarketDataUserCurrency.price)
+        .times(claimAssetMarketDataUserCurrency?.price)
         .toFixed(),
-    [claimAssetMarketDataUserCurrency.price, stakingAmountCryptoPrecision],
+    [claimAssetMarketDataUserCurrency?.price, stakingAmountCryptoPrecision],
   )
 
   const callData = useMemo(() => {

--- a/src/pages/RFOX/components/Overview/EmissionsPool.tsx
+++ b/src/pages/RFOX/components/Overview/EmissionsPool.tsx
@@ -1,6 +1,6 @@
 import type { AssetId } from '@shapeshiftoss/caip'
 import { thorchainAssetId } from '@shapeshiftoss/caip'
-import { bn } from '@shapeshiftoss/chain-adapters'
+import { bn, bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
@@ -34,7 +34,7 @@ export const EmissionsPool: React.FC<EmissionsPoolProps> = ({ stakingAssetId }) 
     endTimestamp: currentEpochMetadataQuery.data?.epochEndTimestamp,
     select: (totalRevenue: bigint) => {
       return bn(fromBaseUnit(totalRevenue.toString(), runeAsset?.precision ?? 0))
-        .times(runeAssetMarketData.price)
+        .times(bnOrZero(runeAssetMarketData?.price))
         .toFixed(2)
     },
   })

--- a/src/pages/RFOX/components/Overview/StakingInfo.tsx
+++ b/src/pages/RFOX/components/Overview/StakingInfo.tsx
@@ -99,7 +99,7 @@ export const StakingInfo: React.FC<StakingInfoProps> = ({
     const currentEpochRewardsCryptoBaseUnit = currentEpochRewardsCryptoBaseUnitQuery.data.toString()
 
     return bnOrZero(fromBaseUnit(currentEpochRewardsCryptoBaseUnit, runeAsset.precision))
-      .times(runeMarketData.price)
+      .times(bnOrZero(runeMarketData?.price))
       .toFixed(2)
   }, [currentEpochRewardsCryptoBaseUnitQuery, runeAsset, runeMarketData])
 

--- a/src/pages/RFOX/components/Overview/StakingInfoItem.tsx
+++ b/src/pages/RFOX/components/Overview/StakingInfoItem.tsx
@@ -48,7 +48,7 @@ export const StakingInfoItem = ({
     if (!amountCryptoBaseUnit) return
 
     return bnOrZero(fromBaseUnit(amountCryptoBaseUnit, asset.precision))
-      .times(marketDataUserCurrency.price)
+      .times(bnOrZero(marketDataUserCurrency?.price))
       .toFixed(2)
   }, [amountCryptoBaseUnit, marketDataUserCurrency, asset])
 

--- a/src/pages/RFOX/components/Overview/Stats.tsx
+++ b/src/pages/RFOX/components/Overview/Stats.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, SimpleGrid } from '@chakra-ui/react'
 import { thorchainAssetId } from '@shapeshiftoss/caip'
-import { bn } from '@shapeshiftoss/chain-adapters'
+import { bn, bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { useMemo } from 'react'
 
 import { EmissionsPool } from './EmissionsPool'
@@ -36,7 +36,7 @@ export const Stats: React.FC = () => {
     if (!affiliateRevenueQuery.data) return
 
     return bn(fromBaseUnit(affiliateRevenueQuery.data, runeAsset?.precision ?? 0))
-      .times(runeAssetMarketData.price)
+      .times(bnOrZero(runeAssetMarketData?.price))
       .toFixed(2)
   }, [affiliateRevenueQuery, runeAsset, runeAssetMarketData])
 

--- a/src/pages/RFOX/components/Overview/TotalStaked.tsx
+++ b/src/pages/RFOX/components/Overview/TotalStaked.tsx
@@ -1,5 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { bn } from '@shapeshiftoss/chain-adapters'
+import { bn, bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { useTranslate } from 'react-polyglot'
 
 import { StatItem } from './StatItem'
@@ -25,7 +25,7 @@ export const TotalStaked: React.FC<TotalStakedProps> = ({ stakingAssetId }) => {
     stakingAssetId,
     select: (totalStaked: bigint) => {
       return bn(fromBaseUnit(totalStaked.toString(), stakingAsset?.precision ?? 0))
-        .times(stakingAssetMarketData.price)
+        .times(bnOrZero(stakingAssetMarketData?.price))
         .toFixed(2)
     },
   })

--- a/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
+++ b/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
@@ -124,8 +124,10 @@ export const useRfoxBridge = ({ confirmedQuote }: UseRfoxBridgeProps): UseRfoxBr
 
   const bridgeAmountUserCurrency = useMemo(
     () =>
-      bnOrZero(bridgeAmountCryptoPrecision).times(sellAssetMarketDataUserCurrency.price).toFixed(),
-    [bridgeAmountCryptoPrecision, sellAssetMarketDataUserCurrency.price],
+      bnOrZero(bridgeAmountCryptoPrecision)
+        .times(bnOrZero(sellAssetMarketDataUserCurrency?.price ?? '0'))
+        .toFixed(),
+    [bridgeAmountCryptoPrecision, sellAssetMarketDataUserCurrency?.price],
   )
 
   const sellAssetAccountNumberFilter = useMemo(
@@ -216,8 +218,10 @@ export const useRfoxBridge = ({ confirmedQuote }: UseRfoxBridgeProps): UseRfoxBr
 
   const networkFeeUserCurrency = useMemo(() => {
     if (!networkFeeCryptoPrecision) return null
-    return bnOrZero(networkFeeCryptoPrecision).times(feeAssetMarketData.price).toFixed()
-  }, [feeAssetMarketData.price, networkFeeCryptoPrecision])
+    return bnOrZero(networkFeeCryptoPrecision)
+      .times(bnOrZero(feeAssetMarketData?.price))
+      .toFixed()
+  }, [feeAssetMarketData?.price, networkFeeCryptoPrecision])
 
   const { mutateAsync: handleBridge } = useMutation({
     mutationFn: async () => {
@@ -303,7 +307,12 @@ export const useRfoxBridge = ({ confirmedQuote }: UseRfoxBridgeProps): UseRfoxBr
     sellAsset,
     buyAsset,
     feeAsset,
-    feeAssetMarketData,
+    feeAssetMarketData: feeAssetMarketData ?? {
+      price: '0',
+      marketCap: '0',
+      volume: '0',
+      changePercent24Hr: 0,
+    },
     sellAssetAccountNumber,
     tradeQuoteQuery,
     allowanceContract,

--- a/src/pages/RFOX/components/Stake/StakeConfirm.tsx
+++ b/src/pages/RFOX/components/Stake/StakeConfirm.tsx
@@ -97,9 +97,9 @@ export const StakeConfirm: React.FC<StakeConfirmProps & StakeRouteProps> = ({
   const stakeAmountUserCurrency = useMemo(
     () =>
       bnOrZero(stakingAmountCryptoPrecision)
-        .times(stakingAssetMarketDataUserCurrency.price)
+        .times(bnOrZero(stakingAssetMarketDataUserCurrency?.price))
         .toFixed(),
-    [stakingAmountCryptoPrecision, stakingAssetMarketDataUserCurrency.price],
+    [stakingAmountCryptoPrecision, stakingAssetMarketDataUserCurrency?.price],
   )
 
   const {

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -225,7 +225,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
       if (bnOrZero(input).lte(0)) return true
 
       const selectedStakingAssetFiatBalance = bnOrZero(selectedStakingAssetBalanceCryptoPrecision)
-        .times(selectedStakingAssetMarketData.price)
+        .times(bnOrZero(selectedStakingAssetMarketData?.price))
         .toString()
 
       const hasEnoughBalance = bnOrZero(input).lte(
@@ -437,9 +437,10 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     translate,
   ])
 
-  const { price: assetUserCurrencyRate } = useAppSelector(state =>
+  const marketData = useAppSelector(state =>
     selectMarketDataByFilter(state, { assetId: selectedStakingAssetId }),
   )
+  const assetUserCurrencyRate = marketData?.price ?? '0'
 
   // Consumed by onMaxClick
   const handleAmountChange = useCallback(

--- a/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
+++ b/src/pages/RFOX/components/Unstake/UnstakeConfirm.tsx
@@ -62,9 +62,9 @@ export const UnstakeConfirm: React.FC<UnstakeRouteProps & UnstakeConfirmProps> =
   const unstakingAmountUserCurrency = useMemo(
     () =>
       bnOrZero(unstakingAmountCryptoPrecision)
-        .times(stakingAssetMarketDataUserCurrency.price)
+        .times(bnOrZero(stakingAssetMarketDataUserCurrency?.price))
         .toFixed(),
-    [stakingAssetMarketDataUserCurrency.price, unstakingAmountCryptoPrecision],
+    [stakingAssetMarketDataUserCurrency?.price, unstakingAmountCryptoPrecision],
   )
 
   const {

--- a/src/pages/RFOX/components/Unstake/UnstakeInput.tsx
+++ b/src/pages/RFOX/components/Unstake/UnstakeInput.tsx
@@ -213,7 +213,7 @@ export const UnstakeInput: React.FC<UnstakeRouteProps & UnstakeInputProps> = ({
     if (!(userStakingBalanceCryptoPrecision && stakingAssetMarketData)) return
 
     return bnOrZero(userStakingBalanceCryptoPrecision)
-      .times(stakingAssetMarketData?.price ?? 0)
+      .times(bnOrZero(stakingAssetMarketData?.price))
       .toFixed(2)
   }, [stakingAssetMarketData, userStakingBalanceCryptoPrecision])
 

--- a/src/pages/TCY/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/TCY/components/Claim/ClaimConfirm.tsx
@@ -90,8 +90,10 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
   )
 
   const amountUserCurrency = useMemo(() => {
-    return bn(amountCryptoPrecision).times(tcyMarketData.price).toFixed(2)
-  }, [tcyMarketData.price, amountCryptoPrecision])
+    return bn(amountCryptoPrecision)
+      .times(bnOrZero(tcyMarketData?.price))
+      .toFixed(2)
+  }, [tcyMarketData?.price, amountCryptoPrecision])
 
   const {
     dustAmountCryptoBaseUnit,
@@ -167,8 +169,10 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
 
     const dustAmountCryptoPrecision = fromBaseUnit(dustAmountCryptoBaseUnit, feeAsset.precision)
 
-    return bn(dustAmountCryptoPrecision).times(feeAssetMarketData.price).toString()
-  }, [dustAmountCryptoBaseUnit, feeAssetMarketData.price, feeAsset])
+    return bn(dustAmountCryptoPrecision)
+      .times(bnOrZero(feeAssetMarketData?.price))
+      .toString()
+  }, [dustAmountCryptoBaseUnit, feeAssetMarketData?.price, feeAsset])
 
   const feeAssetBalanceCryptoBaseUnit = useAppSelector(state =>
     selectPortfolioCryptoBalanceBaseUnitByFilter(state, feeAssetBalanceFilter),

--- a/src/pages/TCY/components/Overview.tsx
+++ b/src/pages/TCY/components/Overview.tsx
@@ -47,7 +47,9 @@ const StakedBalance = ({ accountId }: { accountId: string | undefined }) => {
   const { data: staker } = useTcyStaker(accountId)
 
   const amountCryptoPrecision = fromBaseUnit(staker?.amount ?? '0', THOR_PRECISION)
-  const amountUserCurrency = bnOrZero(amountCryptoPrecision).times(tcyMarketData.price).toFixed(2)
+  const amountUserCurrency = bnOrZero(amountCryptoPrecision)
+    .times(bnOrZero(tcyMarketData?.price))
+    .toFixed(2)
 
   if (!tcyAsset) return null
 

--- a/src/pages/TCY/components/Overview.tsx
+++ b/src/pages/TCY/components/Overview.tsx
@@ -74,7 +74,9 @@ const RewardsBalance = ({ accountId }: { accountId: string | undefined }) => {
   const { data: distributor } = useTcyDistributor(accountId)
 
   const amountCryptoPrecision = fromBaseUnit(distributor?.total ?? '0', THOR_PRECISION)
-  const amountUserCurrency = bnOrZero(amountCryptoPrecision).times(runeMarketData.price).toFixed(2)
+  const amountUserCurrency = bnOrZero(amountCryptoPrecision)
+    .times(bnOrZero(runeMarketData?.price))
+    .toFixed(2)
 
   if (!runeAsset) return null
 

--- a/src/pages/TCY/components/Stake/StakeConfirm.tsx
+++ b/src/pages/TCY/components/Stake/StakeConfirm.tsx
@@ -36,7 +36,7 @@ export const StakeConfirm: React.FC<StakeConfirmProps> = ({ setStakeTxid }) => {
   const fiatAmount = useMemo(
     () =>
       bnOrZero(amountCryptoPrecision)
-        .times(tcyMarketData?.price ?? 0)
+        .times(bnOrZero(tcyMarketData?.price))
         .toFixed(2),
     [amountCryptoPrecision, tcyMarketData],
   )

--- a/src/pages/TCY/components/Stake/StakeInput.tsx
+++ b/src/pages/TCY/components/Stake/StakeInput.tsx
@@ -123,7 +123,8 @@ export const StakeInput: React.FC<TCYRouteProps & { activeAccountNumber: number 
 
       const price = assetUserCurrencyRate ?? 0
       const cryptoAmount = fieldName === 'fiatAmount' ? bnOrZero(inputValue).div(price) : inputValue
-      const fiatAmount = fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(bnOrZero(price))
+      const fiatAmount =
+        fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(bnOrZero(price))
 
       setValue('amountCryptoPrecision', cryptoAmount.toString())
       setValue('fiatAmount', fiatAmount.toString())

--- a/src/pages/TCY/components/Stake/StakeInput.tsx
+++ b/src/pages/TCY/components/Stake/StakeInput.tsx
@@ -78,9 +78,10 @@ export const StakeInput: React.FC<TCYRouteProps & { activeAccountNumber: number 
     name: 'fiatAmount',
   })
 
-  const { price: assetUserCurrencyRate } = useAppSelector(state =>
-    selectMarketDataByFilter(state, { assetId: selectedStakingAsset?.assetId }),
-  )
+  const { price: assetUserCurrencyRate } =
+    useAppSelector(state =>
+      selectMarketDataByFilter(state, { assetId: selectedStakingAsset?.assetId }),
+    ) ?? {}
 
   const accountIdsByAccountNumberAndChainId = useAppSelector(
     selectAccountIdByAccountNumberAndChainId,
@@ -122,7 +123,7 @@ export const StakeInput: React.FC<TCYRouteProps & { activeAccountNumber: number 
 
       const price = assetUserCurrencyRate ?? 0
       const cryptoAmount = fieldName === 'fiatAmount' ? bnOrZero(inputValue).div(price) : inputValue
-      const fiatAmount = fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(price)
+      const fiatAmount = fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(bnOrZero(price))
 
       setValue('amountCryptoPrecision', cryptoAmount.toString())
       setValue('fiatAmount', fiatAmount.toString())

--- a/src/pages/TCY/components/Unstake/UnstakeConfirm.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeConfirm.tsx
@@ -37,7 +37,7 @@ export const UnstakeConfirm: React.FC<UnstakeConfirmProps> = ({ setUnstakeTxid }
   const fiatAmount = useMemo(
     () =>
       bnOrZero(amountCryptoPrecision)
-        .times(tcyMarketData?.price ?? 0)
+        .times(bnOrZero(tcyMarketData?.price))
         .toFixed(2),
     [amountCryptoPrecision, tcyMarketData],
   )

--- a/src/pages/TCY/components/Unstake/UnstakeInput.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeInput.tsx
@@ -89,9 +89,10 @@ export const UnstakeInput: React.FC<TCYRouteProps & { activeAccountNumber: numbe
     name: 'fiatAmount',
   })
 
-  const { price: assetUserCurrencyRate } = useAppSelector(state =>
-    selectMarketDataByFilter(state, { assetId: selectedStakingAsset?.assetId }),
-  )
+  const { price: assetUserCurrencyRate } =
+    useAppSelector(state =>
+      selectMarketDataByFilter(state, { assetId: selectedStakingAsset?.assetId }),
+    ) ?? {}
 
   const accountIdsByAccountNumberAndChainId = useAppSelector(
     selectAccountIdByAccountNumberAndChainId,
@@ -119,7 +120,7 @@ export const UnstakeInput: React.FC<TCYRouteProps & { activeAccountNumber: numbe
 
       const price = assetUserCurrencyRate ?? 0
       const cryptoAmount = fieldName === 'fiatAmount' ? bnOrZero(inputValue).div(price) : inputValue
-      const fiatAmount = fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(price)
+      const fiatAmount = fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(bnOrZero(price))
 
       setValue('amountCryptoPrecision', cryptoAmount.toString())
       setValue('fiatAmount', fiatAmount.toString())

--- a/src/pages/TCY/components/Unstake/UnstakeInput.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeInput.tsx
@@ -120,7 +120,8 @@ export const UnstakeInput: React.FC<TCYRouteProps & { activeAccountNumber: numbe
 
       const price = assetUserCurrencyRate ?? 0
       const cryptoAmount = fieldName === 'fiatAmount' ? bnOrZero(inputValue).div(price) : inputValue
-      const fiatAmount = fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(bnOrZero(price))
+      const fiatAmount =
+        fieldName === 'fiatAmount' ? inputValue : bnOrZero(inputValue).times(bnOrZero(price))
 
       setValue('amountCryptoPrecision', cryptoAmount.toString())
       setValue('fiatAmount', fiatAmount.toString())

--- a/src/pages/ThorChainLP/Pool/components/PairRates.tsx
+++ b/src/pages/ThorChainLP/Pool/components/PairRates.tsx
@@ -5,7 +5,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { Amount } from '@/components/Amount/Amount'
 import { AssetIcon } from '@/components/AssetIcon'
-import { bn } from '@/lib/bignumber/bignumber'
+import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { selectAssetById, selectMarketDataByAssetIdUserCurrency } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -55,8 +55,12 @@ export const PairRates: React.FC<PairRatesProps> = ({ assetIds }) => {
     selectMarketDataByAssetIdUserCurrency(state, assetIds[1]),
   )
 
-  const asset0PricePerAsset1 = bn(asset1MarketData.price).div(asset0MarketData.price).toString()
-  const asset1PricePerAsset0 = bn(asset0MarketData.price).div(asset1MarketData.price).toString()
+  const asset0PricePerAsset1 = bnOrZero(asset1MarketData?.price)
+    .div(bnOrZero(asset0MarketData?.price))
+    .toString()
+  const asset1PricePerAsset0 = bnOrZero(asset0MarketData?.price)
+    .div(bnOrZero(asset1MarketData?.price))
+    .toString()
 
   const handleAssetClick = useCallback(
     (assetId: AssetId) => {

--- a/src/pages/ThorChainLP/Position/Position.tsx
+++ b/src/pages/ThorChainLP/Position/Position.tsx
@@ -194,7 +194,7 @@ export const Position = () => {
       const poolEarnings = data?.meta.pools.find(pool => pool.pool === poolAssetId)
       if (!poolEarnings) return null
 
-      return calculateEarnings(poolEarnings, position.poolShare, runeMarketData.price)
+      return calculateEarnings(poolEarnings, position.poolShare, runeMarketData?.price)
     },
   })
 

--- a/src/pages/ThorChainLP/YourPositions.tsx
+++ b/src/pages/ThorChainLP/YourPositions.tsx
@@ -243,7 +243,7 @@ export const YourPositions = () => {
               )
               if (!poolEarnings) return null
 
-              return calculateEarnings(poolEarnings, position.poolShare, runeMarketData.price)
+              return calculateEarnings(poolEarnings, position.poolShare, runeMarketData?.price)
             },
           })
 
@@ -292,7 +292,7 @@ export const YourPositions = () => {
         },
       },
     ],
-    [pools, runeAsset, runeMarketData.price, translate],
+    [pools, runeAsset, runeMarketData?.price, translate],
   )
 
   const handlePoolClick = useCallback(

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -827,13 +827,14 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
   ])
 
   const poolAssetGasFeeFiatUserCurrency = useMemo(
-    () => bnOrZero(poolAssetTxFeeCryptoPrecision).times(poolAssetFeeAssetMarktData.price),
-    [poolAssetFeeAssetMarktData.price, poolAssetTxFeeCryptoPrecision],
+    () =>
+      bnOrZero(poolAssetTxFeeCryptoPrecision).times(bnOrZero(poolAssetFeeAssetMarktData?.price)),
+    [poolAssetFeeAssetMarktData?.price, poolAssetTxFeeCryptoPrecision],
   )
 
   const runeGasFeeFiatUserCurrency = useMemo(
-    () => bnOrZero(runeTxFeeCryptoPrecision).times(runeMarketData.price),
-    [runeMarketData.price, runeTxFeeCryptoPrecision],
+    () => bnOrZero(runeTxFeeCryptoPrecision).times(bnOrZero(runeMarketData?.price)),
+    [runeMarketData?.price, runeTxFeeCryptoPrecision],
   )
 
   const totalGasFeeFiatUserCurrency = useMemo(() => {
@@ -895,14 +896,14 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
         const amountCryptoPrecision = (() => {
           if (!isFiat) return value
           return bnOrZero(value)
-            .div(bn(marketData.price ?? '0'))
+            .div(bn(marketData?.price))
             .toFixed()
         })()
 
         const amountFiatUserCurrency = (() => {
           if (isFiat) return value
           return bnOrZero(value)
-            .times(bn(marketData.price ?? '0'))
+            .times(bn(marketData?.price))
             .toFixed()
         })()
 
@@ -959,7 +960,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
       setSlippageDecimalPercentage(estimate.slippageDecimalPercent)
 
       const _slippageFiatUserCurrency = bnOrZero(estimate.slippageRuneCryptoPrecision)
-        .times(runeMarketData.price)
+        .times(bnOrZero(runeMarketData?.price))
         .toFixed()
 
       setSlippageFiatUserCurrency(_slippageFiatUserCurrency)
@@ -1079,7 +1080,12 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           const isRune = asset.assetId === runeAsset.assetId
           const marketData = isRune ? runeMarketData : poolAssetMarketData
           const handleAddLiquidityInputChange = createHandleAddLiquidityInputChange(
-            marketData,
+            marketData ?? {
+              price: '0',
+              marketCap: '0',
+              volume: '0',
+              changePercent24Hr: 0,
+            },
             isRune,
           )
 

--- a/src/pages/ThorChainLP/components/PoolInfo.tsx
+++ b/src/pages/ThorChainLP/components/PoolInfo.tsx
@@ -116,7 +116,7 @@ export const PoolInfo = ({
             <Flex gap={2} pl={2} pr={3} py={2} alignItems='center'>
               <AssetIcon size='xs' assetId={assetIds[0]} />
               <Amount.Fiat
-                value={asset0MarketData.price}
+                value={asset0MarketData?.price}
                 prefix={`1 ${asset0.symbol} =`}
                 fontSize='xs'
                 fontWeight='medium'
@@ -127,7 +127,7 @@ export const PoolInfo = ({
             <Flex gap={2} pl={2} pr={3} py={2} alignItems='center'>
               <AssetIcon size='xs' assetId={assetIds[1]} />
               <Amount.Fiat
-                value={asset1MarketData.price}
+                value={asset1MarketData?.price}
                 prefix={`1 ${asset1.symbol} =`}
                 fontSize='xs'
                 fontWeight='medium'

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -447,8 +447,10 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   ])
 
   const poolAssetProtocolFeeFiatUserCurrency = useMemo(() => {
-    return poolAssetFeeAssetProtocolFeeCryptoPrecision.times(poolAssetFeeAssetMarketData.price)
-  }, [poolAssetFeeAssetMarketData.price, poolAssetFeeAssetProtocolFeeCryptoPrecision])
+    return poolAssetFeeAssetProtocolFeeCryptoPrecision.times(
+      bnOrZero(poolAssetFeeAssetMarketData?.price),
+    )
+  }, [poolAssetFeeAssetMarketData?.price, poolAssetFeeAssetProtocolFeeCryptoPrecision])
 
   const poolAssetTxFeeCryptoPrecision = useMemo(
     () =>
@@ -468,19 +470,19 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
 
   const poolAssetFeeAssetDustAmountFiatUserCurrency = useMemo(() => {
     return bnOrZero(poolAssetFeeAssetDustAmountCryptoPrecision).times(
-      poolAssetFeeAssetMarketData.price,
+      bnOrZero(poolAssetFeeAssetMarketData?.price),
     )
-  }, [poolAssetFeeAssetMarketData.price, poolAssetFeeAssetDustAmountCryptoPrecision])
+  }, [poolAssetFeeAssetMarketData?.price, poolAssetFeeAssetDustAmountCryptoPrecision])
 
   // We also include the dust amount in the gas fee as it's deducted in the input validation
   // This will result in displaying gas fees and dust amounts as a single value in the UI
   const poolAssetGasFeeFiatUserCurrency = useMemo(
     () =>
       bnOrZero(poolAssetTxFeeCryptoPrecision)
-        .times(poolAssetFeeAssetMarketData.price)
+        .times(bnOrZero(poolAssetFeeAssetMarketData?.price))
         .plus(poolAssetFeeAssetDustAmountFiatUserCurrency),
     [
-      poolAssetFeeAssetMarketData.price,
+      poolAssetFeeAssetMarketData?.price,
       poolAssetTxFeeCryptoPrecision,
       poolAssetFeeAssetDustAmountFiatUserCurrency,
     ],
@@ -492,8 +494,8 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   }, [actualRuneWithdrawAmountCryptoPrecision, runeOutboundFeeCryptoBaseUnit])
 
   const runeProtocolFeeFiatUserCurrency = useMemo(() => {
-    return runeProtocolFeeCryptoPrecision.times(runeMarketData.price)
-  }, [runeMarketData, runeProtocolFeeCryptoPrecision])
+    return runeProtocolFeeCryptoPrecision.times(bnOrZero(runeMarketData?.price))
+  }, [runeMarketData?.price, runeProtocolFeeCryptoPrecision])
 
   const runeTxFeeCryptoPrecision = useMemo(
     () => fromBaseUnit(estimatedRuneFeesData?.txFeeCryptoBaseUnit ?? 0, runeAsset?.precision ?? 0),
@@ -501,8 +503,8 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   )
 
   const runeGasFeeFiatUserCurrency = useMemo(
-    () => bnOrZero(runeTxFeeCryptoPrecision).times(runeMarketData.price),
-    [runeMarketData.price, runeTxFeeCryptoPrecision],
+    () => bnOrZero(runeTxFeeCryptoPrecision).times(bnOrZero(runeMarketData?.price)),
+    [runeMarketData?.price, runeTxFeeCryptoPrecision],
   )
 
   const totalProtocolFeeFiatUserCurrency = useMemo(() => {
@@ -571,14 +573,14 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
         const amountCryptoPrecision = (() => {
           if (!isFiat) return value
           return bnOrZero(value)
-            .div(bn(marketData.price ?? '0'))
+            .div(bn(marketData?.price))
             .toFixed()
         })()
 
         const amountFiatUserCurrency = (() => {
           if (isFiat) return value
           return bnOrZero(value)
-            .times(bn(marketData.price ?? '0'))
+            .times(bn(marketData?.price))
             .toFixed()
         })()
 
@@ -632,7 +634,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       })
 
       const _slippageFiatUserCurrency = bnOrZero(estimate.slippageRuneCryptoPrecision)
-        .times(runeMarketData.price)
+        .times(bnOrZero(runeMarketData?.price ?? '0'))
         .toFixed()
 
       setSlippageFiatUserCurrency(withdrawType !== 'sym' ? _slippageFiatUserCurrency : '0')
@@ -646,7 +648,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     percentageSelection,
     poolAsset,
     position,
-    runeMarketData.price,
+    runeMarketData?.price,
   ])
 
   useEffect(() => {
@@ -766,7 +768,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
           const isRune = asset.assetId === runeAsset.assetId
           const marketData = isRune ? runeMarketData : poolAssetMarketData
           const handleRemoveLiquidityInputChange = createHandleRemoveLiquidityInputChange(
-            marketData,
+            marketData ?? {
+              price: '0',
+              marketCap: '0',
+              volume: '0',
+              changePercent24Hr: 0,
+            },
             isRune,
           )
           const cryptoAmount = bnOrZero(
@@ -929,7 +936,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       minimumPoolAssetWithdrawAmountFiatUserCurrency.gt(minimumRuneWithdrawAmountFiatUserCurrency)
     ) {
       const minLimitCryptoPrecision = minimumPoolAssetWithdrawAmountFiatUserCurrency
-        .div(poolAssetMarketData.price)
+        .div(bnOrZero(poolAssetMarketData?.price ?? '0'))
         .toFixed(THOR_PRECISION)
       const minLimit = `${minLimitCryptoPrecision} ${poolAsset.symbol}`
       return translate('trade.errors.amountTooSmall', { minLimit })
@@ -942,7 +949,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       minimumRuneWithdrawAmountFiatUserCurrency.gt(minimumPoolAssetWithdrawAmountFiatUserCurrency)
     ) {
       const minLimitCryptoPrecision = minimumRuneWithdrawAmountFiatUserCurrency
-        .div(runeMarketData.price)
+        .div(bnOrZero(runeMarketData?.price ?? '0'))
         .toFixed(THOR_PRECISION)
       const minLimit = `${minLimitCryptoPrecision} ${runeAsset.symbol}`
       return translate('trade.errors.amountTooSmall', { minLimit })
@@ -951,10 +958,10 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     actualAssetWithdrawAmountFiatUserCurrency,
     actualRuneWithdrawAmountFiatUserCurrency,
     poolAsset,
-    poolAssetMarketData.price,
+    poolAssetMarketData?.price,
     poolAssetProtocolFeeFiatUserCurrency,
     runeAsset,
-    runeMarketData.price,
+    runeMarketData?.price,
     runeProtocolFeeFiatUserCurrency,
     slippageFiatUserCurrency,
     translate,

--- a/src/pages/ThorChainLP/queries/hooks/useAllUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useAllUserLpData.ts
@@ -89,7 +89,7 @@ export const useAllUserLpData = (): UseQueryResult<UseAllUserLpDataReturn | null
                     assets,
                     pool,
                     position,
-                    runePrice: runeMarketDataUserCurrency.price,
+                    runePrice: runeMarketDataUserCurrency?.price,
                     liquidityLockupTime: thorchainMimirTimes.liquidityLockupTime,
                   }),
                 )
@@ -109,7 +109,7 @@ export const useAllUserLpData = (): UseQueryResult<UseAllUserLpDataReturn | null
     portfolioAccounts,
     queryClient,
     runeAccountIds,
-    runeMarketDataUserCurrency.price,
+    runeMarketDataUserCurrency?.price,
     thorchainMimirTimes,
   ])
 

--- a/src/pages/ThorChainLP/queries/hooks/usePool.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePool.ts
@@ -48,6 +48,7 @@ export const getPool = (
   runePrice: string,
 ): Pool | undefined => {
   if (!pool) return
+  if (!runePrice) return
 
   const runeAsset = assets[thorchainAssetId]
   if (!runeAsset) return
@@ -67,7 +68,7 @@ export const getPool = (
     ...pool,
     assetId,
     name: `${asset.symbol}/${runeAsset.symbol}`,
-    tvlFiat: fromThorBaseUnit(tvl).times(runePrice).toFixed(),
+    tvlFiat: fromThorBaseUnit(tvl).times(bnOrZero(runePrice)).toFixed(),
   }
 }
 
@@ -166,7 +167,8 @@ export const usePool = (poolAssetId: string) => {
   const { midgard } = reactQueries
 
   const selectPoolData = useCallback(
-    (pool: MidgardPoolResponse) => getPool(pool, assets, runeMarketData.price),
+    (pool: MidgardPoolResponse) =>
+      runeMarketData?.price ? getPool(pool, assets, runeMarketData.price) : undefined,
     [assets, runeMarketData],
   )
 
@@ -208,21 +210,21 @@ export const usePool = (poolAssetId: string) => {
 
   const feeStats = useMemo(() => {
     if (!swapsData.data) return
-    if (!runeMarketData.price) return
-    return getFeeStats(swapsData.data, runeMarketData.price)
-  }, [swapsData.data, runeMarketData.price])
+    if (!runeMarketData?.price) return
+    return getFeeStats(swapsData.data, runeMarketData?.price)
+  }, [swapsData.data, runeMarketData?.price])
 
   const tvlStats = useMemo(() => {
     if (!poolData.data) return
     if (!tvl.data) return
-    if (!runeMarketData.price) return
+    if (!runeMarketData?.price) return
     return getTvlStats(poolData.data, tvl.data, runeMarketData.price)
-  }, [poolData.data, tvl.data, runeMarketData.price])
+  }, [poolData.data, tvl.data, runeMarketData?.price])
 
   const volumeStats = useMemo(() => {
     if (!poolStats.data) return
     if (!swapsData.data) return
-    if (!runeMarketData.price) return
+    if (!runeMarketData?.price) return
 
     const volumeTotalFiat = fromThorBaseUnit(poolStats.data.swapVolume ?? '0')
       .times(runeMarketData.price)
@@ -232,7 +234,7 @@ export const usePool = (poolAssetId: string) => {
       ...getVolumeStats(swapsData.data, runeMarketData.price),
       volumeTotalFiat,
     }
-  }, [poolStats.data, swapsData.data, runeMarketData.price])
+  }, [poolStats.data, swapsData.data, runeMarketData?.price])
 
   const poolWithStats: PoolWithStats | undefined = useMemo(() => {
     if (!(poolData.data && tvlStats && feeStats && volumeStats)) return

--- a/src/pages/ThorChainLP/queries/hooks/usePool.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePool.ts
@@ -45,7 +45,7 @@ export type PoolWithStats = Pool & PoolStats
 export const getPool = (
   pool: MidgardPoolResponse,
   assets: AssetsByIdPartial,
-  runePrice: string,
+  runePrice: string | undefined,
 ): Pool | undefined => {
   if (!pool) return
   if (!runePrice) return

--- a/src/pages/ThorChainLP/queries/hooks/usePools.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePools.ts
@@ -26,6 +26,7 @@ export const usePools = () => {
 
       return midgardPools
         .reduce<Pool[]>((acc, midgardPool) => {
+          if (!runeMarketData?.price) return acc
           const pool = getPool(midgardPool, assets, runeMarketData.price)
           if (!pool) return acc
           acc.push(pool)
@@ -62,12 +63,11 @@ export const usePools = () => {
         const { data } = query
         if (!data) return acc
         const { thorchainNotationPoolAssetId } = data
-
+        if (!runeMarketData?.price) return acc
         acc[thorchainNotationPoolAssetId] = getVolumeStats(data, runeMarketData.price)
-
         return acc
       }, {}),
-    [runeMarketData.price, swapsData],
+    [runeMarketData?.price, swapsData],
   )
 
   const poolsWithVolumeStats = useMemo(() => {

--- a/src/pages/ThorChainLP/queries/hooks/usePools.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePools.ts
@@ -26,8 +26,7 @@ export const usePools = () => {
 
       return midgardPools
         .reduce<Pool[]>((acc, midgardPool) => {
-          if (!runeMarketData?.price) return acc
-          const pool = getPool(midgardPool, assets, runeMarketData.price)
+          const pool = getPool(midgardPool, assets, runeMarketData?.price)
           if (!pool) return acc
           acc.push(pool)
           return acc

--- a/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
+++ b/src/pages/ThorChainLP/queries/hooks/useUserLpData.ts
@@ -22,8 +22,8 @@ type GetPositionArgs = {
   position: Position
   assets: AssetsByIdPartial
   assetId: AssetId
-  assetPrice: string
-  runePrice: string
+  assetPrice: string | undefined
+  runePrice: string | undefined
   liquidityLockupTime: number
 }
 
@@ -61,13 +61,17 @@ export const getUserLpDataPosition = ({
 
   const pendingAssetAmountCryptoPrecision = fromThorBaseUnit(position.assetPending)
   const pendingRuneAmountCryptoPrecision = fromThorBaseUnit(position.runePending)
-  const pendingAssetAmountFiatUserCurrency = pendingAssetAmountCryptoPrecision.times(assetPrice)
-  const pendingRuneAmountFiatUserCurrency = pendingRuneAmountCryptoPrecision.times(runePrice)
+  const pendingAssetAmountFiatUserCurrency = pendingAssetAmountCryptoPrecision.times(
+    bnOrZero(assetPrice),
+  )
+  const pendingRuneAmountFiatUserCurrency = pendingRuneAmountCryptoPrecision.times(
+    bnOrZero(runePrice),
+  )
 
   const assetShareCryptoPrecision = fromThorBaseUnit(assetShareThorBaseUnit)
   const runeShareCryptoPrecision = fromThorBaseUnit(runeShareThorBaseUnit)
-  const assetShareFiat = assetShareCryptoPrecision.times(assetPrice)
-  const runeShareFiat = runeShareCryptoPrecision.times(runePrice)
+  const assetShareFiat = assetShareCryptoPrecision.times(bnOrZero(assetPrice))
+  const runeShareFiat = runeShareCryptoPrecision.times(bnOrZero(runePrice))
 
   const status = (() => {
     const isPending = bnOrZero(position.runePending).gt(0) || bnOrZero(position.assetPending).gt(0)
@@ -184,11 +188,11 @@ export const useUserLpData = ({
         .map(position =>
           getUserLpDataPosition({
             assetId,
-            assetPrice: poolAssetMarketData.price,
+            assetPrice: poolAssetMarketData?.price,
             assets,
             pool,
             position,
-            runePrice: runeMarketData.price,
+            runePrice: runeMarketData?.price,
             liquidityLockupTime: thorchainMimirTimes.liquidityLockupTime,
           }),
         )

--- a/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
+++ b/src/react-queries/hooks/useQuoteEstimatedFeesQuery.ts
@@ -145,7 +145,7 @@ export const useQuoteEstimatedFeesQuery = ({
             const estimatedFees = await estimateFees(estimateFeesArgs)
             const txFeeFiat = bnOrZero(estimatedFees.fast.txFee)
               .div(bn(10).pow(feeAsset.precision))
-              .times(feeAssetMarketData.price)
+              .times(bnOrZero(feeAssetMarketData?.price))
               .toString()
             return { estimatedFees, txFeeFiat, txFeeCryptoBaseUnit: estimatedFees.fast.txFee }
           }

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -42,7 +42,7 @@ export const selectFiatRampBuyAssetsWithMarketData = createSelector(
         price: '0',
         marketCap: '0',
         volume: '0',
-        changePercent24Hr: '0',
+        changePercent24Hr: 0,
       }
       acc.push({ ...assetData, ...marketDataForAsset })
       return acc

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -38,7 +38,12 @@ export const selectFiatRampBuyAssetsWithMarketData = createSelector(
     return assetIds.reduce<AssetWithMarketData[]>((acc, assetId) => {
       const assetData = assetsById[assetId]
       if (!assetData) return acc
-      const marketDataForAsset = marketData[assetId]
+      const marketDataForAsset = marketData[assetId] ?? {
+        price: '0',
+        marketCap: '0',
+        volume: '0',
+        changePercent24Hr: '0',
+      }
       acc.push({ ...assetData, ...marketDataForAsset })
       return acc
     }, [])

--- a/src/state/apis/fiatRamps/selectors.ts
+++ b/src/state/apis/fiatRamps/selectors.ts
@@ -8,7 +8,6 @@ import { fiatRampApi } from './fiatRamps'
 
 import { createDeepEqualOutputSelector } from '@/state/selector-utils'
 import { selectAssetIdParamFromFilter } from '@/state/selectors'
-import { defaultMarketData } from '@/state/slices/marketDataSlice/marketDataSlice'
 import { selectAssets, selectMarketDataUserCurrency } from '@/state/slices/selectors'
 
 export const selectFiatBuyAssetIds = createDeepEqualOutputSelector(
@@ -39,7 +38,7 @@ export const selectFiatRampBuyAssetsWithMarketData = createSelector(
     return assetIds.reduce<AssetWithMarketData[]>((acc, assetId) => {
       const assetData = assetsById[assetId]
       if (!assetData) return acc
-      const marketDataForAsset = marketData[assetId] ?? defaultMarketData
+      const marketDataForAsset = marketData[assetId]
       acc.push({ ...assetData, ...marketDataForAsset })
       return acc
     }, [])

--- a/src/state/slices/marketDataSlice/marketDataSlice.tsx
+++ b/src/state/slices/marketDataSlice/marketDataSlice.tsx
@@ -46,13 +46,6 @@ export const initialState: MarketDataState = {
   isMarketDataLoaded: false,
 }
 
-export const defaultMarketData: MarketData = {
-  price: '0',
-  marketCap: '0',
-  volume: '0',
-  changePercent24Hr: 0,
-}
-
 type CryptoPriceHistoryPayload = {
   timeframe: HistoryTimeframe
   historyDataByAssetId: Record<AssetId, HistoryData[]>

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -3,7 +3,7 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import type { HistoryData, HistoryTimeframe, MarketData } from '@shapeshiftoss/types'
 import createCachedSelector from 're-reselect'
 
-import { defaultMarketData, marketData } from './marketDataSlice'
+import { marketData } from './marketDataSlice'
 import type { MarketDataById } from './types'
 import { getTrimmedOutOfBoundsMarketData } from './utils'
 
@@ -65,16 +65,16 @@ const selectAssetId = (_state: ReduxState, assetId: AssetId) => assetId
 export const selectMarketDataByAssetIdUserCurrency = createCachedSelector(
   selectMarketDataUserCurrency,
   selectAssetId,
-  (marketData, assetId): MarketData => {
-    return marketData[assetId] ?? defaultMarketData
+  (marketData, assetId): MarketData | undefined => {
+    return marketData[assetId]
   },
 )((_state: ReduxState, assetId?: AssetId): AssetId => assetId ?? 'assetId')
 
 export const selectMarketDataByFilter = createCachedSelector(
   selectMarketDataUserCurrency,
   selectAssetIdParamFromFilter,
-  (marketData, assetId): MarketData => {
-    return marketData[assetId ?? ''] ?? defaultMarketData
+  (marketData, assetId): MarketData | undefined => {
+    return marketData[assetId ?? '']
   },
 )((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 

--- a/src/state/slices/marketDataSlice/selectors.ts
+++ b/src/state/slices/marketDataSlice/selectors.ts
@@ -78,14 +78,6 @@ export const selectMarketDataByFilter = createCachedSelector(
   },
 )((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 
-export const selectMarketDataNullableByFilter = createCachedSelector(
-  selectMarketDataUserCurrency,
-  selectAssetIdParamFromFilter,
-  (marketData, assetId): MarketData | undefined => {
-    return marketData[assetId ?? '']
-  },
-)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
-
 const selectTimeframeParam = (_state: ReduxState, timeframe: HistoryTimeframe) => timeframe
 
 export const selectCryptoPriceHistoryTimeframe = createSelector(

--- a/src/state/slices/marketDataSlice/types.ts
+++ b/src/state/slices/marketDataSlice/types.ts
@@ -14,7 +14,7 @@ export type PriceHistoryByTimeframe<T extends SupportedFiatCurrencies | AssetId>
 
 export type MarketDataById<T extends SupportedFiatCurrencies | AssetId> = PartialRecord<
   T,
-  MarketData
+  MarketData | undefined
 >
 
 export type MarketDataStateVariant<T extends SupportedFiatCurrencies | AssetId> = {

--- a/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
@@ -64,7 +64,7 @@ export const ethFoxStakingMetadataResolver = async ({
   const totalSupply = await foxFarmingContract.read.totalSupply()
   const tvl = bnOrZero(totalSupply.toString())
     .div(bn(10).pow(lpAssetPrecision))
-    .times(lpTokenPrice)
+    .times(bnOrZero(lpTokenPrice))
     .toFixed(2)
 
   // apr
@@ -77,8 +77,8 @@ export const ethFoxStakingMetadataResolver = async ({
   const lpTotalSupply = (await uniV2LPContract.read.totalSupply()).toString()
   const foxReserves = bnOrZero(bnOrZero(reserves[1].toString()).toString())
   const ethReserves = bnOrZero(bnOrZero(reserves[0].toString()).toString())
-  const ethPoolRatio = ethReserves.div(lpTotalSupply).toString()
-  const foxPoolRatio = foxReserves.div(lpTotalSupply).toString()
+  const ethPoolRatio = ethReserves.div(bnOrZero(lpTotalSupply)).toString()
+  const foxPoolRatio = foxReserves.div(bnOrZero(lpTotalSupply)).toString()
 
   const totalSupplyV2 = await uniV2LPContract.read.totalSupply()
 

--- a/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/ethFoxStaking/index.ts
@@ -9,7 +9,6 @@ import {
   fetchUniV2PairData,
   getOrCreateContractByAddress,
 } from '@shapeshiftoss/contracts'
-import type { MarketData } from '@shapeshiftoss/types'
 import dayjs from 'dayjs'
 import { getAddress } from 'viem'
 
@@ -46,10 +45,7 @@ export const ethFoxStakingMetadataResolver = async ({
   const state: any = getState() // ReduxState causes circular dependency
   const assets: AssetsState = state.assets
   const lpAssetPrecision = assets.byId[foxEthLpAssetId]?.precision ?? 0
-  const lpTokenMarketData: MarketData = selectMarketDataByAssetIdUserCurrency(
-    state,
-    foxEthLpAssetId,
-  )
+  const lpTokenMarketData = selectMarketDataByAssetIdUserCurrency(state, foxEthLpAssetId)
   const lpTokenPrice = lpTokenMarketData?.price
 
   const { assetReference: contractAddress } = fromAssetId(opportunityId)
@@ -137,10 +133,7 @@ export const ethFoxStakingUserDataResolver = async ({
 }: OpportunityUserDataResolverInput): Promise<{ data: GetOpportunityUserStakingDataOutput }> => {
   const { getState } = reduxApi
   const state: any = getState() // ReduxState causes circular dependency
-  const lpTokenMarketData: MarketData = selectMarketDataByAssetIdUserCurrency(
-    state,
-    foxEthLpAssetId,
-  )
+  const lpTokenMarketData = selectMarketDataByAssetIdUserCurrency(state, foxEthLpAssetId)
   const lpTokenPrice = lpTokenMarketData?.price
 
   const { assetReference } = fromAssetId(opportunityId)

--- a/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/foxy/index.ts
@@ -67,7 +67,7 @@ export const foxyStakingOpportunitiesMetadataResolver = async ({
 
     const tvl = bnOrZero(opportunity.tvl)
       .div(`1e+${underlyingAsset?.precision}`)
-      .times(marketData.price)
+      .times(bnOrZero(marketData?.price))
       .toString()
 
     const apy = foxyApr.data?.foxyApr ?? '0'

--- a/src/state/slices/opportunitiesSlice/resolvers/rFOX/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/rFOX/index.ts
@@ -1,7 +1,6 @@
 import { fromAccountId, fromAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
-import { bn } from '@shapeshiftoss/chain-adapters'
+import { bn, bnOrZero } from '@shapeshiftoss/chain-adapters'
 import { RFOX_PROXY_CONTRACT, viemClientByNetworkId } from '@shapeshiftoss/contracts'
-import type { MarketData } from '@shapeshiftoss/types'
 import { fromBaseUnit } from '@shapeshiftoss/utils'
 import { erc20Abi, getAddress } from 'viem'
 import { readContract } from 'viem/actions'
@@ -37,10 +36,7 @@ export const rFOXStakingMetadataResolver = async ({
 
   const stakingAsset = selectAssetById(state, opportunityId)
 
-  const stakingAssetMarketData: MarketData = selectMarketDataByAssetIdUserCurrency(
-    state,
-    opportunityId,
-  )
+  const stakingAssetMarketData = selectMarketDataByAssetIdUserCurrency(state, opportunityId)
 
   const contractData = await readContract(client, {
     abi: erc20Abi,
@@ -50,7 +46,7 @@ export const rFOXStakingMetadataResolver = async ({
   })
 
   const tvl = bn(fromBaseUnit(contractData.toString(), stakingAsset?.precision ?? 0))
-    .times(stakingAssetMarketData.price)
+    .times(bnOrZero(stakingAssetMarketData?.price))
     .toFixed(2)
 
   const underlyingAssetIds = [opportunityId]

--- a/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
+++ b/src/state/slices/opportunitiesSlice/resolvers/thorchainsavers/index.ts
@@ -154,11 +154,13 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
     const apy = bnOrZero(
       midgardPools.find(pool => pool.asset === thorchainPool.asset)?.saversAPR,
     ).toString()
-    const tvl = fromThorBaseUnit(thorchainPool.synth_supply).times(marketData.price).toFixed()
+    const tvl = fromThorBaseUnit(thorchainPool.synth_supply)
+      .times(bnOrZero(marketData?.price))
+      .toFixed()
     const saversMaxSupplyUserCurrency = fromThorBaseUnit(
       bnOrZero(thorchainPool.synth_supply).plus(thorchainPool.synth_supply_remaining),
     )
-      .times(marketData.price)
+      .times(bnOrZero(marketData?.price))
       .toFixed()
 
     const underlyingAssetRatioBaseUnit = bn(1).times(bn(10).pow(asset.precision)).toString()
@@ -279,7 +281,7 @@ export const thorchainSaversStakingOpportunitiesMetadataResolver = async ({
       id: thorchainAssetId as StakingId,
       provider: DefiProvider.ThorchainSavers,
       tvl: fromThorBaseUnit(runepoolInformation.providers.value)
-        .times(runeMarketData.price)
+        .times(bnOrZero(runeMarketData?.price))
         .toFixed(),
       type: DefiType.Staking,
       underlyingAssetId: thorchainAssetId,

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -25,7 +25,7 @@ import { store } from '@/state/store'
 export const getHopTotalNetworkFeeUserCurrency = (
   networkFeeCryptoBaseUnit: string | undefined,
   feeAsset: Asset,
-  getFeeAssetUserCurrencyRate: (feeAssetId: AssetId) => string,
+  getFeeAssetUserCurrencyRate: (feeAssetId: AssetId) => string | undefined,
 ): BigNumber | undefined => {
   const feeAssetUserCurrencyRate = getFeeAssetUserCurrencyRate(feeAsset.assetId)
 
@@ -33,7 +33,7 @@ export const getHopTotalNetworkFeeUserCurrency = (
 
   const networkFeeFiatPrecision = bnOrZero(
     fromBaseUnit(networkFeeCryptoBaseUnit, feeAsset.precision),
-  ).times(feeAssetUserCurrencyRate)
+  ).times(bnOrZero(feeAssetUserCurrencyRate))
 
   return networkFeeFiatPrecision
 }
@@ -48,7 +48,7 @@ export const getHopTotalNetworkFeeUserCurrency = (
 export const getTotalNetworkFeeUserCurrencyPrecision = (
   quote: TradeQuote | TradeRate,
   getFeeAsset: (assetId: AssetId) => Asset,
-  getFeeAssetRate: (feeAssetId: AssetId) => string,
+  getFeeAssetRate: (feeAssetId: AssetId) => string | undefined,
 ): BigNumber | undefined => {
   // network fee is unknown, which is different than it being akschual 0
   if (quote.steps.every(step => !step.feeData.networkFeeCryptoBaseUnit)) return
@@ -79,7 +79,7 @@ const getNetworkFeeUserCurrency = (quote: TradeQuote | TradeRate | undefined): B
   const getFeeAssetUserCurrencyRate = (feeAssetId: AssetId) =>
     selectMarketDataByFilter(state, {
       assetId: feeAssetId,
-    }).price
+    })?.price
 
   return (
     getTotalNetworkFeeUserCurrencyPrecision(quote, getFeeAsset, getFeeAssetUserCurrencyRate) ??


### PR DESCRIPTION
## Description

Does what it says on the title - stop using 0d out market-data and leverage nullable market-data instead. 
Main benefit of this is this makes detecting *lack* of market-data easier, which is impossible currently. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to https://github.com/shapeshift/web/issues/8686

## Risk

Medium - theoretically, no runtime changes except selectors won't return default market-data with zero'd out fields, which is now handled at view layer by `bnOrZero()`ing out in all call sites (tyvm TS).

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?


## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

Do a general regression test of the market-data across the app and ensure there are no regressoins (no crashes, no weird zero'd out values or wrong ones) 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ☝🏽 
- Scrutinize this line by line and ensure no weird shenanigans (LLMs used here though with many, many manual passes and line-by-line self-review but I may have missed some!)

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ☝🏽 

## Screenshots (if applicable)

https://jam.dev/c/5882c7bc-077a-4fa0-9655-ef8109d29bb4

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
