### PR TITLE
feat: notifications center empty state

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2965,6 +2965,11 @@
       "claimAvailable": "Claim Available",
       "unknown": "Unknown"
     },
+    "emptyState": {
+      "title": "Welcome to ShapeShift",
+      "body1": "This is your action center.",
+      "body2": "Find transactions in progress here."
+    },
     "swap": {
       "processing": "Your swap of %{sellAmountAndSymbol} to %{buyAmountAndSymbol} is being processed.",
       "complete": "Your swap of %{sellAmountAndSymbol} to %{buyAmountAndSymbol} is complete.",

--- a/src/components/Layout/Header/ActionCenter/ActionCenter.tsx
+++ b/src/components/Layout/Header/ActionCenter/ActionCenter.tsx
@@ -16,6 +16,7 @@ import { memo, useMemo, useState } from 'react'
 import { TbBellFilled } from 'react-icons/tb'
 import { useTranslate } from 'react-polyglot'
 
+import { EmptyState } from './components/EmptyState'
 import { LimitOrderActionCard } from './components/LimitOrderActionCard'
 import { SwapActionCard } from './components/SwapActionCard'
 
@@ -51,7 +52,7 @@ export const ActionCenter = memo(() => {
   const { ordersByActionId } = useLimitOrders()
   const swapsById = useAppSelector(swapSlice.selectors.selectSwapsById)
 
-  const actionsCards = useMemo(() => {
+  const maybeActionCards = useMemo(() => {
     return actions.map(action => {
       const actionsCards = (() => {
         switch (action.type) {
@@ -88,6 +89,12 @@ export const ActionCenter = memo(() => {
       return actionsCards
     })
   }, [actions, ordersByActionId, swapsById])
+
+  const actionCardsOrEmpty = useMemo(() => {
+    if (!maybeActionCards.length) return <EmptyState onClose={onClose} />
+
+    return maybeActionCards
+  }, [maybeActionCards])
 
   const actionCenterButton = useMemo(() => {
     if (pendingActions.length) {
@@ -148,7 +155,7 @@ export const ActionCenter = memo(() => {
               height='calc(100vh - 70px - env(safe-area-inset-top))'
               className='scroll-container'
             >
-              {actionsCards}
+              {actionCardsOrEmpty}
             </Box>
           </Box>
         </DrawerContent>

--- a/src/components/Layout/Header/ActionCenter/components/EmptyState.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/EmptyState.tsx
@@ -1,0 +1,62 @@
+import { Box, Button, Card, CardBody, Flex, HStack, Icon, Stack } from '@chakra-ui/react'
+import { useCallback } from 'react'
+import { TbBellFilled } from 'react-icons/tb'
+import { useTranslate } from 'react-polyglot'
+import { useNavigate } from 'react-router'
+
+import { Text } from '@/components/Text/Text'
+
+export const EmptyState = ({ onClose }: { onClose: () => void }) => {
+  const navigate = useNavigate()
+  const translate = useTranslate()
+
+  const handleStartSwappingClick = useCallback(() => {
+    navigate('/trade')
+    onClose()
+  }, [navigate])
+
+  return (
+    <Stack spacing={4} mx={2} borderRadius='lg' transitionProperty='common'>
+      <Flex gap={4} alignItems='flex-start' px={4} py={4}>
+        <Flex
+          align='center'
+          justify='center'
+          minW='45px'
+          minH='45px'
+          borderRadius='50%'
+          bg='blue.500'
+        >
+          <Icon as={TbBellFilled} boxSize={7} color='white' />
+        </Flex>
+        <Stack spacing={0} width='full'>
+          <HStack>
+            <Stack spacing={1} width='full'>
+              <Text fontSize='md' translation='notificationCenter.emptyState.title' />
+              <Box>
+                <Text
+                  fontSize='sm'
+                  color='text.subtle'
+                  translation='notificationCenter.emptyState.body1'
+                />
+                <Text
+                  fontSize='sm'
+                  color='text.subtle'
+                  translation='notificationCenter.emptyState.body2'
+                />
+              </Box>
+            </Stack>
+          </HStack>
+          <Card bg='transparent' mt={4}>
+            <CardBody px={0} py={0}>
+              <Stack gap={4}>
+                <Button colorScheme='blue' width='full' onClick={handleStartSwappingClick}>
+                  {translate('Start Swapping')}
+                </Button>
+              </Stack>
+            </CardBody>
+          </Card>
+        </Stack>
+      </Flex>
+    </Stack>
+  )
+}


### PR DESCRIPTION
## Description

Does what it says on the box - adds empty state for notification center.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9792

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Empty state is shown when there are no notifications (and by extension, is not when there are any)
- "Start Swapping" works from anywhere in the app and routes to swapper

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/761d9437-1f97-47f5-bad0-50f9a3d64794


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
