### PR TITLE
feat: human readable action center copies

### DIFF
--- a/src/AppProviders.tsx
+++ b/src/AppProviders.tsx
@@ -1,9 +1,4 @@
-import {
-  ChakraProvider,
-  ColorModeScript,
-  createLocalStorageManager,
-  createStandaloneToast,
-} from '@chakra-ui/react'
+import { ChakraProvider, ColorModeScript, createLocalStorageManager } from '@chakra-ui/react'
 import { captureException } from '@sentry/react'
 import React, { useCallback } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
@@ -43,7 +38,6 @@ const manager = createLocalStorageManager('ss-theme')
 const splashScreen = <SplashScreen />
 
 export function AppProviders({ children }: ProvidersProps) {
-  const { ToastContainer } = createStandaloneToast()
   const handleError = useCallback(
     (
       error: Error,
@@ -64,13 +58,12 @@ export function AppProviders({ children }: ProvidersProps) {
             <PluginProvider>
               <ColorModeScript storageKey='ss-theme' />
               <ChatwootWidget />
-              <ChakraProvider theme={theme} colorModeManager={manager} cssVarsRoot='body'>
-                <ToastContainer />
-                <PersistGate loading={splashScreen} persistor={persistor}>
-                  <HashRouter basename='/'>
-                    <ScrollToTop />
-                    <BrowserRouterProvider>
-                      <I18nProvider>
+              <I18nProvider>
+                <ChakraProvider theme={theme} colorModeManager={manager} cssVarsRoot='body'>
+                  <PersistGate loading={splashScreen} persistor={persistor}>
+                    <HashRouter basename='/'>
+                      <ScrollToTop />
+                      <BrowserRouterProvider>
                         <WalletProvider>
                           <KeepKeyProvider>
                             <WalletConnectV2Provider>
@@ -86,11 +79,11 @@ export function AppProviders({ children }: ProvidersProps) {
                             </WalletConnectV2Provider>
                           </KeepKeyProvider>
                         </WalletProvider>
-                      </I18nProvider>
-                    </BrowserRouterProvider>
-                  </HashRouter>
-                </PersistGate>
-              </ChakraProvider>
+                      </BrowserRouterProvider>
+                    </HashRouter>
+                  </PersistGate>
+                </ChakraProvider>
+              </I18nProvider>
             </PluginProvider>
           </QueryClientProvider>
         </WagmiProvider>

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2983,6 +2983,18 @@
       "claimAvailable": "Claim Available",
       "unknown": "Unknown"
     },
+    "swap": {
+      "processing": "Your swap of %{sellAmountAndSymbol} to %{buyAmountAndSymbol} is still being processed.",
+      "complete": "Your swap of %{sellAmountAndSymbol} to %{buyAmountAndSymbol} is complete.",
+      "failed": "Your swap of %{sellAmountAndSymbol} to %{buyAmountAndSymbol} has failed.",
+      "streaming": "Your swap of %{sellAmountAndSymbol} to %{buyAmountAndSymbol} is streaming."
+    },
+    "limitOrder": {
+      "placed": "Limit order placed for %{sellAmountAndSymbol} to %{buyAmountAndSymbol}",
+      "complete": "Your order to buy %{buyAmountAndSymbol} for %{sellAmountAndSymbol} was successfully filled.",
+      "cancelled": "Your order to buy %{buyAmountAndSymbol} for %{sellAmountAndSymbol} was cancelled.",
+      "expired": "Your order to buy %{buyAmountAndSymbol} for %{sellAmountAndSymbol} expired."
+    },
     "swapTitle": "%{sellAmount} %{sellSymbol} → %{buyAmount} %{buySymbol}",
     "limitOrderTitle": "%{sellAmount} %{sellSymbol} → %{buyAmount} %{buySymbol}",
     "pendingTransactions": "%{count} Pending",

--- a/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
@@ -10,19 +10,22 @@ import {
   Stack,
   useDisclosure,
 } from '@chakra-ui/react'
+import { SwapStatus } from '@shapeshiftoss/swapper'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { useCallback, useMemo } from 'react'
-import { useTranslate } from 'react-polyglot'
 
 import { ActionStatusIcon } from './ActionStatusIcon'
 import { ActionStatusTag } from './ActionStatusTag'
 import { SwapDetails } from './Details/SwapDetails'
 
+import { Amount } from '@/components/Amount/Amount'
 import { AssetIconWithBadge } from '@/components/AssetIconWithBadge'
 import { HoverTooltip } from '@/components/HoverTooltip/HoverTooltip'
 import { SwapperIcons } from '@/components/MultiHopTrade/components/SwapperIcons'
 import { RawText } from '@/components/Text'
+import type { TextPropTypes } from '@/components/Text/Text'
+import { Text } from '@/components/Text/Text'
 import type { SwapAction } from '@/state/slices/actionSlice/types'
 import { swapSlice } from '@/state/slices/swapSlice/swapSlice'
 import { useAppSelector } from '@/state/store'
@@ -38,7 +41,6 @@ type SwapActionCardProps = {
 
 export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCardProps) => {
   const swapsById = useAppSelector(swapSlice.selectors.selectSwapsById)
-  const translate = useTranslate()
 
   const formattedDate = useMemo(() => {
     const now = dayjs()
@@ -73,20 +75,44 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
     }
   }, [onToggle, isCollapsable])
 
+  const swapNotificationTranslationComponents: TextPropTypes['components'] = useMemo(() => {
+    if (!swap) return
+
+    return {
+      sellAmountAndSymbol: (
+        <Amount.Crypto
+          value={swap.sellAmountCryptoPrecision}
+          symbol={swap.sellAsset.symbol}
+          fontSize='sm'
+          fontWeight='bold'
+          maximumFractionDigits={6}
+          omitDecimalTrailingZeros
+          display='inline'
+        />
+      ),
+      buyAmountAndSymbol: (
+        <Amount.Crypto
+          value={swap.expectedBuyAmountCryptoPrecision}
+          symbol={swap.buyAsset.symbol}
+          fontSize='sm'
+          fontWeight='bold'
+          maximumFractionDigits={6}
+          omitDecimalTrailingZeros
+          display='inline'
+        />
+      ),
+    }
+  }, [swap])
+
   const title = useMemo(() => {
-    return translate('notificationCenter.swapTitle', {
-      sellAmount: swap.sellAmountCryptoPrecision,
-      sellSymbol: swap.sellAsset.symbol,
-      buyAmount: swap.expectedBuyAmountCryptoPrecision,
-      buySymbol: swap.buyAsset.symbol,
-    })
-  }, [
-    swap.sellAmountCryptoPrecision,
-    swap.expectedBuyAmountCryptoPrecision,
-    swap.sellAsset.symbol,
-    swap.buyAsset.symbol,
-    translate,
-  ])
+    if (!swap) return 'notificationCenter.swap.processing'
+    if (swap.isStreaming && swap.status === SwapStatus.Pending)
+      return 'notificationCenter.swap.streaming'
+    if (swap.status === SwapStatus.Success) return 'notificationCenter.swap.complete'
+    if (swap.status === SwapStatus.Failed) return 'notificationCenter.swap.failed'
+
+    return 'notificationCenter.swap.processing'
+  }, [swap])
 
   return (
     <Stack
@@ -111,7 +137,11 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
         <Stack spacing={0} width='full'>
           <HStack onClick={handleClick}>
             <Stack spacing={1} width='full'>
-              <RawText fontSize='sm'>{title}</RawText>
+              <Text
+                fontSize='sm'
+                translation={title}
+                components={swapNotificationTranslationComponents}
+              />
               <HStack fontSize='sm' color='text.subtle' divider={divider} gap={1}>
                 <ActionStatusTag status={action.status} />
                 <RawText>{formattedDate}</RawText>

--- a/src/components/MultiHopTrade/components/LimitOrder/hooks/useLimitOrders.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/hooks/useLimitOrders.tsx
@@ -10,9 +10,8 @@ import { useTranslate } from 'react-polyglot'
 
 import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useGetLimitOrdersQuery } from '@/state/apis/limit-orders/limitOrderApi'
-import { actionSlice } from '@/state/slices/actionSlice/actionSlice'
 import { isLimitOrderAction } from '@/state/slices/actionSlice/types'
-import { selectAssetById, selectEvmAccountIds } from '@/state/slices/selectors'
+import { selectActions, selectAssetById, selectEvmAccountIds } from '@/state/slices/selectors'
 import { store, useAppSelector } from '@/state/store'
 
 export const useLimitOrdersQuery = () => {
@@ -30,7 +29,7 @@ export const useLimitOrders = () => {
   const toast = useToast()
   const translate = useTranslate()
   const prevLimitOrdersData = usePrevious(limitOrdersQuery.currentData)
-  const actions = useAppSelector(actionSlice.selectors.selectActions)
+  const actions = useAppSelector(selectActions)
   const isActionCenterEnabled = useFeatureFlag('ActionCenter')
 
   useEffect(() => {

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -39,6 +39,7 @@ import type { Portfolio } from './slices/portfolioSlice/portfolioSliceCommon'
 import type { Preferences } from './slices/preferencesSlice/preferencesSlice'
 import { preferences } from './slices/preferencesSlice/preferencesSlice'
 import { swapSlice } from './slices/swapSlice/swapSlice'
+import type { SwapState } from './slices/swapSlice/types'
 import { tradeInput } from './slices/tradeInputSlice/tradeInputSlice'
 import type { TxHistory } from './slices/txHistorySlice/txHistorySlice'
 import { txHistory, txHistoryApi } from './slices/txHistorySlice/txHistorySlice'
@@ -154,6 +155,7 @@ export const sliceReducers = {
     localWalletSlice.reducer,
   ),
   action: persistReducer<ActionState>(actionPersistConfig, actionSlice.reducer),
+  swap: persistReducer<SwapState>(swapPersistConfig, swapSlice.reducer),
 }
 
 export const apiSlices = {
@@ -186,8 +188,6 @@ export const apiReducers = {
   [opportunitiesApi.reducerPath]: opportunitiesApi.reducer,
   [abiApi.reducerPath]: abiApi.reducer,
   [limitOrderApi.reducerPath]: persistReducer(limitOrderApiPersistConfig, limitOrderApi.reducer),
-  [actionSlice.reducerPath]: persistReducer(actionPersistConfig, actionSlice.reducer),
-  [swapSlice.reducerPath]: persistReducer(swapPersistConfig, swapSlice.reducer),
 }
 
 export const reducer = combineReducers(Object.assign({}, sliceReducers, apiReducers))

--- a/src/state/slices/actionSlice/actionSlice.ts
+++ b/src/state/slices/actionSlice/actionSlice.ts
@@ -28,6 +28,5 @@ export const actionSlice = createSlice({
   selectors: {
     selectActionsById: state => state.byId,
     selectActionIds: state => state.ids,
-    selectActions: state => state.ids.map(id => state.byId[id]),
   },
 })

--- a/src/state/slices/actionSlice/selectors.ts
+++ b/src/state/slices/actionSlice/selectors.ts
@@ -15,8 +15,16 @@ import {
   selectSwapIdParamFromFilter,
 } from '@/state/selectors'
 
+export const selectActions = createDeepEqualOutputSelector(
+  actionSlice.selectors.selectActionsById,
+  actionSlice.selectors.selectActionIds,
+  (actionsById, actionIds) => {
+    return actionIds.map(id => actionsById[id])
+  },
+)
+
 export const selectWalletActions = createDeepEqualOutputSelector(
-  actionSlice.selectors.selectActions,
+  selectActions,
   selectEnabledWalletAccountIds,
   swapSlice.selectors.selectSwapsById,
   (actions, enabledWalletAccountIds, swapsById) => {
@@ -79,7 +87,7 @@ export const selectSwapActionBySwapId = createDeepEqualOutputSelector(
 )
 
 export const selectOpenLimitOrderActionsFilteredByWallet = createDeepEqualOutputSelector(
-  actionSlice.selectors.selectActions,
+  selectActions,
   selectEnabledWalletAccountIds,
   (actions, enabledWalletAccountIds) => {
     return actions.filter(
@@ -94,7 +102,7 @@ export const selectOpenLimitOrderActionsFilteredByWallet = createDeepEqualOutput
 )
 
 export const selectLimitOrderActionByCowSwapQuoteId = createDeepEqualOutputSelector(
-  actionSlice.selectors.selectActions,
+  selectActions,
   selectCowSwapQuoteIdParamFromRequiredFilter,
   (actions, cowSwapQuoteId) => {
     return actions.find(

--- a/src/state/slices/actionSlice/types.ts
+++ b/src/state/slices/actionSlice/types.ts
@@ -31,12 +31,16 @@ type ActionLimitOrderMetadata = {
   limitOrderId?: OrderId
   sellAmountCryptoBaseUnit: string
   buyAmountCryptoBaseUnit: string
+  sellAmountCryptoPrecision: string
+  buyAmountCryptoPrecision: string
   sellAsset: Asset
   buyAsset: Asset
   limitPrice: LimitPriceByDirection
   expires: number | undefined
   executedBuyAmountCryptoBaseUnit?: string
   executedSellAmountCryptoBaseUnit?: string
+  executedBuyAmountCryptoPrecision?: string
+  executedSellAmountCryptoPrecision?: string
   filledDecimalPercentage?: string
   accountId: AccountId
 }


### PR DESCRIPTION
## Description
- Bring human readable copies to notifications and actions
- Bring notification styles based on the mockups (https://www.figma.com/design/TS6lTeOlz2uU1ya339WUoF/Notification-Center?node-id=75-3202&p=f&t=N5Y14dfND0YVx1Md-0)
- We were duplicating each toasts since 3 years, removed the toast container as I didn't find any places where we show outside of react toasts
- Fixed a rerendering hell with actions, by adding a deep equal selector

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9707

## Risk
Low (behind a flag and not touching anything else than action center, except the toast container)
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try some swaps
- Try some streaming swaps
- Try some limit orders

They all should contains notification styles, human readable copies, close button, open drawer on click
Action center should also contain human readable copies

Be pragmatic on this one, any feedback on copies/styles/flows are more than appreciated 🙏 

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/29e9efad-d6a8-443f-8487-8217eb0d723a
![image](https://github.com/user-attachments/assets/2c6ad304-43db-4115-a71f-9250cc36bc27)
![image](https://github.com/user-attachments/assets/ebd194f3-53e1-46f6-93cc-16a9d99cb296)

Streaming swap:
https://jam.dev/c/a447676d-19e0-4c34-9ae0-3c7df86fa741