### PR TITLE
fix: thor streaming progress

### DIFF
--- a/packages/swapper/src/thorchain-utils/getLatestThorTxStatusMessage.ts
+++ b/packages/swapper/src/thorchain-utils/getLatestThorTxStatusMessage.ts
@@ -41,12 +41,14 @@ export const getLatestThorTxStatusMessage = (
           : ThorchainStatusMessage.InboundFinalizationPending
       }
       case 'swap_status': {
-        const obj = response.stages[key]
-        if (obj === undefined) continue
+        const swapStatusStage = response.stages[key]
+        const inboundFinalizedStage = response.stages.inbound_finalised
+        if (swapStatusStage === undefined || inboundFinalizedStage === undefined) continue
+        if (!inboundFinalizedStage.completed) continue
 
-        return obj.pending
-          ? ThorchainStatusMessage.SwapPending
-          : hasOutboundTx
+        if (swapStatusStage.pending) return ThorchainStatusMessage.SwapPending
+
+        return hasOutboundTx
           ? ThorchainStatusMessage.SwapCompleteAwaitingOutbound
           : ThorchainStatusMessage.SwapCompleteAwaitingDestination
       }


### PR DESCRIPTION
## Description

Works around one wrong assumption of `getLatestThorTxStatusMessage`:

The current assumption is that `stages_reverse_ordered` i.e the guys below, will be perfectly sequential 

https://github.com/shapeshift/web/blob/5f39b2799d25e34266c49afd9871709409e5b17f/packages/swapper/src/thorchain-utils/getLatestThorTxStatusMessage.ts#L12-L18

i.e if one is defined (although possibly pending), we assume the ones after (i.e, the ones *before* in the swap flow because of the reverse) will be completed.

But that is not necessarily true, i.e in this case, `swap_status` will initially be pending for a short bit, while `inbound_finalised` is still `{"completed": false}`.

This means that in that interim while `inbound_finalized` is not completed, and `swap_status` is pending (by virtue of it not having started), we will wrongly go to the `swap_status` case, and detect the swap as complete (where in fact, `!pending`  means it hasn't started), before correctly reverting to its real pending status once `inbound_finalized` is completed and `swap_status` becomes pending.

Fixed by explicitly checking for in-progress `inbound_finalized` in `swap_status`, and treating it the same as if we had no `swap_status` yet. 

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9743

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THOR streaming swaps progress is happy
- THOR regular swaps progress is happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Streaming swap

https://jam.dev/c/789c95bd-7d7f-490c-9aef-a610330061d9

- Regular swap

https://jam.dev/c/f0f018ac-719b-4404-9b47-0a156ef5c864


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
