### PR TITLE
fix: missing relay rates

### DIFF
--- a/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
@@ -148,7 +148,7 @@ export const isRelayQuoteUtxoItemData = (
 export const isRelayQuoteEvmItemData = (
   item: RelayQuoteUtxoItemData | RelayQuoteEvmItemData | RelayQuoteSolanaItemData,
 ): item is RelayQuoteEvmItemData => {
-  return 'to' in item && 'data' in item && 'value' in item && 'gas' in item
+  return 'to' in item && 'data' in item && 'value' in item
 }
 
 export const isRelayQuoteSolanaItemData = (


### PR DESCRIPTION
## Description

Fixes `gas` assumption in `isRelayQuoteEvmItemData` - `to`, `data`, and `value` are required for Tx, but `data` is not guaranteed and is a nice-to-have provided by Relay on a "maybe, if we can" basis.
This removes the assumption, ensuring that rates including Tx data without `gas` are still valid rates and not dismissed.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Try to get a FOX.ARB -> ETH.ARB rate
- Check for items[0].data in the `swap` step of relay.link response in network tab - if there is `gas`, then this is not test-able and you may have to retry with diff. amount/pairs until you see one without `gas`
- Ensure that on a rate with missing `gas`, you still see the rate and can execute it

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

https://jam.dev/c/4de13fe2-e196-4aa5-b711-94f1d1a193f3

- this diff

https://jam.dev/c/09337d66-8d95-4d8c-9f66-96446d71cd4e


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
