### PR TITLE
fix: don't display MAYA balance as CACAO

### DIFF
--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -49,7 +49,6 @@ export const cosmosAssetId: AssetId = 'cosmos:cosmoshub-4/slip44:118'
 export const thorchainAssetId: AssetId = 'cosmos:thorchain-1/slip44:931'
 export const tcyAssetId: AssetId = 'cosmos:thorchain-1/slip44:tcy'
 export const mayachainAssetId: AssetId = 'cosmos:mayachain-mainnet-v1/slip44:931'
-export const mayaTokenAssetId: AssetId = 'cosmos:mayachain-mainnet-v1/slip44:maya'
 export const binanceAssetId: AssetId = 'cosmos:binance-chain-tigris/slip44:714'
 
 export const btcChainId: ChainId = 'bip122:000000000019d6689c085ae165831e93'

--- a/packages/caip/src/constants.ts
+++ b/packages/caip/src/constants.ts
@@ -49,6 +49,7 @@ export const cosmosAssetId: AssetId = 'cosmos:cosmoshub-4/slip44:118'
 export const thorchainAssetId: AssetId = 'cosmos:thorchain-1/slip44:931'
 export const tcyAssetId: AssetId = 'cosmos:thorchain-1/slip44:tcy'
 export const mayachainAssetId: AssetId = 'cosmos:mayachain-mainnet-v1/slip44:931'
+export const mayaTokenAssetId: AssetId = 'cosmos:mayachain-mainnet-v1/slip44:maya'
 export const binanceAssetId: AssetId = 'cosmos:binance-chain-tigris/slip44:714'
 
 export const btcChainId: ChainId = 'bip122:000000000019d6689c085ae165831e93'

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -4,7 +4,9 @@ import type { AssetId } from './assetId/assetId'
 import { fromAssetId, toAssetId } from './assetId/assetId'
 import type { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 import * as constants from './constants'
-import { mayaTokenAssetId, tcyAssetId } from './constants'
+import { tcyAssetId } from './constants'
+
+const mayaTokenAssetId: AssetId = 'cosmos:mayachain-mainnet-v1/slip44:maya'
 
 export const accountIdToChainId = (accountId: AccountId): ChainId =>
   fromAccountId(accountId).chainId

--- a/packages/caip/src/utils.ts
+++ b/packages/caip/src/utils.ts
@@ -4,7 +4,7 @@ import type { AssetId } from './assetId/assetId'
 import { fromAssetId, toAssetId } from './assetId/assetId'
 import type { ChainId, ChainNamespace, ChainReference } from './chainId/chainId'
 import * as constants from './constants'
-import { tcyAssetId } from './constants'
+import { mayaTokenAssetId, tcyAssetId } from './constants'
 
 export const accountIdToChainId = (accountId: AccountId): ChainId =>
   fromAccountId(accountId).chainId
@@ -22,6 +22,7 @@ export const generateAssetIdFromCosmosSdkDenom = (
   nativeAssetId: AssetId,
 ): AssetId => {
   if (denom === 'tcy') return tcyAssetId
+  if (denom === 'maya') return mayaTokenAssetId
   if (denom.startsWith('ibc')) {
     return toAssetId({
       assetNamespace: constants.ASSET_NAMESPACE.ibc,


### PR DESCRIPTION
## Description

Fixes MAYA balance wrongly being detected as CACAO

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9609

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test this while holding both MAYA and CACAO
- CACAO balance matches explorer

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="1728" alt="Image" src="https://github.com/user-attachments/assets/befcadf3-6ef9-4830-9c62-50aff67b523f" />


- this diff

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a63de428-eca1-4eed-94e2-b1c23d083793" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
