### PR TITLE
feat: rm SupportedChainIds types and consts

### DIFF
--- a/packages/swapper/src/constants.ts
+++ b/packages/swapper/src/constants.ts
@@ -1,36 +1,26 @@
 import { assertUnreachable } from '@shapeshiftoss/utils'
 
-import { COW_SWAP_SUPPORTED_CHAIN_IDS } from './cowswap-utils/constants'
 import { arbitrumBridgeSwapper } from './swappers/ArbitrumBridgeSwapper/ArbitrumBridgeSwapper'
 import { arbitrumBridgeApi } from './swappers/ArbitrumBridgeSwapper/endpoints'
-import { ARBITRUM_BRIDGE_SUPPORTED_CHAIN_IDS } from './swappers/ArbitrumBridgeSwapper/utils/constants'
 import { butterSwap } from './swappers/ButterSwap/ButterSwap'
 import { butterSwapApi } from './swappers/ButterSwap/endpoints'
-import { BUTTERSWAP_SUPPORTED_CHAIN_IDS } from './swappers/ButterSwap/utils/constants'
 import { chainflipSwapper } from './swappers/ChainflipSwapper/ChainflipSwapper'
-import { CHAINFLIP_SUPPORTED_CHAIN_IDS } from './swappers/ChainflipSwapper/constants'
 import { chainflipApi } from './swappers/ChainflipSwapper/endpoints'
 import { cowSwapper } from './swappers/CowSwapper/CowSwapper'
 import { cowApi } from './swappers/CowSwapper/endpoints'
 import { jupiterApi } from './swappers/JupiterSwapper/endpoints'
 import { jupiterSwapper } from './swappers/JupiterSwapper/JupiterSwapper'
-import { JUPITER_SUPPORTED_CHAIN_IDS } from './swappers/JupiterSwapper/utils/constants'
-import { MAYACHAIN_SUPPORTED_CHAIN_IDS } from './swappers/MayachainSwapper'
 import { mayachainApi } from './swappers/MayachainSwapper/endpoints'
 import { mayachainSwapper } from './swappers/MayachainSwapper/MayachainSwapper'
-import { PORTALS_SUPPORTED_CHAIN_IDS } from './swappers/PortalsSwapper/constants'
 import { portalsApi } from './swappers/PortalsSwapper/endpoints'
 import { portalsSwapper } from './swappers/PortalsSwapper/PortalsSwapper'
 import { relaySwapper } from './swappers/RelaySwapper'
-import { RELAY_SUPPORTED_CHAIN_IDS } from './swappers/RelaySwapper/constant'
 import { relayApi } from './swappers/RelaySwapper/endpoints'
-import { THORCHAIN_SUPPORTED_CHAIN_IDS } from './swappers/ThorchainSwapper/constants'
 import { thorchainApi } from './swappers/ThorchainSwapper/endpoints'
 import { thorchainSwapper } from './swappers/ThorchainSwapper/ThorchainSwapper'
 import { zrxApi } from './swappers/ZrxSwapper/endpoints'
-import { ZRX_SUPPORTED_CHAIN_IDS } from './swappers/ZrxSwapper/utils/constants'
 import { zrxSwapper } from './swappers/ZrxSwapper/ZrxSwapper'
-import type { SupportedChainIds, Swapper, SwapperApi } from './types'
+import type { Swapper, SwapperApi } from './types'
 import { SwapperName } from './types'
 import { makeSwapErrorRight } from './utils'
 
