### PR TITLE
fix: dApp modal sizing issue (#9565)

### DIFF
--- a/src/plugins/walletConnectToDapps/components/header/ConnectDapp.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/ConnectDapp.tsx
@@ -9,7 +9,6 @@ import { isSome } from '@/lib/utils'
 import { ConnectModal } from '@/plugins/walletConnectToDapps/components/modals/connect/Connect'
 import { useWalletConnectV2 } from '@/plugins/walletConnectToDapps/WalletConnectV2Provider'
 
-const widthProp = { base: 'full', md: 'auto' }
 const walletConnectIcon = <WalletConnectIcon />
 const chevronRightIcon = <ChevronRightIcon />
 
@@ -30,7 +29,6 @@ export const WalletConnectButtons = (buttonProps?: ButtonProps) => {
           leftIcon={walletConnectIcon}
           rightIcon={chevronRightIcon}
           onClick={handleOpen}
-          width={widthProp}
           {...buttonProps}
         >
           {hasSessions

--- a/src/plugins/walletConnectToDapps/components/header/WalletConnectToDappsHeaderButton.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/WalletConnectToDappsHeaderButton.tsx
@@ -16,8 +16,7 @@ import { DappHeaderMenuSummary } from '@/plugins/walletConnectToDapps/components
 import { useWalletConnectV2 } from '@/plugins/walletConnectToDapps/WalletConnectV2Provider'
 
 const paddingProp = { base: 0, md: '20px' }
-const maxWidthProp = { base: '280px', md: 'xs' }
-const minWidthProp = { base: 0, md: 'xs' }
+const menuWidthProp = { base: '355px', md: 'xs' }
 const widthProp = { base: 'full', md: 'auto' }
 
 const WalletConnectV2ConnectedButtonText = ({
@@ -99,14 +98,7 @@ const WalletConnectV2ConnectedButton = memo(() => {
           />
         )}
       </MenuButton>
-      <MenuList
-        zIndex='banner'
-        maxWidth={maxWidthProp}
-        minWidth={minWidthProp}
-        display='flex'
-        flexDir='column'
-        pb={0}
-      >
+      <MenuList zIndex='banner' width={menuWidthProp} display='flex' flexDir='column' pb={0}>
         <DappHeaderMenuSummary />
       </MenuList>
     </Menu>


### PR DESCRIPTION
## Description

I've modified the width settings of both the dApp menu popover and the connect dApp button in order to prevent the overflow issue shown in the ticket.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9565 

## Risk

* Risk here is that in certain scenarios the dApp menu popover may render with a strange width. In particular there could be some specific dApps that render in certain ways that I don't know about that could generate some rendering edge case.

I've tested
* Small mobile screens
* Regular desktop screens
* Small desktop screens
* Zooming in and out in the browser to manipulate rem

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Please test connecting to a variety of dApps and checking that the popover menu works in both mobile and desktop mode.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/1d3fe295-9052-47c5-b813-49ae02953a74