### PR TITLE
fix: hide simple streaming swap steps if its too small

### DIFF
--- a/src/components/Layout/Header/ActionCenter/components/Details/StreamingSwapDetails.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Details/StreamingSwapDetails.tsx
@@ -52,9 +52,11 @@ export const StreamingSwapDetails: React.FC<StreamingSwapDetailsProps> = ({ swap
           isAnimated={true}
           hasStripe={isSwapComplete ? false : true}
         />
-        <RawText>
-          ({attemptedSwapCount}/{maxSwapCount})
-        </RawText>
+        {maxSwapCount ? (
+          <RawText>
+            ({attemptedSwapCount}/{maxSwapCount})
+          </RawText>
+        ) : null}
       </Row.Value>
     </Row>
   )

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -368,18 +368,21 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
         <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
           <HStack>
             <RawText>{firstHopActionTitleText}</RawText>
-            {firstHopStreamingProgress && firstHopStreamingProgress.maxSwapCount > 0 && (
-              <Tag
-                minWidth='auto'
-                // This is not really the best way to do this, but it's the best way to do it for now
-                // The swap won't be complete if it's a multi hop, but for now we don't have any swapper supporting streaming multi hops
-                // We would require to get the state of the streaming swap of the current hop but in reality it's not so easy as
-                // the streaming can contain less chunks than the max chunks
-                colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
-              >
-                {`${firstHopStreamingProgress.attemptedSwapCount}/${firstHopStreamingProgress.maxSwapCount}`}
-              </Tag>
-            )}
+            {firstHopStreamingProgress &&
+              firstHopStreamingProgress.maxSwapCount > 0 &&
+              (firstHopStreamingProgress.attemptedSwapCount > 0 ||
+                activeSwap?.status !== SwapStatus.Success) && (
+                <Tag
+                  minWidth='auto'
+                  // This is not really the best way to do this, but it's the best way to do it for now
+                  // The swap won't be complete if it's a multi hop, but for now we don't have any swapper supporting streaming multi hops
+                  // We would require to get the state of the streaming swap of the current hop but in reality it's not so easy as
+                  // the streaming can contain less chunks than the max chunks
+                  colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
+                >
+                  {`${firstHopStreamingProgress.attemptedSwapCount}/${firstHopStreamingProgress.maxSwapCount}`}
+                </Tag>
+              )}
           </HStack>
           {tradeQuoteFirstHop && firstHopSellAccountId && (
             <VStack>
@@ -484,14 +487,17 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
         <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
           <HStack>
             <RawText>{lastHopActionTitleText}</RawText>
-            {secondHopStreamingProgress && secondHopStreamingProgress.maxSwapCount > 0 && (
-              <Tag
-                minWidth='auto'
-                colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
-              >
-                {`${secondHopStreamingProgress.attemptedSwapCount}/${secondHopStreamingProgress.maxSwapCount}`}
-              </Tag>
-            )}
+            {secondHopStreamingProgress &&
+              secondHopStreamingProgress.maxSwapCount > 0 &&
+              (secondHopStreamingProgress.attemptedSwapCount > 0 ||
+                activeSwap?.status !== SwapStatus.Success) && (
+                <Tag
+                  minWidth='auto'
+                  colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
+                >
+                  {`${secondHopStreamingProgress.attemptedSwapCount}/${secondHopStreamingProgress.maxSwapCount}`}
+                </Tag>
+              )}
           </HStack>
           {tradeQuoteSecondHop && lastHopSellAccountId && (
             <VStack>

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -363,26 +363,29 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
   }, [stepSource, translate])
 
   const firstHopActionTitle = useMemo(() => {
+    const shouldDisplayStreamingSteps =
+      firstHopStreamingProgress &&
+      firstHopStreamingProgress.maxSwapCount > 0 &&
+      (firstHopStreamingProgress.attemptedSwapCount > 0 ||
+        activeSwap?.status !== SwapStatus.Success)
+
     return (
       <VStack width='full' spacing={2} align='stretch'>
         <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
           <HStack>
             <RawText>{firstHopActionTitleText}</RawText>
-            {firstHopStreamingProgress &&
-              firstHopStreamingProgress.maxSwapCount > 0 &&
-              (firstHopStreamingProgress.attemptedSwapCount > 0 ||
-                activeSwap?.status !== SwapStatus.Success) && (
-                <Tag
-                  minWidth='auto'
-                  // This is not really the best way to do this, but it's the best way to do it for now
-                  // The swap won't be complete if it's a multi hop, but for now we don't have any swapper supporting streaming multi hops
-                  // We would require to get the state of the streaming swap of the current hop but in reality it's not so easy as
-                  // the streaming can contain less chunks than the max chunks
-                  colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
-                >
-                  {`${firstHopStreamingProgress.attemptedSwapCount}/${firstHopStreamingProgress.maxSwapCount}`}
-                </Tag>
-              )}
+            {shouldDisplayStreamingSteps && (
+              <Tag
+                minWidth='auto'
+                // This is not really the best way to do this, but it's the best way to do it for now
+                // The swap won't be complete if it's a multi hop, but for now we don't have any swapper supporting streaming multi hops
+                // We would require to get the state of the streaming swap of the current hop but in reality it's not so easy as
+                // the streaming can contain less chunks than the max chunks
+                colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
+              >
+                {`${firstHopStreamingProgress.attemptedSwapCount}/${firstHopStreamingProgress.maxSwapCount}`}
+              </Tag>
+            )}
           </HStack>
           {tradeQuoteFirstHop && firstHopSellAccountId && (
             <VStack>
@@ -482,22 +485,25 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
   ])
 
   const lastHopActionTitle = useMemo(() => {
+    const shouldDisplayStreamingSteps =
+      secondHopStreamingProgress &&
+      secondHopStreamingProgress.maxSwapCount > 0 &&
+      (secondHopStreamingProgress.attemptedSwapCount > 0 ||
+        activeSwap?.status !== SwapStatus.Success)
+
     return (
       <VStack width='full' spacing={2} align='stretch'>
         <Flex alignItems='center' justifyContent='space-between' flex={1} gap={2}>
           <HStack>
             <RawText>{lastHopActionTitleText}</RawText>
-            {secondHopStreamingProgress &&
-              secondHopStreamingProgress.maxSwapCount > 0 &&
-              (secondHopStreamingProgress.attemptedSwapCount > 0 ||
-                activeSwap?.status !== SwapStatus.Success) && (
-                <Tag
-                  minWidth='auto'
-                  colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
-                >
-                  {`${secondHopStreamingProgress.attemptedSwapCount}/${secondHopStreamingProgress.maxSwapCount}`}
-                </Tag>
-              )}
+            {shouldDisplayStreamingSteps && (
+              <Tag
+                minWidth='auto'
+                colorScheme={activeSwap?.status === SwapStatus.Success ? 'green' : 'blue'}
+              >
+                {`${secondHopStreamingProgress.attemptedSwapCount}/${secondHopStreamingProgress.maxSwapCount}`}
+              </Tag>
+            )}
           </HStack>
           {tradeQuoteSecondHop && lastHopSellAccountId && (
             <VStack>


### PR DESCRIPTION
## Description

Streaming swap steps are shown even if it's not really a streaming swap with multiple chunks, previously we were hiding them in the stepper, let's hide them if the streaming swap doesn't contain multiple steps even in the action center

At some point we might decide to do the contrary, and include a single step in `useThorStreaming` even if they are not containing anyone, but I feel like it would be a bit off regarding the under the hood system, this swap hasn't stream any chunks, it's like a regular swap, so it would be kind of wrong to show that it did contain a step, but from a user point of view, it might be better to display at last one step

Let's discuss this during review

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted in https://discord.com/channels/554694662431178782/1384911763388239943/1385027842546471013

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try a very small swap (0.011 ETH to AAVE on Ethereum for example)
- When the status is confirmed, open the stepper, you shouldn't see `0/1` like previously
- Same for the action center, no `0/0` shown

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/f1361c73-3eb3-419b-b154-0a9e9f841dcf)
