### PR TITLE
fix: tcy claim cta label wrapping

### DIFF
--- a/src/pages/TCY/components/TCYCta.tsx
+++ b/src/pages/TCY/components/TCYCta.tsx
@@ -11,6 +11,9 @@ import { AssetIcon } from '@/components/AssetIcon'
 import { selectIsPortfolioLoading } from '@/state/slices/selectors'
 
 const margin = { base: 4, md: 0 }
+const buttonMaxW = { base: '120px', md: 'none' }
+const buttonPx = { base: 3, md: 4 }
+const buttonPy = { base: 3, md: 2 }
 
 const CtaSkeleton = () => {
   return (
@@ -43,7 +46,16 @@ export const TCYCta = () => {
       <Stack spacing={0} ml={4}>
         <AlertTitle>{translate(hasClaims ? 'TCY.cta.hasClaimsTitle' : 'TCY.cta.title')}</AlertTitle>
       </Stack>
-      <Button ml='auto' flexShrink={0} onClick={handleClick}>
+      <Button
+        ml='auto'
+        flexShrink={0}
+        onClick={handleClick}
+        whiteSpace='normal'
+        height='auto'
+        maxW={buttonMaxW}
+        px={buttonPx}
+        py={buttonPy}
+      >
         {translate('TCY.cta.button')}
       </Button>
     </Alert>


### PR DESCRIPTION
## Description

Fixes the label of the button for the TCY Claims CTA on lower resolutions to allow wrapping and better sizing (especially for more verbose translations).

@reallybeard could you please validate the change?  It's relatively local so it won't affect other parts of the app's styling.

## Risk

Low.

> High Risk PRs Require 2 approvals

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing
Check the button appearance and functionality in English and other languages.

### Engineering
☝️ 

### Operations
☝️ 

## Screenshots (if applicable)
### Before (en/fr):
![image](https://github.com/user-attachments/assets/6cd000a4-78f4-4dfe-b400-9738e92e3c0b)
![image](https://github.com/user-attachments/assets/b672c946-32b7-418d-b091-a858e99da00b)

### After (en/fr):
![image](https://github.com/user-attachments/assets/2d3ce6a4-5936-4443-80d1-73a69849c439)
![image](https://github.com/user-attachments/assets/fc3683bf-92cc-4652-9ec7-973f7253efca)
![image](https://github.com/user-attachments/assets/90a44cc5-d1b1-4cdc-b7ee-0ff25bbf73f8)
