### PR TITLE
fix: tcy sends

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -200,7 +200,9 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
   ): Promise<{ txToSign: ThorchainSignTx }> {
     try {
       const { sendMax, to, value, from, chainSpecific } = input
-      const { fee } = chainSpecific
+      const { coin = 'THOR.RUNE', fee } = chainSpecific
+
+      if (coin !== 'THOR.RUNE' && coin !== 'THOR.TCY') throw new Error('unsupported coin type')
 
       if (!fee) throw new Error('fee is required')
 
@@ -210,7 +212,7 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
       const msg: ThorchainMsgSend = {
         type: ThorchainMessageType.MsgSend,
         value: {
-          amount: [{ amount, denom: this.denom }],
+          amount: [{ amount, denom: coin === 'THOR.TCY' ? 'tcy' : this.denom }],
           from_address: from,
           to_address: to,
         },

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -1,5 +1,5 @@
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { CHAIN_NAMESPACE, fromAccountId, fromChainId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, fromAccountId, fromChainId, tcyAssetId } from '@shapeshiftoss/caip'
 import type {
   BuildSendTxInput,
   FeeData,
@@ -213,7 +213,11 @@ export const handleSend = async ({
         value,
         wallet,
         accountNumber,
-        chainSpecific: { gas: fees.chainSpecific.gasLimit, fee: fees.txFee },
+        chainSpecific: {
+          gas: fees.chainSpecific.gasLimit,
+          fee: fees.txFee,
+          ...(sendInput.assetId === tcyAssetId ? { coin: 'THOR.TCY' } : {}),
+        },
         sendMax: sendInput.sendMax,
       }
       const adapter = assertGetCosmosSdkChainAdapter(chainId)


### PR DESCRIPTION
## Description

Ensures tcy sends uses the `tcy` denom, failure to do so means RUNE will be sent instead, as it does currently

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9593


## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, only risk is RUNE sends being borked, though realistically v. low risk of that, test accordingly

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- TCY sends actually send TCY
- RUNE sends are still happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/d9ee2520-a600-46d7-8751-0a9109072f10


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
