### PR TITLE
feat: add basic/advanced toggle to quote cards and card redesign

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -847,6 +847,15 @@
       "warning": "High slippage tolerances can result in unfavorable trades.",
       "lowSlippage": "Slippage below 0.05% may result in a failed transaction."
     },
+    "quoteBadge": {
+      "bestRate": "Best Rate",
+      "fastest": "Fastest",
+      "lowestGas": "Lowest Gas"
+    },
+     "quoteDisplay": {
+      "title": "Quote Display",
+      "info": "Choose your quote display style."
+    },
     "sort": {
       "sortBy": "Sort Quotes By",
       "auto": "Auto",
@@ -1041,7 +1050,10 @@
     "fiatAmountOnChain": "%{amountFiatFormatted} on %{chainName}",
     "quote": {
       "cantSetSlippage": "We are unable to set a custom slippage (%{userSlippageFormatted}) for %{swapperName}",
-      "slippage": "Slippage: %{slippageFormatted}"
+      "gas": "The gas to complete this swapper's transaction.",
+      "priceImpact": "The price impact on the route for this swap.",
+      "slippage": "This is the slippage on this quote.",
+      "timeEstimate": "This is the estimated time for this swap to complete."
     },
     "awaitingPermit2Approval": "Awaiting token transfer",
     "awaitingSwap": "Awaiting swap via %{swapperName}",

--- a/src/components/MultiHopTrade/components/SharedTradeInput/QuoteDisplaySelector.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/QuoteDisplaySelector.tsx
@@ -1,0 +1,54 @@
+import { Box, Button, ButtonGroup } from '@chakra-ui/react'
+import type { FC } from 'react'
+import { memo, useCallback } from 'react'
+
+import { Text } from '@/components/Text'
+import { preferences, QuoteDisplayOption } from '@/state/slices/preferencesSlice/preferencesSlice'
+import { useAppDispatch, useAppSelector } from '@/state/store'
+
+export const QuoteDisplaySelector: FC = memo(() => {
+  const quoteDisplayOption = useAppSelector(preferences.selectors.selectQuoteDisplayOption)
+
+  const dispatch = useAppDispatch()
+
+  const handleBasicDisplaySelect = useCallback((): void => {
+    dispatch(preferences.actions.setQuoteDisplayOption(QuoteDisplayOption.Basic))
+  }, [dispatch])
+
+  const handleAdvancedDisplaySelect = useCallback((): void => {
+    dispatch(preferences.actions.setQuoteDisplayOption(QuoteDisplayOption.Advanced))
+  }, [dispatch])
+
+  return (
+    <Box>
+      <Text translation='trade.quoteDisplay.title' />
+      <Text
+        translation='trade.quoteDisplay.info'
+        fontWeight='medium'
+        fontSize='xs'
+        color='text.subtle'
+      />
+      <ButtonGroup
+        size='sm'
+        bg='background.input.base'
+        mt={4}
+        p={1}
+        borderRadius='xl'
+        variant='ghost'
+      >
+        <Button
+          isActive={quoteDisplayOption === QuoteDisplayOption.Basic}
+          onClick={handleBasicDisplaySelect}
+        >
+          Basic
+        </Button>
+        <Button
+          isActive={quoteDisplayOption === QuoteDisplayOption.Advanced}
+          onClick={handleAdvancedDisplaySelect}
+        >
+          Advanced
+        </Button>
+      </ButtonGroup>
+    </Box>
+  )
+})

--- a/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/QuoteSortSelector.tsx
@@ -21,7 +21,7 @@ export const QuoteSortSelector: FC = memo(() => {
       <Text translation='trade.sort.sortBy' />
       <Text translation='trade.sort.info' fontWeight='medium' fontSize='xs' color='text.subtle' />
       <ButtonGroup
-        mt={6}
+        mt={4}
         size='sm'
         borderRadius='xl'
         variant='ghost'

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedSettingsPopover.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Button,
   ButtonGroup,
+  Divider,
   FormControl,
   IconButton,
   Input,
@@ -22,6 +23,7 @@ import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FaGear } from 'react-icons/fa6'
 import { useTranslate } from 'react-polyglot'
 
+import { QuoteDisplaySelector } from './QuoteDisplaySelector'
 import { QuoteSortSelector } from './QuoteSortSelector'
 
 import { HelperTooltip } from '@/components/HelperTooltip/HelperTooltip'
@@ -145,8 +147,8 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
           </Box>
         </Tooltip>
         <PopoverContent>
-          <PopoverBody>
-            <Row>
+          <PopoverBody px={0} py={4}>
+            <Row px={4}>
               <Row.Label>
                 <HelperTooltip label={translate('trade.slippageInfo')}>
                   <Text translation='trade.slippage.maxSlippage' />
@@ -154,7 +156,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
               </Row.Label>
               <Row.Value>{slippageType === SlippageType.Auto && 'Auto'}</Row.Value>
             </Row>
-            <Row py={2} gap={2} mt={2}>
+            <Row px={4} py={2} gap={2} mt={2}>
               <Row.Value>
                 <ButtonGroup
                   size='sm'
@@ -199,7 +201,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
               )}
             </Row>
             {isHighSlippage && slippageType === SlippageType.Custom && (
-              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
+              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={4} py={0}>
                 <AlertIcon />
                 <AlertDescription lineHeight='1.5'>
                   {translate('trade.slippage.warning')}
@@ -207,7 +209,7 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
               </Alert>
             )}
             {isLowSlippage && slippageType === SlippageType.Custom && (
-              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={0} py={0}>
+              <Alert mt={2} fontSize='sm' status='warning' bg='transparent' px={4} py={0}>
                 <AlertIcon />
                 <AlertDescription lineHeight='1.5'>
                   {translate('trade.slippage.lowSlippage')}
@@ -215,11 +217,16 @@ export const SharedSettingsPopover: FC<SharedSettingsPopoverProps> = memo(
               </Alert>
             )}
 
+            <Divider mt={4} />
+
             {enableSortBy && (
-              <Box mt={4} borderTop='1px solid' borderTopColor='border.base' pt={4} width='full'>
+              <Box pt={4} px={4} width='full'>
                 <QuoteSortSelector />
               </Box>
             )}
+            <Box pt={6} px={4} width='full'>
+              <QuoteDisplaySelector />
+            </Box>
           </PopoverBody>
         </PopoverContent>
       </Popover>

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -25,9 +25,9 @@ import { selectIsTradeQuoteApiQueryPending } from '@/state/apis/swapper/selector
 import type { ApiQuote } from '@/state/apis/swapper/types'
 import { TradeQuoteValidationError } from '@/state/apis/swapper/types'
 import { selectInputBuyAsset, selectInputSellAsset } from '@/state/slices/tradeInputSlice/selectors'
+import { getBestQuotesByCategory } from '@/state/slices/tradeQuoteSlice/helpers'
 import {
   selectActiveQuoteMetaOrDefault,
-  selectBuyAmountAfterFeesCryptoPrecision,
   selectIsSwapperResponseAvailable,
   selectIsTradeQuoteRequestAborted,
   selectLoadingSwappers,
@@ -62,15 +62,16 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
   const availableTradeQuotesDisplayCache = useAppSelector(selectUserAvailableTradeQuotes)
   const unavailableTradeQuotesDisplayCache = useAppSelector(selectUserUnavailableTradeQuotes)
   const loadingSwappers = useAppSelector(selectLoadingSwappers)
-  const bestQuoteData = sortedQuotes[0]?.errors.length === 0 ? sortedQuotes[0] : undefined
   const translate = useTranslate()
   const buyAsset = useAppSelector(selectInputBuyAsset)
   const sellAsset = useAppSelector(selectInputSellAsset)
   const unavailableAccordionRef = useRef<HTMLDivElement>(null)
-  const bestTotalReceiveAmountCryptoPrecision = useAppSelector(
-    selectBuyAmountAfterFeesCryptoPrecision,
-  )
   const sortOption = useAppSelector(tradeQuoteSlice.selectors.selectQuoteSortOption)
+
+  const bestQuotesByCategory = useMemo(
+    () => getBestQuotesByCategory(availableTradeQuotesDisplayCache),
+    [availableTradeQuotesDisplayCache],
+  )
 
   const shouldUseComisSansMs = useMemo(() => {
     return buyAsset?.assetId === dogeAssetId || sellAsset?.assetId === dogeAssetId
@@ -100,8 +101,8 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
       return []
     }
 
-    return availableTradeQuotesDisplayCache.map((quoteData, i) => {
-      const { id, errors } = quoteData
+    return availableTradeQuotesDisplayCache.map(quoteData => {
+      const { id } = quoteData
 
       const isActive = activeQuoteMeta !== undefined && activeQuoteMeta.identifier === id
 
@@ -110,11 +111,11 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
           <TradeQuote
             isActive={isActive}
             isLoading={isQuoteLoading(quoteData)}
-            isBest={i === 0 && errors.length === 0}
+            isBestRate={bestQuotesByCategory.bestRate === quoteData.id}
+            isFastest={bestQuotesByCategory.fastest === quoteData.id}
+            isLowestGas={bestQuotesByCategory.lowestGas === quoteData.id}
             key={id}
             quoteData={quoteData}
-            bestTotalReceiveAmountCryptoPrecision={bestTotalReceiveAmountCryptoPrecision}
-            bestInputOutputRatio={bestQuoteData?.inputOutputRatio}
             onBack={onBack}
           />
         </MotionBox>
@@ -125,8 +126,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
     availableTradeQuotesDisplayCache,
     activeQuoteMeta,
     isQuoteLoading,
-    bestTotalReceiveAmountCryptoPrecision,
-    bestQuoteData?.inputOutputRatio,
+    bestQuotesByCategory,
     onBack,
   ])
 
@@ -140,22 +140,13 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
         <TradeQuote
           isActive={false}
           isLoading={isQuoteLoading(quoteData)}
-          isBest={false}
           key={quoteData.id}
           quoteData={quoteData}
-          bestTotalReceiveAmountCryptoPrecision={undefined}
-          bestInputOutputRatio={bestQuoteData?.inputOutputRatio}
           onBack={onBack}
         />
       )
     })
-  }, [
-    isTradeQuoteRequestAborted,
-    unavailableTradeQuotesDisplayCache,
-    isQuoteLoading,
-    bestQuoteData?.inputOutputRatio,
-    onBack,
-  ])
+  }, [isTradeQuoteRequestAborted, unavailableTradeQuotesDisplayCache, isQuoteLoading, onBack])
 
   const unavailableQuotesLength = useMemo(
     () =>
@@ -193,13 +184,10 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
           <TradeQuote
             isActive={false}
             isLoading={true}
-            isBest={false}
             key={id}
             // eslint doesn't understand useMemo not possible to use inside map
             // eslint-disable-next-line react-memo/require-usememo
             quoteData={quoteData}
-            bestTotalReceiveAmountCryptoPrecision={undefined}
-            bestInputOutputRatio={undefined}
             onBack={onBack}
           />
         </MotionBox>

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteBadges.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteBadges.tsx
@@ -1,0 +1,74 @@
+import type { FlexProps } from '@chakra-ui/react'
+import { Flex, Tag, TagLeftIcon, Tooltip, useColorModeValue } from '@chakra-ui/react'
+import type { FC } from 'react'
+import { useMemo } from 'react'
+import type { IconType } from 'react-icons'
+import { TbClockHour3, TbGasStation, TbRosetteDiscountCheckFilled } from 'react-icons/tb'
+import { useTranslate } from 'react-polyglot'
+
+type QuoteBadgeProps = { icon: IconType; label?: string; iconMode?: boolean }
+const QuoteBadge: FC<QuoteBadgeProps> = ({ icon, label, iconMode = false }) => {
+  const badgeBg = useColorModeValue('blackAlpha.50', 'whiteAlpha.50')
+  return (
+    <Tooltip label={iconMode ? label : undefined}>
+      <Tag gap={1.5} padding={2} rounded='full' backgroundColor={badgeBg} whiteSpace='nowrap'>
+        {iconMode ? null : label}
+        <TagLeftIcon as={icon} color='green.500' margin={0} />
+      </Tag>
+    </Tooltip>
+  )
+}
+
+export type TradeQuoteBadgesProps = FlexProps & {
+  isBestRate?: boolean
+  isFastest?: boolean
+  isLowestGas?: boolean
+  iconOnlyIfCount?: number
+}
+export const TradeQuoteBadges: React.FC<TradeQuoteBadgesProps> = ({
+  isBestRate,
+  isFastest,
+  isLowestGas,
+  iconOnlyIfCount,
+  ...rest
+}) => {
+  const translate = useTranslate()
+
+  const badgeCount = useMemo(
+    () => [isBestRate, isFastest, isLowestGas].reduce((acc, curr) => (curr ? acc + 1 : acc), 0),
+    [isBestRate, isFastest, isLowestGas],
+  )
+
+  const iconOnly = useMemo(
+    (): boolean => iconOnlyIfCount !== undefined && badgeCount >= iconOnlyIfCount,
+    [badgeCount, iconOnlyIfCount],
+  )
+
+  if (badgeCount === 0) return null
+
+  return (
+    <Flex alignItems='center' gap={2} {...rest}>
+      {isBestRate && (
+        <QuoteBadge
+          icon={TbRosetteDiscountCheckFilled}
+          iconMode={iconOnly}
+          label={translate('trade.quoteBadge.bestRate')}
+        />
+      )}
+      {isFastest && (
+        <QuoteBadge
+          icon={TbClockHour3}
+          iconMode={iconOnly}
+          label={translate('trade.quoteBadge.fastest')}
+        />
+      )}
+      {isLowestGas && (
+        <QuoteBadge
+          icon={TbGasStation}
+          iconMode={iconOnly}
+          label={translate('trade.quoteBadge.lowestGas')}
+        />
+      )}
+    </Flex>
+  )
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteCard.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteCard.tsx
@@ -5,7 +5,7 @@ import { useMemo } from 'react'
 
 import { SwapperIcon } from '../../SwapperIcon/SwapperIcon'
 
-import { RawText } from '@/components/Text'
+import { TooltipWithTouch } from '@/components/TooltipWithTouch'
 
 const borderRadius = { base: 'md', md: 'lg' }
 const hoverProps = {
@@ -14,8 +14,8 @@ const hoverProps = {
 }
 
 export type TradeQuoteCardProps = {
-  title: string
   swapperName: SwapperName
+  swapperTitle?: string
   isActive: boolean
   isActionable: boolean
   headerContent: JSX.Element
@@ -25,8 +25,8 @@ export type TradeQuoteCardProps = {
 }
 
 export const TradeQuoteCard = ({
-  title,
   swapperName,
+  swapperTitle,
   isActive,
   isActionable,
   headerContent,
@@ -67,20 +67,11 @@ export const TradeQuoteCard = ({
       transitionProperty='common'
       transitionDuration='normal'
     >
-      <CardHeader fontWeight='normal' fontSize='sm' pl={3} pr={4}>
-        <Flex justifyContent='space-between' alignItems='center'>
-          <Flex
-            gap={2}
-            alignItems='center'
-            overflow='hidden'
-            textOverflow='ellipsis'
-            whiteSpace='nowrap'
-          >
-            <SwapperIcon swapperName={swapperName} />
-            <RawText fontWeight='medium' isTruncated>
-              {title}
-            </RawText>
-          </Flex>
+      <CardHeader fontWeight='normal' fontSize='sm' pl={3} pr={4} pb={2}>
+        <Flex alignItems='center' gap={2}>
+          <TooltipWithTouch label={swapperTitle}>
+            <SwapperIcon swapperName={swapperName} size='sm' />
+          </TooltipWithTouch>
           {headerContent}
         </Flex>
       </CardHeader>

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteExchangeRate.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteExchangeRate.tsx
@@ -1,0 +1,62 @@
+import type { FlexProps } from '@chakra-ui/react'
+import { Flex } from '@chakra-ui/react'
+import type { Asset } from '@shapeshiftoss/types'
+import type { BigNumber } from '@shapeshiftoss/utils'
+import { bn } from '@shapeshiftoss/utils'
+import { useCallback, useMemo, useState } from 'react'
+
+import { useLocaleFormatter } from '@/hooks/useLocaleFormatter/useLocaleFormatter'
+
+const hoverDottedUnderline = { textDecorationStyle: 'solid' }
+
+type TradeQuoteExchangeRateProps = FlexProps & {
+  buyAsset: Asset
+  sellAsset: Asset
+  totalReceiveAmountCryptoPrecision: string
+  sellAmountCryptoPrecision: string
+}
+export const TradeQuoteExchangeRate: React.FC<TradeQuoteExchangeRateProps> = ({
+  sellAsset,
+  buyAsset,
+  totalReceiveAmountCryptoPrecision,
+  sellAmountCryptoPrecision,
+  ...rest
+}) => {
+  const [shouldFlipRate, setShouldFlipRate] = useState<boolean>(false)
+
+  const exchangeRate = useMemo((): BigNumber.Value => {
+    const rate = bn(totalReceiveAmountCryptoPrecision).dividedBy(bn(sellAmountCryptoPrecision))
+    return shouldFlipRate ? bn(1).dividedBy(rate) : rate
+  }, [totalReceiveAmountCryptoPrecision, sellAmountCryptoPrecision, shouldFlipRate])
+
+  const {
+    number: { toCrypto },
+  } = useLocaleFormatter()
+
+  const handleFlipRate = useCallback(
+    (e: React.MouseEvent<HTMLDivElement, MouseEvent>): void => {
+      e.stopPropagation()
+      setShouldFlipRate(!shouldFlipRate)
+    },
+    [shouldFlipRate],
+  )
+
+  const fromAsset = shouldFlipRate ? buyAsset : sellAsset
+  const toAsset = shouldFlipRate ? sellAsset : buyAsset
+
+  return (
+    <Flex
+      gap={1}
+      alignItems='center'
+      fontSize='sm'
+      fontWeight='medium'
+      textUnderlineOffset='4px'
+      textDecoration='underline dotted'
+      onClick={handleFlipRate}
+      _hover={hoverDottedUnderline}
+      {...rest}
+    >
+      {`1 ${fromAsset.symbol} = ${toCrypto(exchangeRate, toAsset.symbol)}`}
+    </Flex>
+  )
+}

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteMetaItem.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/components/TradeQuoteMetaItem.tsx
@@ -1,0 +1,25 @@
+import type { FlexProps } from '@chakra-ui/react'
+import { Flex, Icon, Skeleton, Tooltip } from '@chakra-ui/react'
+import type { IconType } from 'react-icons'
+
+type TradeQuoteMetaItemProps = FlexProps & {
+  tooltip?: string
+  icon: IconType
+  error?: boolean
+  isLoading: boolean
+}
+export const TradeQuoteMetaItem: React.FC<TradeQuoteMetaItemProps> = ({
+  tooltip,
+  icon,
+  error,
+  isLoading,
+  children,
+  ...rest
+}) => (
+  <Tooltip label={tooltip}>
+    <Flex gap={1} alignItems='center' {...rest}>
+      <Icon as={icon} color={error ? 'text.error' : 'text.subtle'} boxSize={18} />
+      <Skeleton isLoaded={!isLoading}>{children}</Skeleton>
+    </Flex>
+  </Tooltip>
+)

--- a/src/state/slices/preferencesSlice/preferencesSlice.ts
+++ b/src/state/slices/preferencesSlice/preferencesSlice.ts
@@ -99,6 +99,11 @@ export enum HomeMarketView {
   Watchlist = 'Watchlist',
 }
 
+export enum QuoteDisplayOption {
+  Basic = 'basic',
+  Advanced = 'Advanced',
+}
+
 export type Preferences = {
   featureFlags: FeatureFlags
   selectedLocale: string
@@ -112,6 +117,7 @@ export type Preferences = {
   snapInstalled: boolean
   watchedAssets: AssetId[]
   selectedHomeView: HomeMarketView
+  quoteDisplayOption: QuoteDisplayOption
 }
 
 const initialState: Preferences = {
@@ -194,6 +200,7 @@ const initialState: Preferences = {
   snapInstalled: false,
   watchedAssets: [],
   selectedHomeView: HomeMarketView.TopAssets,
+  quoteDisplayOption: QuoteDisplayOption.Basic,
 }
 
 export const preferences = createSlice({
@@ -261,6 +268,9 @@ export const preferences = createSlice({
     setHomeMarketView: create.reducer((state, { payload }: { payload: HomeMarketView }) => {
       state.selectedHomeView = payload
     }),
+    setQuoteDisplayOption: create.reducer((state, { payload }: { payload: QuoteDisplayOption }) => {
+      state.quoteDisplayOption = payload
+    }),
   }),
   selectors: {
     selectFeatureFlags: state => state.featureFlags,
@@ -274,5 +284,6 @@ export const preferences = createSlice({
     selectShowSnapsModal: state => state.showSnapsModal,
     selectSelectedHomeView: state => state.selectedHomeView,
     selectShowConsentBanner: state => state.showConsentBanner,
+    selectQuoteDisplayOption: state => state.quoteDisplayOption,
   },
 })

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -6,7 +6,11 @@ import {
   LimitPriceMode,
   PriceDirection,
 } from '@/state/slices/limitOrderInputSlice/constants'
-import { CurrencyFormats, HomeMarketView } from '@/state/slices/preferencesSlice/preferencesSlice'
+import {
+  CurrencyFormats,
+  HomeMarketView,
+  QuoteDisplayOption,
+} from '@/state/slices/preferencesSlice/preferencesSlice'
 import { QuoteSortOption } from '@/state/slices/tradeQuoteSlice/types'
 
 const mockApiFactory = <T extends unknown>(reducerPath: T) => ({
@@ -151,6 +155,7 @@ export const mockStore: ReduxState = {
       ThorchainTcyActivity: false,
       MayaSwap: false,
     },
+    quoteDisplayOption: QuoteDisplayOption.Basic,
     selectedLocale: 'en',
     balanceThreshold: '0',
     selectedCurrency: 'USD',


### PR DESCRIPTION
## Description

NOTE: this is based off of the polling PR. Please only review the final commit until that is merged and this is rebased.

This PR introduces toggling between "advanced" and "basic" quote card view as well as a few design and informational adjustments to the quote card.

* "Basic" mode removes slippage, price impact and exchange rate from the card
* We've replaced the percentage diff from best rate indicator in favour of an "overall loss" indicator. Shown in brackets after the fiat received amount. like "$9821(-$7.02)".
* We've introduced "Quote badges" instead of our "best" tag. Previously the best tag simply showed the "best" result based on your sort choice. Now, regardless of sort, we tag the Best Rate, Fastest and Lowest Gas.
* Small icon adjustments to the quote info data at the bottom of the card like slippage, gas, etc...
* Font adjustments
* Swapper icon no longer shows name (you can see it on hover)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9639 

## Risk

Medium risk

The actual changes here are generally either the clean removal of a feature no longer needed or design adjustments. There's no critical logic being fiddled with here. However, the swapper is a crucial component so it's still reasonably high risk even so.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Input an amount to trade/bridge to see the swapper
* Click the settings cog to toggle between advanced and basic view

![image](https://github.com/user-attachments/assets/ae561c37-f2b9-4174-a120-abfa006deea0)


* Test the cards at various screen sizes in both Advanced and Basic mode
* Test sorting and make sure the quote badges look correct for fastest, best rate and lowest gas
* Test scenarios where quotes have no badges or all the badges
* Test that the "loss amount in fiat" number looks correct. It should be the total amount how how much money you lose in fiat vs. how much you put in. Test changing currency

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

Tried to go with more of a min diff approach here but it's still somewhat noisy due to the need to shuffle things around a bit

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/d83ef7d1-21e1-4ef9-88ff-7e03dc269792
