### PR TITLE
fix: onramper sells honor selected sell asset and currency

### DIFF
--- a/src/components/Modals/FiatRamps/fiatRampProviders/onramper.ts
+++ b/src/components/Modals/FiatRamps/fiatRampProviders/onramper.ts
@@ -192,17 +192,21 @@ export const createOnRamperUrl = async ({
   if (!defaultCrypto) throw new Error('Failed to get onRamperSymbols head')
 
   params.set('apiKey', apiKey)
-  params.set('defaultCrypto', defaultCrypto)
   params.set('wallets', `${defaultCrypto}:${address}`)
 
   if (action === FiatRampAction.Sell) {
     // Note: selling via OnRamper does not allow selecting the currency, their api currently does not support it
     params.set('mode', 'sell')
+    params.set('sell_defaultCrypto', defaultCrypto)
+    params.set('sell_defaultFiat', fiatCurrency)
+    params.set('sell_onlyCryptos', onRamperSymbols.join(','))
   } else {
+    params.set('mode', 'buy')
+    params.set('defaultCrypto', defaultCrypto)
     params.set('onlyCryptos', onRamperSymbols.join(','))
+    params.set('defaultFiat', fiatCurrency)
   }
   params.set('language', language)
-  params.set('defaultFiat', fiatCurrency)
 
   params.set('themeName', mode === 'dark' ? 'dark' : 'light')
   currentUrl && params.set('redirectURL', currentUrl)


### PR DESCRIPTION
## Description

Conforms to latest Onramper [spec](https://docs.onramper.com/docs/supported-widget-parameters-offramp) for offramping, ensuring that the selected currency and selected assets are actually there when selling.
Currently in develop, sell works for the default BTC/USD selection, but trying to select any other asset/currency won't work.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/9705

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure Onramper buys are still happy and still open a widget with the selected asset/currency
- Ensure Onramper sells are happy and now open a widget with the selected asset/currency

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop: borked sell asset and currency selection

https://jam.dev/c/62df9d73-341d-40ee-bacf-a905ff44cd64

- this diff: honored sell asset and currency selection

https://jam.dev/c/006b13e0-60ba-4b65-ba48-f17d14f6dfda


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
