### PR TITLE
fix: diff and zero out balances when upserting to portfolio

### DIFF
--- a/src/state/slices/portfolioSlice/portfolioSlice.ts
+++ b/src/state/slices/portfolioSlice/portfolioSlice.ts
@@ -131,14 +131,14 @@ export const portfolio = createSlice({
       draftState.accounts.ids = Object.keys(draftState.accounts.byId)
 
       // Handle account balances
-      Object.entries(payload.accountBalances.byId).forEach(([accountId, balances]) => {
+      Object.entries(payload.accountBalances.byId).forEach(([accountId, payloadBalances]) => {
         if (!draftState.accountBalances.byId[accountId]) {
           draftState.accountBalances.byId[accountId] = {}
         }
 
         const missingAssetIds = difference(
           Object.keys(draftState.accountBalances.byId[accountId]),
-          Object.keys(balances),
+          Object.keys(payloadBalances),
         )
 
         // Zero out missing assets
@@ -150,7 +150,7 @@ export const portfolio = createSlice({
         draftState.accountBalances.byId[accountId] = {
           ...draftState.accountBalances.byId[accountId],
           ...zeroedBalances,
-          ...balances,
+          ...payloadBalances,
         }
       })
 


### PR DESCRIPTION
## Description

We were not diffing assets when upserting to portfolio, for IBC chains, those assets are not returned from unchained, meaning we were not zeroing out unexisting balances from the portfolio slice

Check when upserting if the balance is existing in the actual slice, if it's existing but the asset is not returned by unchained, zero out this balance!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9624

## Risk
Medium 

This could involve risks of balances not updated or maybe some potential performances issues if we loop over a big list of balances for no reasons
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to do anything with your balances, unstake something stake something (tcy for example, stake some fox, play with your balance)
No regressions on the balance update should be found after this PR, sending, swapping...
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/c11835c0-016c-4a52-91da-2716da5b9e47