### PR TITLE
fix: action center polish

### DIFF
--- a/src/components/Layout/Header/ActionCenter/ActionCenter.tsx
+++ b/src/components/Layout/Header/ActionCenter/ActionCenter.tsx
@@ -62,9 +62,7 @@ export const ActionCenter = memo(() => {
               <SwapActionCard
                 key={action.id}
                 action={action}
-                isCollapsable={Boolean(
-                  swap.isStreaming && swap.metadata.streamingSwapMetadata?.maxSwapCount,
-                )}
+                isCollapsable={Boolean(swap?.txLink)}
               />
             )
           }

--- a/src/components/Layout/Header/ActionCenter/components/LimitOrderActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/LimitOrderActionCard.tsx
@@ -46,17 +46,17 @@ type NotificationCardProps = {
 
 export const LimitOrderActionCard = ({
   isCollapsable = true,
-  defaultIsOpen = true,
+  defaultIsOpen = false,
   onCancelOrder,
   order,
   action,
 }: NotificationCardProps) => {
   const { isOpen, onToggle } = useDisclosure({ defaultIsOpen })
-  const { createdAt, status, type } = action
+  const { updatedAt, status, type } = action
 
   const formattedDate = useMemo(() => {
     const now = dayjs()
-    const notificationDate = dayjs(createdAt)
+    const notificationDate = dayjs(updatedAt)
     const sevenDaysAgo = now.subtract(7, 'day')
 
     if (notificationDate.isAfter(sevenDaysAgo)) {
@@ -64,7 +64,7 @@ export const LimitOrderActionCard = ({
     } else {
       return notificationDate.toDate().toLocaleString()
     }
-  }, [createdAt])
+  }, [updatedAt])
 
   const handleClick = useCallback(() => {
     if (isCollapsable) {

--- a/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon, ChevronUpIcon, ExternalLinkIcon } from '@chakra-ui/icons'
+import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons'
 import {
   Card,
   CardBody,
@@ -6,7 +6,6 @@ import {
   Flex,
   HStack,
   Icon,
-  Link,
   Stack,
   useDisclosure,
 } from '@chakra-ui/react'
@@ -44,7 +43,7 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
 
   const formattedDate = useMemo(() => {
     const now = dayjs()
-    const notificationDate = dayjs(action.createdAt)
+    const notificationDate = dayjs(action.updatedAt)
     const sevenDaysAgo = now.subtract(7, 'day')
 
     if (notificationDate.isAfter(sevenDaysAgo)) {
@@ -52,21 +51,21 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
     } else {
       return notificationDate.toDate().toLocaleString()
     }
-  }, [action.createdAt])
+  }, [action.updatedAt])
 
   const swap = useMemo(() => {
     return swapsById[action.swapMetadata.swapId]
   }, [action, swapsById])
 
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: isCollapsable })
+  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: swap?.isStreaming })
 
   const hoverProps = useMemo(
     () => ({
-      bg: swap?.txLink || isCollapsable ? 'background.button.secondary.hover' : 'transparent',
-      cursor: swap?.txLink || isCollapsable ? 'pointer' : 'default',
+      bg: isCollapsable ? 'background.button.secondary.hover' : 'transparent',
+      cursor: isCollapsable ? 'pointer' : 'default',
       textDecoration: 'none',
     }),
-    [swap?.txLink, isCollapsable],
+    [isCollapsable],
   )
 
   const handleClick = useCallback(() => {
@@ -121,9 +120,6 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
       borderRadius='lg'
       transitionProperty='common'
       transitionDuration='fast'
-      as={Link}
-      href={swap?.txLink && !swap.isStreaming && !isCollapsable ? swap.txLink : undefined}
-      isExternal
       _hover={hoverProps}
     >
       <Flex gap={4} alignItems='flex-start' px={4} py={4}>
@@ -155,9 +151,6 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
                 )}
               </HStack>
             </Stack>
