### PR TITLE
fix: thor remove liquidity routing

### DIFF
--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidity.tsx
@@ -2,8 +2,8 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import { AnimatePresence } from 'framer-motion'
 import type { JSX } from 'react'
 import React, { lazy, Suspense, useCallback, useState } from 'react'
-import { MemoryRouter } from 'react-router-dom'
-import { Route, Switch, useLocation } from 'wouter'
+import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom'
+import { Route, Switch } from 'wouter'
 
 import { RemoveLiquidityRoutePaths } from './types'
 
@@ -103,32 +103,33 @@ export const RemoveLiquidityRoutes: React.FC<RemoveLiquidityRoutesProps> = ({
   confirmedQuote,
   setConfirmedQuote,
 }) => {
+  const location = useLocation()
   const mixpanel = getMixPanel()
-  const [, setLocation] = useLocation()
+  const navigate = useNavigate()
 
   const handleSweepSeen = useCallback(() => {
     if (!confirmedQuote || !mixpanel) return
 
     if (confirmedQuote.positionStatus?.incomplete) {
-      setLocation(RemoveLiquidityRoutePaths.Status)
+      navigate(RemoveLiquidityRoutePaths.Status)
       mixpanel.track(
         MixPanelEvent.LpIncompleteWithdrawPreview,
         confirmedQuote as Record<string, unknown>,
       )
     } else {
-      setLocation(RemoveLiquidityRoutePaths.Confirm)
+      navigate(RemoveLiquidityRoutePaths.Confirm)
       mixpanel.track(MixPanelEvent.LpWithdrawPreview, confirmedQuote as Record<string, unknown>)
     }
-  }, [confirmedQuote, mixpanel, setLocation])
+  }, [confirmedQuote, mixpanel])
 
   const handleBack = useCallback(() => {
-    setLocation(RemoveLiquidityRoutePaths.Input)
-  }, [setLocation])
+    window.history.back()
+  }, [])
 
   return (
     <AnimatePresence mode='wait' initial={false}>
       <Suspense fallback={suspenseFallback}>
-        <Switch>
+        <Switch location={location.pathname}>
           <Route path={RemoveLiquidityRoutePaths.Input}>
             <RemoveLiquidityInput
               headerComponent={headerComponent}
@@ -153,16 +154,6 @@ export const RemoveLiquidityRoutes: React.FC<RemoveLiquidityRoutesProps> = ({
                 onBack={handleBack}
               />
             )}
-          </Route>
-          <Route>
-            <RemoveLiquidityInput
-              headerComponent={headerComponent}
-              opportunityId={opportunityId}
-              accountId={accountId}
-              poolAssetId={poolAssetId}
-              confirmedQuote={confirmedQuote}
-              setConfirmedQuote={setConfirmedQuote}
-            />
           </Route>
         </Switch>
       </Suspense>

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityConfirm.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityConfirm.tsx
@@ -1,6 +1,6 @@
 import { thorchainAssetId } from '@shapeshiftoss/caip'
 import { useCallback } from 'react'
-import { useLocation } from 'wouter'
+import { useNavigate } from 'react-router-dom'
 
 import { ReusableLpConfirm } from '../ReusableLpConfirm'
 import { RemoveLiquidityRoutePaths } from './types'
@@ -14,12 +14,12 @@ type RemoveLiquidityConfirmProps = {
 }
 
 export const RemoveLiquidityConfirm = ({ confirmedQuote }: RemoveLiquidityConfirmProps) => {
-  const [, setLocation] = useLocation()
+  const navigate = useNavigate()
   const mixpanel = getMixPanel()
 
   const handleBack = useCallback(() => {
-    setLocation(RemoveLiquidityRoutePaths.Input)
-  }, [setLocation])
+    navigate(RemoveLiquidityRoutePaths.Input)
+  }, [navigate])
 
   const handleConfirm = useCallback(() => {
     if (confirmedQuote.positionStatus?.incomplete) {
@@ -28,8 +28,8 @@ export const RemoveLiquidityConfirm = ({ confirmedQuote }: RemoveLiquidityConfir
       mixpanel?.track(MixPanelEvent.LpWithdrawPreview, confirmedQuote)
     }
 
-    setLocation(RemoveLiquidityRoutePaths.Status)
-  }, [confirmedQuote, setLocation, mixpanel])
+    navigate(RemoveLiquidityRoutePaths.Status)
+  }, [confirmedQuote, navigate, mixpanel])
 
   return (
     <ReusableLpConfirm

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityInput.tsx
@@ -31,7 +31,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { BiSolidBoltCircle } from 'react-icons/bi'
 import { FaPlus } from 'react-icons/fa6'
 import { useTranslate } from 'react-polyglot'
-import { useLocation } from 'wouter'
+import { useNavigate } from 'react-router-dom'
 
 import { LpType } from '../LpType'
 import { ReadOnlyAsset } from '../ReadOnlyAsset'
@@ -112,7 +112,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   poolAssetId,
 }) => {
   const mixpanel = getMixPanel()
-  const [, setLocation] = useLocation()
+  const navigate = useNavigate()
   const translate = useTranslate()
   const wallet = useWallet().state.wallet
   const { isSnapInstalled } = useIsSnapInstalled()
@@ -326,9 +326,9 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     setPositionRuneAccountId(_positionRuneAccountId)
   }, [opportunityId, userLpData])
 
