### PR TITLE
feat: auto validate external address on input

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedRecipientAddress.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedRecipientAddress.tsx
@@ -1,4 +1,4 @@
-import { CheckIcon, CloseIcon, EditIcon } from '@chakra-ui/icons'
+import { CloseIcon, EditIcon } from '@chakra-ui/icons'
 import {
   FormControl,
   FormLabel,
@@ -14,7 +14,6 @@ import {
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import type { FieldValues } from 'react-hook-form'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 
@@ -39,7 +38,6 @@ import { parseAddressInputWithChainId } from '@/lib/address/address'
 import { middleEllipsis } from '@/lib/utils'
 
 const editIcon = <EditIcon />
-const checkIcon = <CheckIcon />
 const closeIcon = <CloseIcon />
 
 const iconButtonHoverSx = { bg: 'gray.600' }
@@ -146,7 +144,6 @@ export const SharedRecipientAddress = ({
   const {
     formState: { isValidating, isValid },
     setValue: setFormValue,
-    handleSubmit: handleFormContextSubmit,
     trigger,
   } = useFormContext()
 
@@ -233,21 +230,6 @@ export const SharedRecipientAddress = ({
     setFormValue(SendFormFields.Input, '')
   }, [onReset, setFormValue])
 
-  const handleSubmit = useCallback(
-    (values: FieldValues) => {
-      // We don't need to revalidate here as submit will only be enabled if the form is valid
-      const address = values[SendFormFields.Input].trim()
-      onSubmit(address)
-      setIsRecipientAddressEditing(false)
-    },
-    [onSubmit],
-  )
-
-  const handleFormSubmit = useMemo(
-    () => handleFormContextSubmit(handleSubmit),
-    [handleFormContextSubmit, handleSubmit],
-  )
-
   const shouldForceDisplayManualAddressEntry = useIsManualReceiveAddressRequired({
     shouldForceManualAddressEntry: Boolean(shouldForceManualAddressEntry),
     sellAccountId: sellAssetAccountId,
@@ -305,19 +287,6 @@ export const SharedRecipientAddress = ({
             justifyContent='flex-end'
             pointerEvents='none'
           >
-            <IconButton
-              pointerEvents='auto'
-              color='green.500'
-              aria-label='Save'
-              isDisabled={!isValid || isValidating || !value?.length}
-              size='xs'
-              onClick={handleFormSubmit}
-              icon={checkIcon}
-              isLoading={isValidating}
-              borderRadius='full'
-              bg='gray.700'
-              _hover={iconButtonHoverSx}
-            />
             <IconButton
               pointerEvents='auto'
               color='red.500'


### PR DESCRIPTION
## Description

Revalidate address on change, it fixes two things:
- if you paste your address, the UX is way better as it's your address, it's instant validated and you don't have to click on anything
- If the user enter a wrong address, he can modify it and it will be revalidated, previously it was buggy as the validate button was disabled, now it's revalidated automatically

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #8378

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Past a manual receive address
- or type it manually
- It will be auto validated and ready to use!
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/e3dd108f-3e20-4ce8-880e-c3207048bae8