@@ -45,68 +35,57 @@ export const QUOTE_TIMEOUT_ERROR = makeSwapErrorRight({
 // PartialRecord not used to ensure exhaustiveness
 export const swappers: Record<
   SwapperName,
-  | (SwapperApi & Swapper & { supportedChainIds: SupportedChainIds; pollingInterval: number })
-  | undefined
+  (SwapperApi & Swapper & { pollingInterval: number }) | undefined
 > = {
   [SwapperName.Thorchain]: {
     ...thorchainSwapper,
     ...thorchainApi,
-    supportedChainIds: THORCHAIN_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Mayachain]: {
     ...mayachainSwapper,
     ...mayachainApi,
-    supportedChainIds: MAYACHAIN_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Zrx]: {
     ...zrxSwapper,
     ...zrxApi,
-    supportedChainIds: ZRX_SUPPORTED_CHAIN_IDS,
 
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.CowSwap]: {
     ...cowSwapper,
     ...cowApi,
-    supportedChainIds: COW_SWAP_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.ArbitrumBridge]: {
     ...arbitrumBridgeSwapper,
     ...arbitrumBridgeApi,
-    supportedChainIds: ARBITRUM_BRIDGE_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Portals]: {
     ...portalsSwapper,
     ...portalsApi,
-    supportedChainIds: PORTALS_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Chainflip]: {
     ...chainflipSwapper,
     ...chainflipApi,
-    supportedChainIds: CHAINFLIP_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Jupiter]: {
     ...jupiterSwapper,
     ...jupiterApi,
-    supportedChainIds: JUPITER_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Relay]: {
     ...relaySwapper,
     ...relayApi,
-    supportedChainIds: RELAY_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.ButterSwap]: {
     ...butterSwap,
     ...butterSwapApi,
-    supportedChainIds: BUTTERSWAP_SUPPORTED_CHAIN_IDS,
     pollingInterval: DEFAULT_GET_TRADE_QUOTE_POLLING_INTERVAL,
   },
   [SwapperName.Test]: undefined,

--- a/packages/swapper/src/cowswap-utils/constants.ts
+++ b/packages/swapper/src/cowswap-utils/constants.ts
@@ -2,7 +2,6 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { zeroAddress } from 'viem'
 
-import type { SupportedChainIds } from '../types'
 
 export const ORDER_TYPE_FIELDS = [
   { name: 'sellToken', type: 'address' },
@@ -30,10 +29,6 @@ export const SUPPORTED_CHAIN_IDS: ChainId[] = [
   KnownChainIds.BaseMainnet,
 ]
 
-export const COW_SWAP_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: SUPPORTED_CHAIN_IDS,
-  buy: SUPPORTED_CHAIN_IDS,
-}
 
 export const COW_SWAP_VAULT_RELAYER_ADDRESS = '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
 export const COW_SWAP_SETTLEMENT_ADDRESS = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'

--- a/packages/swapper/src/cowswap-utils/constants.ts
+++ b/packages/swapper/src/cowswap-utils/constants.ts
@@ -2,7 +2,6 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import { zeroAddress } from 'viem'
 
-
 export const ORDER_TYPE_FIELDS = [
   { name: 'sellToken', type: 'address' },
   { name: 'buyToken', type: 'address' },
@@ -28,7 +27,6 @@ export const SUPPORTED_CHAIN_IDS: ChainId[] = [
   KnownChainIds.ArbitrumMainnet,
   KnownChainIds.BaseMainnet,
 ]
-
 
 export const COW_SWAP_VAULT_RELAYER_ADDRESS = '0xc92e8bdf79f0507f65a392b0ab4667716bfe0110'
 export const COW_SWAP_SETTLEMENT_ADDRESS = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'

--- a/packages/swapper/src/swappers/ArbitrumBridgeSwapper/utils/constants.ts
+++ b/packages/swapper/src/swappers/ArbitrumBridgeSwapper/utils/constants.ts
@@ -1,14 +1,6 @@
-import type { ChainId } from '@shapeshiftoss/caip'
 import { bn } from '@shapeshiftoss/utils'
 
-import type { SupportedChainIds } from '../../../types'
 import { BRIDGE_TYPE } from '../types'
-import { arbitrumBridgeSupportedChainIds } from './types'
-
-export const ARBITRUM_BRIDGE_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: arbitrumBridgeSupportedChainIds as unknown as ChainId[],
-  buy: arbitrumBridgeSupportedChainIds as unknown as ChainId[],
-}
 
 // Broad estimate calculated by looking at a couple of different ERC-20 deposits
 // https://github.com/OffchainLabs/arbitrum-token-bridge/blob/d17c88ef3eef3f4ffc61a04d34d50406039f045d/packages/arb-token-bridge-ui/src/util/TokenDepositUtils.ts#L45-L51

--- a/packages/swapper/src/swappers/ButterSwap/utils/constants.ts
+++ b/packages/swapper/src/swappers/ButterSwap/utils/constants.ts
@@ -1,36 +1,3 @@
-import {
-  arbitrumChainId,
-  bchChainId,
-  bscChainId,
-  btcChainId,
-  ethChainId,
-  optimismChainId,
-  polygonChainId,
-} from '@shapeshiftoss/caip'
-
-import type { SupportedChainIds } from '../../../types'
-
-export const BUTTERSWAP_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: [
-    ethChainId,
-    arbitrumChainId,
-    optimismChainId,
-    bscChainId,
-    polygonChainId,
-    bchChainId,
-    btcChainId,
-  ],
-  buy: [
-    ethChainId,
-    arbitrumChainId,
-    optimismChainId,
-    bscChainId,
-    polygonChainId,
-    bchChainId,
-    btcChainId,
-  ],
-}
-
 export const DEFAULT_BUTTERSWAP_AFFILIATE_BPS = 50
 
 const BUTTERSWAP_AFFILIATE = '' // TODO: add affiliate

--- a/packages/swapper/src/swappers/ChainflipSwapper/constants.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/constants.ts
@@ -13,7 +13,7 @@ import {
 import type { Asset } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import type { SupportedChainIds, SwapSource } from '../../types'
+import type { SwapSource } from '../../types'
 import { SwapperName } from '../../types'
 import { ChainflipNetwork } from './types'
 
@@ -41,11 +41,6 @@ export const chainIdToChainflipNetwork: Partial<Record<ChainId, ChainflipNetwork
   [KnownChainIds.ArbitrumMainnet]: ChainflipNetwork.Arbitrum,
   [KnownChainIds.BitcoinMainnet]: ChainflipNetwork.Bitcoin,
   [KnownChainIds.SolanaMainnet]: ChainflipNetwork.Solana,
-}
-
-export const CHAINFLIP_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: ChainflipSupportedChainIds as unknown as ChainId[],
-  buy: ChainflipSupportedChainIds as unknown as ChainId[],
 }
 
 export const CHAINFLIP_SWAP_SOURCE: SwapSource = SwapperName.Chainflip

--- a/packages/swapper/src/swappers/JupiterSwapper/utils/constants.ts
+++ b/packages/swapper/src/swappers/JupiterSwapper/utils/constants.ts
@@ -1,14 +1,7 @@
 import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
-import type { SupportedChainIds } from '../../../types'
-
 export const jupiterSupportedChainIds: ChainId[] = [KnownChainIds.SolanaMainnet]
-
-export const JUPITER_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: jupiterSupportedChainIds,
-  buy: jupiterSupportedChainIds,
-}
 
 export const PDA_ACCOUNT_CREATION_COST = 2040000
 

