### PR TITLE
fix: net worth wrapping and breaking alignment on mobile loading

### DIFF
--- a/src/pages/Dashboard/components/DashboardHeader/WalletBalance.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader/WalletBalance.tsx
@@ -1,5 +1,5 @@
 import type { FlexProps, ResponsiveValue } from '@chakra-ui/react'
-import { Flex, Spinner } from '@chakra-ui/react'
+import { Box, Flex, Spinner } from '@chakra-ui/react'
 import { bnOrZero } from '@shapeshiftoss/chain-adapters'
 import type { Property } from 'csstype'
 import { memo, useMemo } from 'react'
@@ -71,8 +71,8 @@ export const WalletBalance: React.FC<WalletBalanceProps> = memo(
 
     return (
       <Flex flexDir={balanceFlexDir} alignItems={alignItems ?? portfolioTextAlignment}>
-        <Flex gap={2}>
-          <Text fontWeight='medium' translation={label} color='text.subtle' />
+        <Box position='relative'>
+          <Text fontWeight='medium' translation={label} color='text.subtle' whiteSpace='nowrap' />
 
           {(isOpportunitiesLoading || isAccountsMetadataFetching) && (
             <TooltipWithTouch
@@ -81,10 +81,10 @@ export const WalletBalance: React.FC<WalletBalanceProps> = memo(
                 opportunityAccountsLoaded: walletOpportunityAccountIds.length,
               })}
             >
-              <Spinner color='blue.500' size='sm' />
+              <Spinner color='blue.500' size='sm' position='absolute' right={-8} top={1} />
             </TooltipWithTouch>
           )}
-        </Flex>
+        </Box>
         <Amount.Fiat
           lineHeight='shorter'
           value={netWorth}


### PR DESCRIPTION
## Description

Prevent the "net worth" label from wrapping when the loader is being displayed and ruining alignment.

Went with absolute positioning here rather than simply preventing the label from wrapping so that the net worth label doesn't jump when the loader finishes.


## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Low risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Test that the net worth loading spinner alignment and position looks reasonable on both desktop and mobile. As well as a variety of screen sizes.

Refresh your screen and connect a wallet whilst on the wallet page to see a spinner

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
 
Mobile - https://jam.dev/c/050d4bd7-28ce-4aae-be99-38acab4ac0f4

Desktop - https://jam.dev/c/2be77fba-e955-4f72-9dfa-29110a0db5dd
