### PR TITLE
fix: dont feed lodash big numbers

### DIFF
--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -9,7 +9,6 @@ import type {
 } from '@shapeshiftoss/swapper'
 import { getHopByIndex } from '@shapeshiftoss/swapper'
 import type { Asset, PartialRecord } from '@shapeshiftoss/types'
-import { orderBy } from 'lodash'
 
 import type { ActiveQuoteMeta } from './types'
 import { QuoteSortOption } from './types'
@@ -152,86 +151,66 @@ const sortApiQuotes = (
   unorderedQuotes: ApiQuote[],
   sortOption: QuoteSortOption = QuoteSortOption.BEST_RATE,
 ): ApiQuote[] => {
-  // Custom sorting function rather than an orderBy iteratee to keep my sanity, since this didn't play too well with it
-  if (sortOption === QuoteSortOption.FASTEST) {
-    const sorted = [...unorderedQuotes].sort((a, b) => {
-      const getExecutionTime = (quote: ApiQuote) => {
-        if (!quote.quote?.steps?.length) return undefined
+  return [...unorderedQuotes].sort((a, b) => {
+    switch (sortOption) {
+      case QuoteSortOption.FASTEST: {
+        const aScore = getFastestScore(a)
+        const bScore = getFastestScore(b)
 
-        // Note, we *need* this and don't want to sum to 0. undefined and 0 have two v. diff meanings
-        if (quote.quote.steps.every(step => step.estimatedExecutionTimeMs === undefined)) {
-          return undefined
-        }
+        // Handle undefined times (push to end)
+        if (aScore === Number.MAX_SAFE_INTEGER && bScore === Number.MAX_SAFE_INTEGER) return 0
+        if (aScore === Number.MAX_SAFE_INTEGER) return 1
+        if (bScore === Number.MAX_SAFE_INTEGER) return -1
 
-        return quote.quote.steps.reduce((total, step) => {
-          // Opt chain to keep tsc happy, we already know it will be defined after the above check
-          return total + (step.estimatedExecutionTimeMs ?? 0)
-        }, 0)
+        return aScore - bScore // Ascending (fastest first)
       }
 
-      const aTime = getExecutionTime(a)
-      const bTime = getExecutionTime(b)
+      case QuoteSortOption.LOWEST_GAS: {
+        const aScore = getLowestGasScore(a)
+        const bScore = getLowestGasScore(b)
 
-      if (aTime === undefined && bTime === undefined) return 0
-      if (aTime === undefined) return 1 // Push undefined to last, we don't know the ETA here
-      if (bTime === undefined) return -1 // Keep defined ETA above undefined
+        // Handle unknown gas (push to end)
+        const aIsMax = aScore.eq(Number.MAX_SAFE_INTEGER)
+        const bIsMax = bScore.eq(Number.MAX_SAFE_INTEGER)
 
-      // Number compare is safe since we're dealing with unix timestamps
-      return aTime - bTime
-    })
-    return sorted
+        if (aIsMax && bIsMax) return 0
+        if (aIsMax) return 1
+        if (bIsMax) return -1
+
+        return aScore.minus(bScore).toNumber() // Ascending (lowest first)
+      }
+
+      case QuoteSortOption.BEST_RATE:
+      default: {
+        const aScore = getBestRateScore(a)
+        const bScore = getBestRateScore(b)
+
+        return bScore.minus(aScore).toNumber() // Descending (highest first)
+      }
+    }
+  })
+}
+
+const getBestRateScore = (quote: ApiQuote): BigNumber => {
+  if (!quote.quote?.steps?.length) return bn(0)
+  const lastStep = quote.quote.steps[quote.quote.steps.length - 1]
+  return bnOrZero(lastStep.buyAmountAfterFeesCryptoBaseUnit)
+}
+
+const getFastestScore = (quote: ApiQuote): number => {
+  if (!quote.quote?.steps?.length) return Number.MAX_SAFE_INTEGER
+
+  if (quote.quote.steps.every(step => step.estimatedExecutionTimeMs === undefined)) {
+    return Number.MAX_SAFE_INTEGER
   }
-  const iteratees: ((quote: ApiQuote) => any)[] = (() => {
-    switch (sortOption) {
-      case QuoteSortOption.LOWEST_GAS:
-        return [
-          // Presort by un/available network fees
-          (quote: ApiQuote) => {
-            if (!quote.quote?.steps) return true
 
-            // Unknown gas - assume latest
-            if (quote.quote.steps.every(step => !step?.feeData?.networkFeeCryptoBaseUnit))
-              return true
+  return quote.quote.steps.reduce((total, step) => {
+    return total + (step.estimatedExecutionTimeMs ?? 0)
+  }, 0)
+}
 
-            return false
-          },
-          // Then sort by the actual fee amount in user currency
-          (quote: ApiQuote) => {
-            return getNetworkFeeUserCurrency(quote.quote)
-          },
-        ]
-      case QuoteSortOption.BEST_RATE:
-      default:
-        return [
-          (quote: ApiQuote) => {
-            if (!quote.quote?.steps?.length) return bn(0)
-
-            // Get the last step for multi-hop trades
-            const steps = quote.quote.steps
-            const lastStep = steps[steps.length - 1]
-
-            // Use buyAmountAfterFeesCryptoBaseUnit which should match the displayed amount
-            const buyAmount = bnOrZero(lastStep.buyAmountAfterFeesCryptoBaseUnit)
-
-            return buyAmount
-          },
-        ]
-    }
-  })()
-
-  const sortOrders: ('asc' | 'desc')[] = (() => {
-    switch (sortOption) {
-      case QuoteSortOption.LOWEST_GAS:
-        return ['asc', 'asc'] // Lowest to highest network fees
-      case QuoteSortOption.BEST_RATE:
-      default:
-        return ['desc'] // Highest to lowest received amount after fees
-    }
-  })()
-
-  const ordered = orderBy(unorderedQuotes, iteratees, sortOrders)
-
-  return ordered
+const getLowestGasScore = (quote: ApiQuote): BigNumber => {
+  return getNetworkFeeUserCurrency(quote.quote)
 }
 
 export const sortTradeQuotes = (


### PR DESCRIPTION
## Description

Fixes a bug in quote sorting where the best rate doesn't always rise to the top when sorting. The issue was that we were trying to pass BigNumber's to lodash for orderby.

I've modified the sorting algo to be a bit more standard and uniform and utilise BigNumber comparisons for both gas and best rate.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9747

## Risk

Medium risk. This is a substantial rewrite of the quote sorting algorithm. Risk here is that the sorting breaks (although it's already broken in some cases which is what this fixes)

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Test that quote sorting still works as expected.

Test a variety of different coin pairings

I was able to replicate this issue using the trade that hpayne did. Try a few different input values.

![image](https://github.com/user-attachments/assets/c065893f-1b03-4e21-b856-211811f85ee9)


<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/e0ce5dcd-2ba6-4089-8879-94cf2536d9c3
