### PR TITLE
fix: enable action center toasts only if the feature flag is enabled

### DIFF
--- a/src/hooks/useActionCenterSubscriber/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscriber/useSwapActionSubscriber.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo } from 'react'
 import { TbCircleCheckFilled, TbCircleXFilled } from 'react-icons/tb'
 import { useTranslate } from 'react-polyglot'
 
+import { useFeatureFlag } from '../useFeatureFlag/useFeatureFlag'
 import { fetchIsSmartContractAddressQuery } from '../useIsSmartContractAddress/useIsSmartContractAddress'
 import { useLocaleFormatter } from '../useLocaleFormatter/useLocaleFormatter'
 import { useWallet } from '../useWallet/useWallet'
@@ -41,6 +42,7 @@ export const useSwapActionSubscriber = ({ onDrawerOpen }: UseSwapActionSubscribe
   const dispatch = useAppDispatch()
   const translate = useTranslate()
   const toastColor = useColorModeValue('white', 'gray.900')
+  const isActionCenterEnabled = useFeatureFlag('ActionCenter')
 
   const {
     number: { toCrypto },
@@ -267,10 +269,12 @@ export const useSwapActionSubscriber = ({ onDrawerOpen }: UseSwapActionSubscribe
                   }),
                 )
 
-                toast({
-                  title: notificationTitle,
-                  status: 'success',
-                })
+                if (isActionCenterEnabled) {
+                  toast({
+                    title: notificationTitle,
+                    status: 'success',
+                  })
+                }
                 return
               }
             }
@@ -297,10 +301,12 @@ export const useSwapActionSubscriber = ({ onDrawerOpen }: UseSwapActionSubscribe
               swapId: swap.id,
             })?.title
 
-            toast({
-              title: notificationTitle,
-              status: 'success',
-            })
+            if (isActionCenterEnabled) {
+              toast({
+                title: notificationTitle,
+                status: 'success',
+              })
+            }
 
             return
           }
@@ -344,10 +350,12 @@ export const useSwapActionSubscriber = ({ onDrawerOpen }: UseSwapActionSubscribe
           }),
         )
 
-        toast({
-          title: notificationTitle,
-          status: 'success',
-        })
+        if (isActionCenterEnabled) {
+          toast({
+            title: notificationTitle,
+            status: 'success',
+          })
+        }
       }
 
       if (status === TxStatus.Failed) {
@@ -368,10 +376,12 @@ export const useSwapActionSubscriber = ({ onDrawerOpen }: UseSwapActionSubscribe
           }),
         )
 
-        toast({
-          title: translate('notificationCenter.swapError'),
-          status: 'error',
-        })
+        if (isActionCenterEnabled) {
+          toast({
+            title: translate('notificationCenter.swapError'),
+            status: 'error',
+          })
+        }
       }
 
       return {
@@ -380,7 +390,7 @@ export const useSwapActionSubscriber = ({ onDrawerOpen }: UseSwapActionSubscribe
         buyTxHash,
       }
     },
-    [toCrypto, translate, toast, dispatch],
+    [toCrypto, translate, toast, dispatch, isActionCenterEnabled],
   )
 
   // Update actions status when swap is confirmed or failed


### PR DESCRIPTION
## Description

Those toasts are not production ready, we don't want to show them if the feature flag is disabled (this is currently in production and feels not polished at all)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Found while talking with 🐐 

## Risk
Low

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- No swap toast if the action center flag is disabled
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/e76796a6-5ca3-48fb-9c67-7f09150dbee0