### PR TITLE
fix: fox farming deposit

### DIFF
--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx
@@ -1,6 +1,5 @@
 import { Center, useToast } from '@chakra-ui/react'
 import type { AccountId } from '@shapeshiftoss/caip'
-import { toAssetId } from '@shapeshiftoss/caip'
 import qs from 'qs'
 import { useCallback, useEffect, useMemo, useReducer } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -31,7 +30,6 @@ import { toOpportunityId } from '@/state/slices/opportunitiesSlice/utils'
 import {
   selectAggregatedEarnUserStakingOpportunityByStakingId,
   selectIsPortfolioLoading,
-  selectMarketDataByAssetIdUserCurrency,
 } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -47,10 +45,7 @@ export const FoxFarmingDeposit: React.FC<FoxFarmingDepositProps> = ({
   const translate = useTranslate()
   const toast = useToast()
   const { query, location } = useBrowserRouter<DefiQueryParams, DefiParams>()
-  const { assetNamespace, chainId, contractAddress, assetReference } = query
-
-  const assetId = toAssetId({ chainId, assetNamespace, assetReference })
-  const marketData = useAppSelector(state => selectMarketDataByAssetIdUserCurrency(state, assetId))
+  const { assetNamespace, chainId, contractAddress } = query
 
   const { farmingAccountId } = useFoxEth()
 
@@ -118,7 +113,7 @@ export const FoxFarmingDeposit: React.FC<FoxFarmingDepositProps> = ({
     }
   }, [translate, contractAddress, accountId, handleAccountIdChange])
 
-  if (loading || !marketData || !foxFarmingOpportunity || !StepConfig) {
+  if (loading || !foxFarmingOpportunity || !StepConfig) {
     return (
       <Center minW='350px' minH='350px'>
         <CircularProgress />


### PR DESCRIPTION
## Description

Fixes the fox farming deposit modal, which unblocks release https://github.com/shapeshift/web/pull/9578

We were checking if we had market data for the Evergreen staking contract (`0xe7e16e2b05440c2e484c5c41ac3e5a4d15da2744`), which we never will have. Since `selectMarketDataByAssetIdUserCurrency` can now return `undefined` (as of https://github.com/shapeshift/web/pull/9576), the following line was returning: 

https://github.com/shapeshift/web/blob/04da10e73aea59bc8fd00b84f7952375d061c827/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/FoxFarmingDeposit.tsx#L121-L127

This PR removes the market data check, as a) it never worked, and b) `src/features/defi/components/Deposit/Deposit.tsx` can handle `undefined` market data.

To cherry-pick into release.

## Issue (if applicable)

- https://jam.dev/c/55c8979d-f974-421c-8e69-4dcfa893c877
- https://discord.com/channels/554694662431178782/1374189111988060271/1374213534455435358
- Regression from https://github.com/shapeshift/web/pull/9576

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Ensure the FOX farming deposit modal opens and works.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A