### PR TITLE
fix: copy state on mobile app

### DIFF
--- a/src/components/MobileWalletDialog/routes/ManualBackup/ManualBackup.tsx
+++ b/src/components/MobileWalletDialog/routes/ManualBackup/ManualBackup.tsx
@@ -5,7 +5,6 @@ import {
   Icon,
   SimpleGrid,
   Text as CText,
-  useClipboard,
   useColorModeValue,
   VStack,
 } from '@chakra-ui/react'
@@ -30,6 +29,7 @@ import {
   DialogHeaderRight,
 } from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
+import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
 
 const copyIcon = <Icon as={FiCopy} />
 
@@ -70,7 +70,15 @@ export const ManualBackup = ({ showContinueButton = true }: ManualBackupProps) =
     return location.state.vault.getWords() ?? []
   }, [location.state?.vault])
 
-  const { onCopy, hasCopied } = useClipboard(!revokedRef.current ? words.join(' ') : '')
+  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
+
+  const handleCopyClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation()
+      copyToClipboard(!revokedRef.current ? words.join(' ') : '')
+    },
+    [copyToClipboard, words, revokedRef],
+  )
 
   const wordsButtonList = useMemo(() => {
     if (revokedRef.current) return null
@@ -143,12 +151,12 @@ export const ManualBackup = ({ showContinueButton = true }: ManualBackupProps) =
             <Box flex={1} height='1px' backgroundColor='text.subtle' />
             <Button
               variant='ghost'
-              onClick={onCopy}
+              onClick={handleCopyClick}
               leftIcon={copyIcon}
               color='text.subtle'
               flexShrink={0}
             >
-              {hasCopied
+              {isCopied
                 ? translate('walletProvider.manualBackup.copied')
                 : translate('walletProvider.manualBackup.copyToClipboard')}
             </Button>

--- a/src/hooks/useCopyToClipboard.tsx
+++ b/src/hooks/useCopyToClipboard.tsx
@@ -21,15 +21,15 @@ export function useCopyToClipboard({ timeout = 2000 }: useCopyToClipboardProps) 
     if (isCopying) return
     setIsCopying(true)
 
-    void navigator.clipboard.writeText(value).then(() => {
-      setIsCopied(true)
+    void navigator.clipboard.writeText(value)
 
-      setTimeout(() => {
-        // Reset the state after the timeout
-        setIsCopying(false)
-        setIsCopied(false)
-      }, timeout)
-    })
+    setIsCopied(true)
+
+    setTimeout(() => {
+      // Reset the state after the timeout
+      setIsCopying(false)
+      setIsCopied(false)
+    }, timeout)
   }
 
   return { isCopied, copyToClipboard }


### PR DESCRIPTION
## Description

Copy states were bork on mobile, specially when using the "backup" view, because `clipboard` has a different implementation on mobile app than inside a browser and doesn't return a promise, if we base the behavior of the isCopied state on the promise, it wont work for mobile

Assuming if the user clicks it is going to copy anyway, I don't see a point where this would be erroring 

If we don't agree with this, we can always fix for the backup view only until we update the mobile app

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Just caught while playing around

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- On mobile app, using expo, try to use the backup modal and copy the seed phrase
- Button should say "Copied" and after 2 second it should come back to "Copy to clipboard"
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/f1b6afca-66fe-4fa8-8e3f-7c2d407b44cf