### PR TITLE
fix: wcv2 session_authenticate events

### DIFF
--- a/src/plugins/walletConnectToDapps/components/modals/connect/Connect.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/connect/Connect.tsx
@@ -27,7 +27,10 @@ const Connect = ({ initialUri, isOpen, onClose }: Props) => {
   const handleConnectV2 = useCallback(
     async (uri: string) => {
       try {
-        const connectionResult = await pair?.({ uri })
+        // We do not handle session_authenticate events, which assumes a SIWE payload, so we make it a session_proposal instead
+        const connectionResult = await pair?.({
+          uri: uri.replace('sessionAuthenticate', 'sessionProposal'),
+        })
         if (connectionResult) onClose()
       } catch (error: unknown) {
         console.debug(error)


### PR DESCRIPTION
## Description

Makes sure we consistently handle `session_authenticate` wc events as `session_proposal`, since the wc dApps feature is built around proposals and doesn't support authentication requests. In effect, the result is pretty much the same.

~~Note, this only *tackles* https://github.com/shapeshift/web/issues/9663 making things slightly less worse - since base is down on all endpoints, unable to test this, to be retested once base is up.~~

Disregard the above, this actually closes it, tested with https://appkit-lab.reown.com/library/ethers-siwe/

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- closes https://github.com/shapeshift/web/issues/9663

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None - `session_authenticate` is already unhandled, and other methods are still handled the same as before.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Connect to Venice 
- Able to see proposal modal (you won't be able to proceed since base is borked, unless you magically have base account/s)

- Connect to https://appkit-lab.reown.com/library/ethers-siwe/ (i.e click "Connect Wallet")
- Ensure you are able to confirm proposal
- Ensure you're able to sign SIWE message

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Venice:

<img width="1728" alt="Screenshot 2025-06-17 at 18 37 24" src="https://github.com/user-attachments/assets/884f9115-223c-4f9f-b4c5-674d20fa0e42" />

- Appkit demo:

https://jam.dev/c/e96cf993-b7f0-4e9b-9e38-1eebb2c58c5c

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
