### PR TITLE
fix: relay don't parse "Could not fill request, retrying" as "Taking a bit longer than usual to find a route"

### DIFF
--- a/packages/swapper/src/swappers/RelaySwapper/utils/getLatestRelayStatusMessage.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/getLatestRelayStatusMessage.ts
@@ -2,12 +2,11 @@ import { RelayStatusMessage } from '../constant'
 import type { RelayStatus } from './types'
 
 export const getLatestRelayStatusMessage = (status: RelayStatus): string => {
-  const { status: statusValue, details } = status
+  const { status: statusValue } = status
 
   switch (true) {
     case statusValue === 'waiting':
       return RelayStatusMessage.WaitingForDeposit
-    case statusValue === 'pending' && details?.includes('Could not fill request'):
     case statusValue === 'delayed':
       return RelayStatusMessage.Retrying
     case statusValue === 'pending':


### PR DESCRIPTION
## Description

Literally what it says on the box, pending status is pending, not delayed/retrying which is what we were parsing it as.

There is currently an issue with Li.Fi and BTC outbound, as Relay seems to be a bit unreliable here: 
  - sometimes they will as soon as there is a mempool Tx and be in pending "Could not fill request (will retry)" state before the swap is executed (which would be pretty fast, but is still in a wrong state for 30s or so).
  - othertimes, they will be in the above state up until 1 conf (which can take many, many minutes)

Regardless of the Relay bug here, the parsing of "Could not fill request (will retry)" as "Taking a bit longer than usual to find a route, hang tight..." was wrong, as the swap was pending, not retrying.

My understanding is that we understood the whole "Could not fill request (will retry)" wrong: we thought it meant Relay was searching for a route, but it means something along the lines of "Can't return status because our API and/or indexer is derp and doesn't rely on mempool, but hey should work after 1 conf" of sorts.

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9642

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a x -> BTC Tx on Relay
- Open network tab and filter by relay
- Ensure that whenever status is "Could not fill request (will retry)", you see "Deposit detected, processing swap..." in app 
- Ensure that whenever Relay goes to success, that's also reflected in app

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
