### PR TITLE
fix: useIsSnapInstalled go stale immediately

### DIFF
--- a/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
+++ b/src/hooks/useIsSnapInstalled/useIsSnapInstalled.tsx
@@ -76,8 +76,8 @@ export const useIsSnapInstalled = (): {
     queryKey: ['snapInstallation', connectedRdns, isConnected],
     queryFn: checkSnapInstallation,
     refetchInterval: POLL_INTERVAL,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 5 * 60 * 1000, // 5 minutes
+    staleTime: 0,
+    gcTime: 0,
   })
 
   return snapInstallation


### PR DESCRIPTION
## Description

Fixes the very edge, but very valid case of connecting with snap installed, disconnecting, then uninstalling the snap while in disconnected state which produces a wrong "snap uninstalled" modal on reconnect.
The reason was despite us polling (good) we were also having garbage collect and stale time (wrong) which means that things could be wrong for a few seconds/render. Not an issue in most cases, but actually an issue here.
Fixed by making us go stale immediately (react-query's default) and having no garbage collect - this was effectively useless either way as we're not really concerned about caching/gc since we poll so often either way.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9357

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connecting MM with snap installed, disconnecting, then uninstalling the snap while in disconnected state should *not* pop up a "Snap Uninstalled" modal
- Snap installed detection should still be happy
- Snap uninstallation detection should still be happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^


## Screenshots (if applicable)

https://jam.dev/c/5296ebee-e0e9-4878-92be-5b3bfa8c006a


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
