### PR TITLE
bug: fixing strange padding on the trade settings gear

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -144,6 +144,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
                 icon={faGear}
                 variant='ghost'
                 minWidth={0}
+                padding={2}
                 isDisabled={isDisabled}
               />
             </PopoverTrigger>


### PR DESCRIPTION
## Description

Fixed the padding on the gear icon for swapper settings; it was missing declared padding. Tried our flex shrink but yeah the damn thing just needed some love. 

## Issue (if applicable)

closes #9649 

## Risk

Low risk, button still works and looks normal now.

## Testing

Run it locally and it should work as expected. 

### Engineering

As above

### Operations

When we go to release just another set of eyes if the gear looks normal. 

## Screenshots (if applicable)

![Screenshot 2025-06-02 at 11 10 13 PM](https://github.com/user-attachments/assets/c9bc2bbe-b4ed-4921-bb88-c661df735214)