--- a/packages/swapper/src/swappers/MayachainSwapper/constants.ts
+++ b/packages/swapper/src/swappers/MayachainSwapper/constants.ts
@@ -1,8 +1,15 @@
+import { fromAssetId } from '@shapeshiftoss/caip'
+
 import type { SwapSource } from '../../types'
 import { SwapperName } from '../../types'
+import { assetIdToMayaPoolAssetIdMap } from './utils/poolAssetHelpers/poolAssetHelpers'
 
 export const CACAO_PRECISION = 10
 export const MAYACHAIN_PRECISION = 8
 export const MAYACHAIN_AFFILIATE_NAME = 'ssmaya'
+
+export const MAYACHAIN_SUPPORTED_CHAIN_IDS = [
+  ...new Set(Object.keys(assetIdToMayaPoolAssetIdMap).map(assetId => fromAssetId(assetId).chainId)),
+]
 
 export const MAYACHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Mayachain} • Streaming`

--- a/packages/swapper/src/swappers/MayachainSwapper/constants.ts
+++ b/packages/swapper/src/swappers/MayachainSwapper/constants.ts
@@ -1,24 +1,8 @@
-import { fromAssetId } from '@shapeshiftoss/caip'
-
-import type { SupportedChainIds, SwapSource } from '../../types'
+import type { SwapSource } from '../../types'
 import { SwapperName } from '../../types'
-import { assetIdToMayaPoolAssetIdMap } from './utils/poolAssetHelpers/poolAssetHelpers'
 
 export const CACAO_PRECISION = 10
 export const MAYACHAIN_PRECISION = 8
 export const MAYACHAIN_AFFILIATE_NAME = 'ssmaya'
-
-export const MAYACHAIN_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: [
-    ...new Set(
-      Object.keys(assetIdToMayaPoolAssetIdMap).map(assetId => fromAssetId(assetId).chainId),
-    ),
-  ],
-  buy: [
-    ...new Set(
-      Object.keys(assetIdToMayaPoolAssetIdMap).map(assetId => fromAssetId(assetId).chainId),
-    ),
-  ],
-}
 
 export const MAYACHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Mayachain} • Streaming`