-            {!isCollapsable && swap.txLink && (
-              <Icon as={ExternalLinkIcon} ml='auto' my='auto' fontSize='sm' />
-            )}
             {isCollapsable && (
               <Icon
                 as={isOpen ? ChevronUpIcon : ChevronDownIcon}

--- a/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
@@ -26,6 +26,7 @@ import { RawText } from '@/components/Text'
 import type { TextPropTypes } from '@/components/Text/Text'
 import { Text } from '@/components/Text/Text'
 import type { SwapAction } from '@/state/slices/actionSlice/types'
+import { ActionStatus } from '@/state/slices/actionSlice/types'
 import { swapSlice } from '@/state/slices/swapSlice/swapSlice'
 import { useAppSelector } from '@/state/store'
 
@@ -57,7 +58,9 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
     return swapsById[action.swapMetadata.swapId]
   }, [action, swapsById])
 
-  const { isOpen, onToggle } = useDisclosure({ defaultIsOpen: swap?.isStreaming })
+  const { isOpen, onToggle } = useDisclosure({
+    defaultIsOpen: swap?.isStreaming && action.status === ActionStatus.Pending,
+  })
 
   const hoverProps = useMemo(
     () => ({

--- a/src/hooks/useActionCenterSubscriber/useLimitOrderActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscriber/useLimitOrderActionSubscriber.tsx
@@ -58,8 +58,9 @@ export const useLimitOrderActionSubscriber = ({
   const { currentData: ordersResponse } = useLimitOrdersQuery()
   const toast = useToast({
     position: 'bottom-right',
-    duration: null,
+    duration: isDrawerOpen ? 5000 : null,
   })
+  const previousIsDrawerOpen = usePrevious(isDrawerOpen)
   const openLimitOrders = useAppSelector(selectOpenLimitOrderActionsFilteredByWallet)
   const quoteExpirationTimestamp = useAppSelector(selectActiveQuoteExpirationTimestamp)
 
@@ -81,10 +82,10 @@ export const useLimitOrderActionSubscriber = ({
   const actions = useAppSelector(selectLimitOrderActionsByWallet)
 
   useEffect(() => {
-    if (isDrawerOpen) {
+    if (isDrawerOpen && !previousIsDrawerOpen) {
       toast.closeAll()
     }
-  }, [isDrawerOpen, toast])
+  }, [isDrawerOpen, toast, previousIsDrawerOpen])
 
   // Create action after user confirmed the intent of placing a limit order
   useEffect(() => {

--- a/src/hooks/useActionCenterSubscriber/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscriber/useSwapActionSubscriber.tsx
@@ -45,7 +45,7 @@ export const useSwapActionSubscriber = ({
   const translate = useTranslate()
 
   const toast = useToast({
-    duration: null,
+    duration: isDrawerOpen ? 5000 : null,
     position: 'bottom-right',
   })
 
@@ -56,12 +56,13 @@ export const useSwapActionSubscriber = ({
   } = useWallet()
   const activeSwapId = useAppSelector(swapSlice.selectors.selectActiveSwapId)
   const previousSwapStatus = usePrevious(activeSwapId ? swapsById[activeSwapId]?.status : undefined)
+  const previousIsDrawerOpen = usePrevious(isDrawerOpen)
 
   useEffect(() => {
-    if (isDrawerOpen) {
+    if (isDrawerOpen && !previousIsDrawerOpen) {
       toast.closeAll()
     }
-  }, [isDrawerOpen, toast])
+  }, [isDrawerOpen, toast, previousIsDrawerOpen])
 
   // Create swap and action after user confirmed the intent
   useEffect(() => {


### PR DESCRIPTION
## Description
- Make tx link consistent (always collapsable with the link button as content), not collapsable until we have a tx link
- Display toast even if the action center drawer is opened but make it timeout after 5s
- Use `updatedAt` dates instead of `createdAt` in all the action card details
- Hide content of action cards by default (except for pending streaming swaps)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

spotted while ops testings here: https://discord.com/channels/554694662431178782/1385698719759994890/1387290254196871308

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to do some swaps without the drawer opened, click on toast it should open the drawer and dismiss all toasts
- Try to do some swaps with the drawer opened
- You can also try a streaming swap and verify the content is opened by default in the drawer
- If the streaming is success, the streaming swap content should be closed by default
- Try limit orders, it should behave the same as swaps

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/fa1ef805-466e-428a-aae0-72a09be70fdf