### PR TITLE
chore: fixing the discounts sentence on the fox page

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2898,7 +2898,7 @@
   },
   "foxPage": {
     "title": "FOX Token Dashboard",
-    "description": "Since 2019, our shapeshifting FOX Token has been offering users an ever-expanding world of utility and advantages. Today, our ERC-20 governance token gives you fee discounts, a share in revenues on THORChain, and enables you to influence the future of ShapeShift through your vote. Stake, swap, buy, supply, and manage your FOX holdings here.",
+    "description": "Since 2019, our shapeshifting FOX Token has been offering users an ever-expanding world of utility and advantages. Today, our ERC-20 governance token gives you a share in revenues on THORChain, and enables you to influence the future of ShapeShift through your vote. Stake, swap, buy, supply, and manage your FOX holdings here.",
     "foxToken": "FOX Token",
     "24hrPriceChange": "24h Price Change",
     "rfox": {


### PR DESCRIPTION
## Description

This fixes a copy snafu on the fox page now that 55 bps has been passed and merged. I checked with @firebomb1 and deleting the string isn't necessary on edits, there is a script to flag key changes that translators will fix. Hopefully is all good. Happy to delete the keys though if that's preferred.

## Issue (if applicable)

closes no issue. just some spotted copy problem.

## Risk

none

## Testing
Fire up local and give it a read. 

### Engineering

At some point double check copy makes sense on a local build. 

### Operations

Doubel check, dev matches local and words good. 

## Screenshots (if applicable)

![Screenshot 2025-05-19 at 3 03 59 PM](https://github.com/user-attachments/assets/e3119814-ccf7-4884-9cf9-63d8af326308)