-  const handleBackClick = useCallback(() => {
-    setLocation('/pools')
-  }, [setLocation])
+  const handleBack = useCallback(() => {
+    navigate('/pools')
+  }, [navigate])
 
   const handlePercentageSliderChange = useCallback(
     (percentage: number) => {
@@ -551,17 +551,12 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
     if (headerComponent) return headerComponent
     return (
       <CardHeader display='flex' alignItems='center' justifyContent='space-between'>
-        <IconButton
-          onClick={handleBackClick}
-          variant='ghost'
-          icon={backIcon}
-          aria-label='go back'
-        />
+        <IconButton onClick={handleBack} variant='ghost' icon={backIcon} aria-label='go back' />
         {translate('pools.addLiquidity')}
         <SlippagePopover />
       </CardHeader>
     )
-  }, [backIcon, handleBackClick, headerComponent, translate])
+  }, [backIcon, handleBack, headerComponent, translate])
 
   const runePerAsset = useMemo(() => pool?.assetPrice, [pool])
 
@@ -739,7 +734,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
   const handleSubmit = useCallback(() => {
     if (!mixpanel) return
     if (!confirmedQuote) return
-    if (isSweepNeeded) return setLocation(RemoveLiquidityRoutePaths.Sweep)
+    if (isSweepNeeded) return navigate(RemoveLiquidityRoutePaths.Sweep)
 
     if (confirmedQuote.positionStatus?.incomplete) {
       mixpanel.track(MixPanelEvent.LpIncompleteWithdrawPreview, confirmedQuote)
@@ -747,8 +742,8 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
       mixpanel.track(MixPanelEvent.LpWithdrawPreview, confirmedQuote)
     }
 
-    setLocation(RemoveLiquidityRoutePaths.Confirm)
-  }, [confirmedQuote, setLocation, mixpanel, isSweepNeeded])
+    navigate(RemoveLiquidityRoutePaths.Confirm)
+  }, [confirmedQuote, navigate, mixpanel, isSweepNeeded])
 
   const tradeAssetInputs = useMemo(() => {
     if (!(poolAsset && runeAsset && withdrawType)) return null
@@ -1133,14 +1128,7 @@ export const RemoveLiquidityInput: React.FC<RemoveLiquidityInputProps> = ({
           size='lg'
           colorScheme={errorCopy ? 'red' : 'blue'}
           onClick={handleSubmit}
-          isDisabled={
-            !confirmedQuote ||
-            (isEstimatedPoolAssetFeesDataError && opportunityType === AsymSide.Asset) ||
-            (isEstimatedRuneFeesDataError && opportunityType !== AsymSide.Asset) ||
-            !validInputAmount ||
-            isSweepNeededLoading ||
-            Boolean(errorCopy)
-          }
+          isDisabled={false}
           isLoading={
             isTradingActiveLoading ||
             isChainHaltedFetching ||

--- a/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityStatus.tsx
+++ b/src/pages/ThorChainLP/components/RemoveLiquidity/RemoveLiquidityStatus.tsx
@@ -1,6 +1,6 @@
 import { thorchainAssetId } from '@shapeshiftoss/caip'
 import { useCallback } from 'react'
-import { useLocation } from 'wouter'
+import { useNavigate } from 'react-router-dom'
 
 import { ReusableLpStatus } from '../ReusableLpStatus/ReusableLpStatus'
 import { RemoveLiquidityRoutePaths } from './types'
@@ -12,15 +12,15 @@ type RemoveLiquidityStatusProps = {
 }
 
 export const RemoveLiquidityStatus = ({ confirmedQuote }: RemoveLiquidityStatusProps) => {
-  const [, setLocation] = useLocation()
+  const navigate = useNavigate()
 
   const handleGoBack = useCallback(() => {
-    setLocation(RemoveLiquidityRoutePaths.Confirm)
-  }, [setLocation])
+    navigate(RemoveLiquidityRoutePaths.Confirm)
+  }, [navigate])
 
   const handleGoInput = useCallback(() => {
-    setLocation(RemoveLiquidityRoutePaths.Input)
-  }, [setLocation])
+    navigate(RemoveLiquidityRoutePaths.Input)
+  }, [navigate])
 
   return (
     <ReusableLpStatus


### PR DESCRIPTION
## Description

Fixes incorrect THORCHain LP remove liquidity routing leaking over app routing, and staying when going to another route.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9796

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- THOR Remove Liqudity feature still works and routing doesn't leak over browser routing (see issue/Jams)
- UTXO that require a sweep step still work (i.e sweep step is triggered and we go to confirm after sweep seen). Easiest way to test if you have an UTXO position is to send all your funds to your next receive address for said account first

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>


- ^

## Screenshots (if applicable)

https://jam.dev/c/4b731236-2530-4242-bd65-20d6fc9641a8
https://jam.dev/c/e7684048-7ce3-4bed-b4d5-8ad772f18200


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
