### PR TITLE
fix: dashboard don't open wallet modal while local wallet is loading

### DIFF
--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -79,14 +79,15 @@ export const Dashboard = memo(() => {
 
   const {
     dispatch: walletDispatch,
-    state: { isConnected },
+    state: { isLoadingLocalWallet, isConnected },
   } = useWallet()
 
   useEffect(() => {
+    if (isLoadingLocalWallet) return
     if (isConnected) return
 
     walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-  }, [isConnected, walletDispatch])
+  }, [isLoadingLocalWallet, isConnected, walletDispatch])
 
   const handleSlideIndexChange = useCallback(
     (index: number) => {


### PR DESCRIPTION
## Description

Looks like we're not too fast, and local wallet loading (and eventually, `SET_IS_CONNECTED` true) will happen *after* the wallet modal has been fired. 
This fixes it by not firing the modal while the local wallet is loading.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9291

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to wallet page with a connected EVM wallet
- Refresh
- Ensure that the wallet modal doesn't pop up in the interim where the local wallet is loading (warning icon in wallet menu)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/3481bc05-d366-4e21-b8ac-78dcffc8b491

- this diff

https://jam.dev/c/8debaf25-3c9c-4b00-8bce-ac60db364cc3


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
