### PR TITLE
feat: swapper sort options as radios

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, ButtonGroup, FormControl, InputGroup, Stack } from '@chakra-ui/react'
+import { Box, Flex, FormControl, InputGroup, Radio, RadioGroup, Stack } from '@chakra-ui/react'
 import type { FC } from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -33,19 +33,6 @@ export const QuoteSortSelector: FC = memo(() => {
     }
   }, [currentSortOption])
 
-  const sortTypeTranslation = useMemo(() => {
-    switch (currentSortType) {
-      case SortType.BestRate:
-        return translate('trade.sort.bestRate')
-      case SortType.LowestGas:
-        return translate('trade.sort.lowestGas')
-      case SortType.Fastest:
-        return translate('trade.sort.fastest')
-      default:
-        return ''
-    }
-  }, [currentSortType, translate])
-
   const handleSortTypeChange = useCallback(
     (sortType: SortType) => {
       const sortOption: QuoteSortOption = (() => {
@@ -64,21 +51,6 @@ export const QuoteSortSelector: FC = memo(() => {
     [dispatch],
   )
 
-  const handleBestRateSortTypeChange = useCallback(
-    () => handleSortTypeChange(SortType.BestRate),
-    [handleSortTypeChange],
-  )
-
-  const handleLowestGasSortTypeChange = useCallback(
-    () => handleSortTypeChange(SortType.LowestGas),
-    [handleSortTypeChange],
-  )
-
-  const handleFastestSortTypeChange = useCallback(
-    () => handleSortTypeChange(SortType.Fastest),
-    [handleSortTypeChange],
-  )
-
   return (
     <>
       <Row>
@@ -87,53 +59,84 @@ export const QuoteSortSelector: FC = memo(() => {
             <Text translation='trade.sort.sortBy' />
           </HelperTooltip>
         </Row.Label>
-        <Row.Value>{sortTypeTranslation}</Row.Value>
       </Row>
       <Row py={2} gap={2} mt={2}>
         <FormControl>
           <InputGroup variant='filled' width='full'>
-            <Stack
-              bg='background.input.base'
-              px={1}
-              py={1}
-              borderRadius='xl'
-              width='100%'
-              direction='column'
-            >
-              <Button
-                onClick={handleBestRateSortTypeChange}
-                isActive={currentSortType === SortType.BestRate}
-                variant='ghost'
+            <RadioGroup value={currentSortType} onChange={handleSortTypeChange} width='100%'>
+              <Stack
+                bg='transparent'
+                px={1}
+                py={1}
+                borderRadius='xl'
+                borderColor='border.base'
+                borderWidth={1}
                 width='100%'
-                justifyContent='flex-start'
-                fontSize='sm'
-                fontWeight='normal'
+                direction='column'
+                spacing={2}
               >
-                {translate('trade.sort.bestRate')}
-              </Button>
-              <Button
-                onClick={handleLowestGasSortTypeChange}
-                isActive={currentSortType === SortType.LowestGas}
-                variant='ghost'
-                width='100%'
-                justifyContent='flex-start'
-                fontSize='sm'
-                fontWeight='normal'
-              >
-                {translate('trade.sort.lowestGas')}
-              </Button>
-              <Button
-                onClick={handleFastestSortTypeChange}
-                isActive={currentSortType === SortType.Fastest}
-                variant='ghost'
-                width='100%'
-                justifyContent='flex-start'
-                fontSize='sm'
-                fontWeight='normal'
-              >
-                {translate('trade.sort.fastest')}
-              </Button>
-            </Stack>
+                <Flex
+                  as='label'
+                  align='center'
+                  justify='space-between'
+                  width='100%'
+                  px={2}
+                  py={2}
+                  borderRadius='lg'
+                  cursor='pointer'
+                  htmlFor='sort-best-rate'
+                  bg={currentSortType === SortType.BestRate ? 'gray.700' : 'transparent'}
+                >
+                  <Box fontSize='sm'>{translate('trade.sort.bestRate')}</Box>
+                  <Radio
+                    id='sort-best-rate'
+                    value={SortType.BestRate}
+                    isChecked={currentSortType === SortType.BestRate}
+                    pointerEvents='none'
+                  />
+                </Flex>
+                <Flex
+                  as='label'
+                  align='center'
+                  justify='space-between'
+                  width='100%'
+                  px={2}
+                  py={2}
+                  borderRadius='lg'
+                  cursor='pointer'
+                  htmlFor='sort-lowest-gas'
+                  bg={currentSortType === SortType.LowestGas ? 'gray.700' : 'transparent'}
+                >
+                  <Box fontSize='sm'>{translate('trade.sort.lowestGas')}</Box>
+                  <Radio
+                    id='sort-lowest-gas'
+                    value={SortType.LowestGas}
+                    isChecked={currentSortType === SortType.LowestGas}
+                    pointerEvents='none'
+                  />
+                </Flex>
+                <Flex
+                  as='label'
+                  align='center'
+                  justify='space-between'
+                  width='100%'
+                  px={2}
+                  py={2}
+                  borderRadius='lg'
+                  cursor='pointer'
+                  htmlFor='sort-fastest'
+                  bg={currentSortType === SortType.Fastest ? 'gray.700' : 'transparent'}
+                >
+                  <Box fontSize='sm'>{translate('trade.sort.fastest')}</Box>
+                  <Radio
+                    id='sort-fastest'
+                    value={SortType.Fastest}
+                    isChecked={currentSortType === SortType.Fastest}
+                    pointerEvents='none'
+                  />
+                </Flex>
+              </Stack>
+            </RadioGroup>
           </InputGroup>
         </FormControl>
       </Row>

--- a/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonGroup, FormControl, InputGroup } from '@chakra-ui/react'
+import { Box, Button, ButtonGroup, FormControl, InputGroup, Stack } from '@chakra-ui/react'
 import type { FC } from 'react'
 import { memo, useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -90,41 +90,52 @@ export const QuoteSortSelector: FC = memo(() => {
         <Row.Value>{sortTypeTranslation}</Row.Value>
       </Row>
       <Row py={2} gap={2} mt={2}>
-        <Row.Value>
-          <FormControl>
-            <InputGroup variant='filled'>
-              <ButtonGroup
-                size='sm'
-                bg='background.input.base'
-                px={1}
-                py={1}
-                borderRadius='xl'
+        <FormControl>
+          <InputGroup variant='filled' width='full'>
+            <Stack
+              bg='background.input.base'
+              px={1}
+              py={1}
+              borderRadius='xl'
+              width='100%'
+              direction='column'
+            >
+              <Button
+                onClick={handleBestRateSortTypeChange}
+                isActive={currentSortType === SortType.BestRate}
                 variant='ghost'
-                isAttached
-                width='full'
+                width='100%'
+                justifyContent='flex-start'
+                fontSize='sm'
+                fontWeight='normal'
               >
-                <Button
-                  onClick={handleBestRateSortTypeChange}
-                  isActive={currentSortType === SortType.BestRate}
-                >
-                  {translate('trade.sort.bestRate')}
-                </Button>
-                <Button
-                  onClick={handleLowestGasSortTypeChange}
-                  isActive={currentSortType === SortType.LowestGas}
-                >
-                  {translate('trade.sort.lowestGas')}
-                </Button>
-                <Button
-                  onClick={handleFastestSortTypeChange}
-                  isActive={currentSortType === SortType.Fastest}
-                >
-                  {translate('trade.sort.fastest')}
-                </Button>
-              </ButtonGroup>
-            </InputGroup>
-          </FormControl>
-        </Row.Value>
+                {translate('trade.sort.bestRate')}
+              </Button>
+              <Button
+                onClick={handleLowestGasSortTypeChange}
+                isActive={currentSortType === SortType.LowestGas}
+                variant='ghost'
+                width='100%'
+                justifyContent='flex-start'
+                fontSize='sm'
+                fontWeight='normal'
+              >
+                {translate('trade.sort.lowestGas')}
+              </Button>
+              <Button
+                onClick={handleFastestSortTypeChange}
+                isActive={currentSortType === SortType.Fastest}
+                variant='ghost'
+                width='100%'
+                justifyContent='flex-start'
+                fontSize='sm'
+                fontWeight='normal'
+              >
+                {translate('trade.sort.fastest')}
+              </Button>
+            </Stack>
+          </InputGroup>
+        </FormControl>
       </Row>
     </>
   )

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -123,14 +123,8 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
       [handleSlippageTypeChange],
     )
 
-    const isHighSlippage = useMemo(
-      () => slippageAmount && bnOrZero(slippageAmount).gt(1),
-      [slippageAmount],
-    )
-    const isLowSlippage = useMemo(
-      () => slippageAmount && bnOrZero(slippageAmount).lt(0.05),
-      [slippageAmount],
-    )
+    const isHighSlippage = useMemo(() => bnOrZero(slippageAmount).gt(1), [slippageAmount])
+    const isLowSlippage = useMemo(() => bnOrZero(slippageAmount).lt(0.05), [slippageAmount])
 
     if (!isAdvancedSlippageEnabled) return null
 
@@ -150,7 +144,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
             </PopoverTrigger>
           </Box>
         </Tooltip>
-        <PopoverContent width='auto' maxWidth='md'>
+        <PopoverContent>
           <PopoverBody>
             <Row>
               <Row.Label>
@@ -188,7 +182,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
               {slippageType === SlippageType.Custom && (
                 <Row.Value>
                   <FormControl isInvalid={isInvalid}>
-                    <InputGroup variant='filled' maxWidth='100px'>
+                    <InputGroup variant='filled'>
                       <Input
                         placeholder={slippageAmount}
                         value={slippageAmount}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -216,7 +216,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
             )}
 
             {enableSortBy && (
-              <Box mt={4} borderTop='1px solid' borderTopColor='border.base' pt={4}>
+              <Box mt={4} borderTop='1px solid' borderTopColor='border.base' pt={4} width='full'>
                 <QuoteSortSelector />
               </Box>
             )}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -198,7 +198,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
                 </Row.Value>
               )}
             </Row>
-            {isHighSlippage && (
+            {isHighSlippage && slippageType === SlippageType.Custom && (
               <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
                 <AlertIcon />
                 <AlertDescription lineHeight='1.5'>
@@ -206,7 +206,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
                 </AlertDescription>
               </Alert>
             )}
-            {isLowSlippage && (
+            {isLowSlippage && slippageType === SlippageType.Custom && (
               <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
                 <AlertIcon />
                 <AlertDescription lineHeight='1.5'>


### PR DESCRIPTION
## Description

This PR:

- Makes swapper rate sort options vertically-aligned radios
- Removes the useless reminder of the selected sort option on the right
- Does *not* display the high/low slippage warnings for auto - the intent of this warning is to inform users of their slippage choice which may affect trade execution. But it is very much heuristics-based (i.e us deciding that x.xx% is too high/low, which may be right in some cases, but also absolutely wrong in others, as it's entirely dependant on AMM pool conditions and other factors and is not a rule set in stone)
- Does a bit of cleanup while in thy house

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9684

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test quote sort options with various languages and ensure it consistently looks good

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/0b328c89-7e75-4236-a24a-6975cf2ffa9a


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