--- a/packages/swapper/src/swappers/MayachainSwapper/utils/index.ts
+++ b/packages/swapper/src/swappers/MayachainSwapper/utils/index.ts
@@ -15,7 +15,7 @@ export const assertValidTrade = ({
   buyAsset: Asset
   sellAsset: Asset
 }): Result<boolean, SwapErrorRight> => {
-  if (!MAYACHAIN_SUPPORTED_CHAIN_IDS.sell.includes(sellAsset.chainId)) {
+  if (!MAYACHAIN_SUPPORTED_CHAIN_IDS.includes(sellAsset.chainId)) {
     return Err(
       makeSwapErrorRight({
         message: `[MayachainSwapper: assertValidTrade] - unsupported sell chain`,
@@ -25,7 +25,7 @@ export const assertValidTrade = ({
     )
   }
 
-  if (!MAYACHAIN_SUPPORTED_CHAIN_IDS.buy.includes(buyAsset.chainId)) {
+  if (!MAYACHAIN_SUPPORTED_CHAIN_IDS.includes(buyAsset.chainId)) {
     return Err(
       makeSwapErrorRight({
         message: `[MayachainSwapper: assertValidTrade] - unsupported buy chain`,

--- a/packages/swapper/src/swappers/PortalsSwapper/constants.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/constants.ts
@@ -1,13 +1,4 @@
-import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
-
-import type { SupportedChainIds } from '../../types'
-import { PortalsSupportedChainIds } from './types'
-
-export const PORTALS_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: PortalsSupportedChainIds as unknown as ChainId[],
-  buy: PortalsSupportedChainIds as unknown as ChainId[],
-}
 
 export const chainIdToPortalsNetwork: Partial<Record<KnownChainIds, string>> = {
   [KnownChainIds.EthereumMainnet]: 'ethereum',

--- a/packages/swapper/src/swappers/PortalsSwapper/types.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/types.ts
@@ -10,6 +10,6 @@ export const PortalsSupportedChainIds = [
   KnownChainIds.OptimismMainnet,
   KnownChainIds.GnosisMainnet,
   KnownChainIds.BaseMainnet,
-] as const
+]
 
 export type PortalsSupportedChainId = (typeof PortalsSupportedChainIds)[number]

--- a/packages/swapper/src/swappers/PortalsSwapper/types.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/types.ts
@@ -1,7 +1,8 @@
+import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
 // https://api.portals.fi/v1/networks
-export const PortalsSupportedChainIds = [
+export const PortalsSupportedChainIds: ChainId[] = [
   KnownChainIds.EthereumMainnet,
   KnownChainIds.ArbitrumMainnet,
   KnownChainIds.AvalancheMainnet,

--- a/packages/swapper/src/swappers/PortalsSwapper/types.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/types.ts
@@ -1,8 +1,7 @@
-import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
 // https://api.portals.fi/v1/networks
-export const PortalsSupportedChainIds: ChainId[] = [
+export const PortalsSupportedChainIds = [
   KnownChainIds.EthereumMainnet,
   KnownChainIds.ArbitrumMainnet,
   KnownChainIds.AvalancheMainnet,

--- a/packages/swapper/src/swappers/RelaySwapper/constant.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/constant.ts
@@ -24,7 +24,6 @@ import {
   polygon,
 } from 'viem/chains'
 
-import type { SupportedChainIds } from '../../types'
 import { TradeQuoteError } from '../../types'
 import { RelayErrorCode } from './utils/types'
 
@@ -73,11 +72,6 @@ export const RELAY_SOLANA_TOKEN_ADDRESS = '11111111111111111111111111111111'
 export const DEFAULT_RELAY_EVM_USER_ADDRESS = '0x000000000000000000000000000000000000dead'
 export const DEFAULT_RELAY_BTC_USER_ADDRESS = 'bc1q4vxn43l44h30nkluqfxd9eckf45vr2awz38lwa'
 export const DEFAULT_RELAY_SOLANA_USER_ADDRESS = 'CbKGgVKLJFb8bBrf58DnAkdryX6ubewVytn7X957YwNr'
-
-export const RELAY_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: relaySupportedChainIds,
-  buy: relaySupportedChainIds,
-}
 
 export const MAXIMUM_SUPPORTED_RELAY_STEPS = 2
 

--- a/packages/swapper/src/swappers/ThorchainSwapper/constants.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/constants.ts
@@ -1,8 +1,15 @@
+import { fromAssetId } from '@shapeshiftoss/caip'
+
 import type { SwapSource } from '../../types'
 import { SwapperName } from '../../types'
+import { assetIdToThorPoolAssetIdMap } from './utils/poolAssetHelpers/poolAssetHelpers'
 
 export const THORCHAIN_PRECISION = 8
 export const THORCHAIN_AFFILIATE_NAME = 'ss'
+
+export const THORCHAIN_SUPPORTED_CHAIN_IDS = [
+  ...new Set(Object.keys(assetIdToThorPoolAssetIdMap).map(assetId => fromAssetId(assetId).chainId)),
+]
 
 export const THORCHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain} • Streaming`
 export const THORCHAIN_LONGTAIL_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain} • Long-tail`

--- a/packages/swapper/src/swappers/ThorchainSwapper/constants.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/constants.ts
@@ -1,24 +1,8 @@
-import { fromAssetId } from '@shapeshiftoss/caip'
-
-import type { SupportedChainIds, SwapSource } from '../../types'
+import type { SwapSource } from '../../types'
 import { SwapperName } from '../../types'
-import { assetIdToThorPoolAssetIdMap } from './utils/poolAssetHelpers/poolAssetHelpers'
 
 export const THORCHAIN_PRECISION = 8
 export const THORCHAIN_AFFILIATE_NAME = 'ss'
-
-export const THORCHAIN_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: [
-    ...new Set(
-      Object.keys(assetIdToThorPoolAssetIdMap).map(assetId => fromAssetId(assetId).chainId),
-    ),
-  ],
-  buy: [
-    ...new Set(
-      Object.keys(assetIdToThorPoolAssetIdMap).map(assetId => fromAssetId(assetId).chainId),
-    ),
-  ],
-}
 
 export const THORCHAIN_STREAM_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain} • Streaming`
 export const THORCHAIN_LONGTAIL_SWAP_SOURCE: SwapSource = `${SwapperName.Thorchain} • Long-tail`

--- a/packages/swapper/src/swappers/ThorchainSwapper/getTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/getTradeQuote/getTradeQuote.ts
@@ -21,8 +21,8 @@ export const getTradeQuote = async (
   const { sellAsset, buyAsset } = input
 
   if (
-    !THORCHAIN_SUPPORTED_CHAIN_IDS.sell.includes(sellAsset.chainId) ||
-    !THORCHAIN_SUPPORTED_CHAIN_IDS.buy.includes(buyAsset.chainId)
+    !THORCHAIN_SUPPORTED_CHAIN_IDS.includes(sellAsset.chainId) ||
+    !THORCHAIN_SUPPORTED_CHAIN_IDS.includes(buyAsset.chainId)
   ) {
     return Err(
       makeSwapErrorRight({

--- a/packages/swapper/src/swappers/ThorchainSwapper/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/getTradeRate/getTradeRate.ts
@@ -21,8 +21,8 @@ export const getTradeRate = async (
   const { sellAsset, buyAsset } = input
 
   if (
-    !THORCHAIN_SUPPORTED_CHAIN_IDS.sell.includes(sellAsset.chainId) ||
-    !THORCHAIN_SUPPORTED_CHAIN_IDS.buy.includes(buyAsset.chainId)
+    !THORCHAIN_SUPPORTED_CHAIN_IDS.includes(sellAsset.chainId) ||
+    !THORCHAIN_SUPPORTED_CHAIN_IDS.includes(buyAsset.chainId)
   ) {
     return Err(
       makeSwapErrorRight({

--- a/packages/swapper/src/swappers/ZrxSwapper/utils/constants.ts
+++ b/packages/swapper/src/swappers/ZrxSwapper/utils/constants.ts
@@ -1,7 +1,4 @@
-import type { ChainId } from '@shapeshiftoss/caip'
 import { KnownChainIds } from '@shapeshiftoss/types'
-
-import type { SupportedChainIds } from '../../../types'
 
 // Zrx doesn't have an easily accessible master assets list.
 // We assume all erc20's are supported and remove these explicitly unsupported assets
@@ -24,11 +21,6 @@ export const ZRX_SUPPORTED_CHAINIDS = Object.freeze([
   KnownChainIds.ArbitrumMainnet,
   KnownChainIds.BaseMainnet,
 ])
-
-export const ZRX_SUPPORTED_CHAIN_IDS: SupportedChainIds = {
-  sell: ZRX_SUPPORTED_CHAINIDS as ChainId[],
-  buy: ZRX_SUPPORTED_CHAINIDS as ChainId[],
-}
 
 // https://0x.org/docs/developer-resources/faqs-and-troubleshooting
 export const ZRX_NATIVE_ASSET_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -650,11 +650,6 @@ export type TradeExecutionEventMap = {
   [TradeExecutionEvent.Error]: (args: unknown) => void
 }
 
-export type SupportedChainIds = {
-  buy: ChainId[]
-  sell: ChainId[]
-}
-
 export type MonadicSwapperAxiosService = ReturnType<typeof makeSwapperAxiosServiceMonadic>
 
 export enum MixPanelEvent {

--- a/src/pages/Markets/hooks/useRows.tsx
+++ b/src/pages/Markets/hooks/useRows.tsx
@@ -1,5 +1,5 @@
 import type { ChainId } from '@shapeshiftoss/caip'
-import { PORTALS_SUPPORTED_CHAIN_IDS } from '@shapeshiftoss/swapper'
+import { PortalsSupportedChainIds } from 'packages/swapper/src/swappers/PortalsSwapper/types'
 import type { JSX } from 'react'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
@@ -130,7 +130,7 @@ export const useRows = ({ limit }: { limit: number }) => {
             sortBy={sortBy}
           />
         ),
-        supportedChainIds: PORTALS_SUPPORTED_CHAIN_IDS.buy,
+        supportedChainIds: PortalsSupportedChainIds,
       },
     }),
     [coingeckoSupportedChainIds, limit, translate],

--- a/src/pages/ThorChainLP/queries/hooks/usePool.ts
+++ b/src/pages/ThorChainLP/queries/hooks/usePool.ts
@@ -57,7 +57,7 @@ export const getPool = (
   if (!assetId) return
 
   const chainId = fromAssetId(assetId).chainId
-  if (!THORCHAIN_SUPPORTED_CHAIN_IDS.sell.includes(chainId)) return
+  if (!THORCHAIN_SUPPORTED_CHAIN_IDS.includes(chainId)) return
 
   const asset = assets[assetId]
   if (!asset) return


### PR DESCRIPTION
## Description

This one is an actual ommission from https://github.com/shapeshift/web/issues/9243, removes dead "chain supported" constants that literally redeclare the existing `<SWAPPER>_SUPPORTED_CHAIN_IDS` consts as the same on the buy and sell side i.e: 

```typescript
{buy: <SWAPPER>_SUPPORTED_CHAIN_IDS, sell: <SWAPPER>_SUPPORTED_CHAIN_IDS}
```

Which definitely validates the nuke, as this type/those constants didn't bring anything new to the table!

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- relates to the closed https://github.com/shapeshift/web/issues/9243

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

None, also dead code

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- CI is happy

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
