### PR TITLE
feat: show bridge tx on butter swaps

### DIFF
--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/checkTradeStatus.test.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/checkTradeStatus.test.ts
@@ -9,9 +9,11 @@ import * as xhrModule from '../xhr'
 import { checkTradeStatus } from './checkTradeStatus'
 vi.mock('../xhr', () => ({
   getBridgeInfoBySourceHash: vi.fn(),
+  getBridgeInfoById: vi.fn(),
 }))
 
 const getBridgeInfoBySourceHash = xhrModule.getBridgeInfoBySourceHash as ReturnType<typeof vi.fn>
+const getBridgeInfoById = xhrModule.getBridgeInfoById as ReturnType<typeof vi.fn>
 
 // Minimal adapter mock
 const minimalAdapter = { chainId: '1', getType: () => 'Evm' } as any
@@ -31,12 +33,51 @@ const baseInput: Omit<CheckTradeStatusInput, 'txHash'> = {
 
 describe('checkTradeStatus', () => {
   it('should return Confirmed status and buyTxHash for a completed ButterSwap swap', async () => {
+    // Mock the first call to get basic bridge info with ID
     getBridgeInfoBySourceHash.mockResolvedValue(
       Ok({
+        id: 12345,
         state: 1,
-        toHash: '7a4d8686e186a5f86f7f3a71dc8181c66e9b40a68edd068e99cdeea77514a157',
+        toHash: null,
+        fromChain: {} as any,
+        toChain: {} as any,
+        sourceAddress: '',
+        amount: '',
+        fromToken: {} as any,
+        sourceHash: '',
+        receiveToken: {} as any,
+        receiveAmount: '',
+        toAddress: '',
+        timestamp: '',
+        timestampLong: 0,
+        completeTime: '',
+        completeTimeLong: 0,
       }),
     )
+
+    // Mock the second call to get detailed bridge info with relayerHash
+    getBridgeInfoById.mockResolvedValue(
+      Ok({
+        id: 12345,
+        state: 1,
+        toHash: '7a4d8686e186a5f86f7f3a71dc8181c66e9b40a68edd068e99cdeea77514a157',
+        relayerHash: 'bridge_tx_hash_123',
+        fromChain: {} as any,
+        toChain: {} as any,
+        sourceAddress: '',
+        amount: '',
+        fromToken: {} as any,
+        sourceHash: '',
+        receiveToken: {} as any,
+        receiveAmount: '',
+        toAddress: '',
+        timestamp: '',
+        timestampLong: 0,
+        completeTime: '',
+        completeTimeLong: 0,
+      }),
+    )
+
     const result = await checkTradeStatus({
       ...baseInput,
       txHash: '0x9d15eeda2c298ec630b799618c718d823bb58b729e77b60e6661c7093ff5e81e',
@@ -45,6 +86,7 @@ describe('checkTradeStatus', () => {
     expect(result.buyTxHash).toBe(
       '7a4d8686e186a5f86f7f3a71dc8181c66e9b40a68edd068e99cdeea77514a157',
     )
+    expect(result.bridgeTxHash).toBe('bridge_tx_hash_123')
   })
 
   it('should return Unknown status if no info is found', async () => {

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
@@ -6,7 +6,7 @@ import { getDefaultSlippageDecimalPercentageForSwapper } from '../../../constant
 import type { GetTradeRateInput, SwapErrorRight, SwapperDeps, TradeRate } from '../../../types'
 import { SwapperName, TradeQuoteError } from '../../../types'
 import { createTradeAmountTooSmallErr, makeSwapErrorRight } from '../../../utils'
-import { DEFAULT_BUTTERSWAP_AFFILIATE_BPS, makeButterSwapAffiliate } from '../utils/constants'
+import { makeButterSwapAffiliate } from '../utils/constants'
 import {
   ButterSwapErrorCode,
   butterSwapErrorToTradeQuoteError,
@@ -43,7 +43,7 @@ export const getTradeRate = async (
     buyAsset,
     sellAmountCryptoBaseUnit: amount,
     slippage,
-    affiliate: makeButterSwapAffiliate(affiliateBps ?? DEFAULT_BUTTERSWAP_AFFILIATE_BPS),
+    affiliate: makeButterSwapAffiliate(affiliateBps),
   })
   if (result.isErr()) {
     return Err(result.unwrapErr())

--- a/packages/swapper/src/swappers/ButterSwap/types.ts
+++ b/packages/swapper/src/swappers/ButterSwap/types.ts
@@ -1,5 +1,3 @@
-// Type definitions inferred from validators.ts for ButterSwap
-
 export type ErrorType = {
   errno: number
   message: string
@@ -175,12 +173,56 @@ export type BridgeInfo = {
   amount: string
   fromToken: TokenInfo
   sourceHash: string
-  relayerHash: string | undefined
   toHash: string | null
   receiveToken: TokenInfo
   receiveAmount: string
   toAddress: string
   destinationToken?: TokenInfo | null
+  state: number
+  timestamp: string
+  timestampLong: number
+  completeTime: string
+  completeTimeLong: number
+}
+
+export type DetailedBridgeInfo = {
+  id?: number | null
+  fromChain: ChainInfo
+  relayerChain?: ChainInfo
+  toChain: ChainInfo
+  tokenAddress?: string
+  tokenSymbol?: string
+  sourceAddress: string
+  amount: string | number
+  inAmount?: string | number
+  fee?: string
+  fromToken: TokenInfo
+  sourceHash: string
+  relayerHash?: string | null
+  toHash: string | null
+  receiveToken: TokenInfo
+  receiveAmount: string | number
+  toAddress: string
+  destinationToken?: TokenInfo | null
+  sourceToken?: TokenInfo
+  feeToken?: TokenInfo
+  fromTokenDecimal?: number
+  isMessageBridge?: number
+  bridgeToken?: unknown | null
+  bridgeAmount?: unknown | null
+  chainPoolChainDict?: unknown | null
+  chainPoolTokenDict?: unknown | null
+  chainPoolAddress?: unknown | null
+  chainPoolAmount?: unknown | null
+  chainPoolAction?: unknown | null
+  chainPoolHash?: unknown | null
+  routerAmount?: number
+  integratorAmount?: number
+  nativeAmount?: number
+  integratorNative?: number
+  routerFeeToken?: string
+  stage?: unknown | null
+  status?: unknown | null
   state: number
   timestamp: string
   timestampLong: number
@@ -201,5 +243,13 @@ export type BridgeInfoApiResponse = {
   message: string
   data: {
     info: BridgeInfo | null
+  }
+}
+
+export type DetailedBridgeInfoApiResponse = {
+  code: number
+  message: string
+  data: {
+    info: DetailedBridgeInfo | null
   }
 }

--- a/packages/swapper/src/swappers/ButterSwap/utils/constants.ts
+++ b/packages/swapper/src/swappers/ButterSwap/utils/constants.ts
@@ -1,5 +1,3 @@
-export const DEFAULT_BUTTERSWAP_AFFILIATE_BPS = 50
-
 const BUTTERSWAP_AFFILIATE = '' // TODO: add affiliate
 
 export const makeButterSwapAffiliate = (affiliateBps: string): string | undefined => {

--- a/packages/swapper/src/swappers/ButterSwap/xhr.ts
+++ b/packages/swapper/src/swappers/ButterSwap/xhr.ts
@@ -8,7 +8,14 @@ import { zeroAddress } from 'viem'
 import type { SwapErrorRight } from '../../types'
 import { TradeQuoteError } from '../../types'
 import { makeSwapErrorRight } from '../../utils'
-import type { BridgeInfo, BridgeInfoApiResponse, BuildTxResponse, RouteResponse } from './types'
+import type {
+  BridgeInfo,
+  BridgeInfoApiResponse,
+  BuildTxResponse,
+  DetailedBridgeInfo,
+  DetailedBridgeInfoApiResponse,
+  RouteResponse,
+} from './types'
 import { butterHistoryService } from './utils/butterSwapHistoryService'
 import { butterService } from './utils/butterSwapService'
 import { chainIdToButterSwapChainId } from './utils/helpers'
@@ -135,6 +142,33 @@ export const getBridgeInfoBySourceHash = async (
       '/api/queryBridgeInfoBySourceHash',
       {
         params: { hash },
+      },
+    )
+    if (result.isErr()) {
+      throw result.unwrapErr()
+    }
+    const data = result.unwrap().data
+    if (!data || !data.data || !data.data.info) {
+      return Ok(undefined)
+    }
+    return Ok(data.data.info)
+  } catch (e) {
+    return Ok(undefined)
+  }
+}
+
+/**
+ * Get detailed bridge information by ID
+ * This endpoint is undocumented by Butter, but used in their UI
+ */
+export const getBridgeInfoById = async (
+  id: number,
+): ButterSwapPromise<DetailedBridgeInfo | undefined> => {
+  try {
+    const result = await butterHistoryService.get<DetailedBridgeInfoApiResponse>(
+      '/api/queryBridgeInfoById',
+      {
+        params: { id },
       },
     )
     if (result.isErr()) {

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -353,6 +353,7 @@ export enum TransactionExecutionState {
 export type SwapExecutionMetadata = {
   state: TransactionExecutionState
   sellTxHash?: string
+  bridgeTxHash?: string
   buyTxHash?: string
   streamingSwap?: StreamingSwapMetadata
   message?: string | [string, InterpolationOptions]
@@ -380,6 +381,7 @@ export type Swap = {
   buyAsset: Asset
   status: SwapStatus
   sellTxHash?: string
+  bridgeTxHash?: string
   buyTxHash?: string
   statusMessage?: string | [string, Polyglot.InterpolationOptions] | undefined
   sellAccountId: AccountId | undefined
@@ -534,6 +536,7 @@ export type CheckTradeStatusInput = {
 export type TradeStatus = {
   status: TxStatus
   buyTxHash: string | undefined
+  bridgeTxHash?: string | undefined
   message: string | [string, InterpolationOptions] | undefined
 }
 
@@ -631,6 +634,7 @@ export type SolanaTransactionExecutionInput = CommonTradeExecutionInput &
 
 export enum TradeExecutionEvent {
   SellTxHash = 'sellTxHash',
+  BridgeTxHash = 'bridgeTxHash',
   Status = 'status',
   Success = 'success',
   Fail = 'fail',
@@ -638,12 +642,14 @@ export enum TradeExecutionEvent {
 }
 
 export type SellTxHashArgs = { stepIndex: SupportedTradeQuoteStepIndex; sellTxHash: string }
+export type BridgeTxHashArgs = { stepIndex: SupportedTradeQuoteStepIndex; bridgeTxHash: string }
 export type StatusArgs = TradeStatus & {
   stepIndex: number
 }
 
 export type TradeExecutionEventMap = {
   [TradeExecutionEvent.SellTxHash]: (args: SellTxHashArgs) => void
+  [TradeExecutionEvent.BridgeTxHash]: (args: BridgeTxHashArgs) => void
   [TradeExecutionEvent.Status]: (args: StatusArgs) => void
   [TradeExecutionEvent.Success]: (args: StatusArgs) => void
   [TradeExecutionEvent.Fail]: (args: StatusArgs) => void

--- a/src/components/MultiHopTrade/components/TradeConfirm/TxLabel.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TxLabel.tsx
@@ -15,6 +15,7 @@ export const TxLabel = ({
   stepSource,
   quoteSwapperName,
   isBuyTxHash,
+  isBridge,
 }: {
   txHash: string
   explorerBaseUrl: string
@@ -22,6 +23,7 @@ export const TxLabel = ({
   stepSource: SwapSource | undefined
   quoteSwapperName: SwapperName | undefined
   isBuyTxHash?: boolean
+  isBridge?: boolean
 }) => {
   const { data: maybeSafeTx } = useSafeTxQuery({
     maybeSafeTxHash: txHash,
@@ -41,6 +43,7 @@ export const TxLabel = ({
     stepSource,
     ...(isBuyTxHash ? { txId: txHash } : { tradeId: txHash }),
     maybeChainflipSwapId,
+    isBridge,
   })
 
   return txLink ? (

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -400,6 +400,15 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
                   quoteSwapperName={activeTradeQuote.swapperName}
                 />
               )}
+              {firstHopSwap.bridgeTxHash && (
+                <TxLabel
+                  txHash={firstHopSwap.bridgeTxHash}
+                  explorerBaseUrl={tradeQuoteFirstHop.sellAsset.explorerTxLink} // We don't track the bridge asset explorer base URL, but the sell asset works for this purpose
+                  accountId={firstHopSellAccountId}
+                  stepSource={stepSource}
+                  quoteSwapperName={activeTradeQuote.swapperName}
+                />
+              )}
               {firstHopSwap.buyTxHash && firstHopSwap.buyTxHash !== firstHopSwap.sellTxHash && (
                 <TxLabel
                   isBuyTxHash
@@ -420,6 +429,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     firstHopSellAccountId,
     firstHopStreamingProgress,
     firstHopSwap.buyTxHash,
+    firstHopSwap.bridgeTxHash,
     firstHopSwap.sellTxHash,
     stepSource,
     activeTradeQuote.swapperName,

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -403,10 +403,11 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
               {firstHopSwap.bridgeTxHash && (
                 <TxLabel
                   txHash={firstHopSwap.bridgeTxHash}
-                  explorerBaseUrl={tradeQuoteFirstHop.sellAsset.explorerTxLink} // We don't track the bridge asset explorer base URL, but the sell asset works for this purpose
+                  explorerBaseUrl={tradeQuoteFirstHop.sellAsset.explorerTxLink}
                   accountId={firstHopSellAccountId}
                   stepSource={stepSource}
                   quoteSwapperName={activeTradeQuote.swapperName}
+                  isBridge={true}
                 />
               )}
               {firstHopSwap.buyTxHash && firstHopSwap.buyTxHash !== firstHopSwap.sellTxHash && (

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeExecution.tsx
@@ -159,6 +159,16 @@ export const useTradeExecution = (
           tradeQuoteSlice.actions.setSwapSellTxHash({ hopIndex, sellTxHash, id: confirmedTradeId }),
         )
       })
+      execution.on(TradeExecutionEvent.BridgeTxHash, ({ bridgeTxHash }) => {
+        txHashReceived = true
+        dispatch(
+          tradeQuoteSlice.actions.setSwapBridgeTxHash({
+            hopIndex,
+            bridgeTxHash,
+            id: confirmedTradeId,
+          }),
+        )
+      })
       execution.on(TradeExecutionEvent.Status, ({ buyTxHash, message }) => {
         dispatch(
           tradeQuoteSlice.actions.setSwapTxMessage({ hopIndex, message, id: confirmedTradeId }),

--- a/src/lib/getTxLink.ts
+++ b/src/lib/getTxLink.ts
@@ -18,6 +18,7 @@ type GetTxBaseUrl = {
   stepSource?: Dex | SwapSource
   defaultExplorerBaseUrl: string
   isOrder?: boolean
+  isBridge?: boolean
 }
 
 // An eip-3770 compliant mapping of ChainId to chain shortname
@@ -45,6 +46,7 @@ export const getTxBaseUrl = ({
   stepSource,
   defaultExplorerBaseUrl,
   isOrder,
+  isBridge,
 }: GetTxBaseUrl): string => {
   switch (stepSource) {
     case Dex.CowSwap:
@@ -67,7 +69,7 @@ export const getTxBaseUrl = ({
     case SwapperName.Relay:
       return 'https://relay.link/transaction/'
     case SwapperName.ButterSwap:
-      return 'https://explorer.butterswap.io/tx/'
+      return isBridge ? 'https://www.maposcan.io/tx/' : 'https://explorer.butterswap.io/tx/'
     default:
       return defaultExplorerBaseUrl
   }
@@ -82,11 +84,12 @@ export const getTxLink = ({
   address,
   chainId,
   maybeChainflipSwapId,
+  isBridge,
 }: GetTxLink): string => {
   const isSafeTxHash = maybeSafeTx?.isSafeTxHash
   const id = txId ?? tradeId
   const isOrder = !!tradeId
-  const baseUrl = getTxBaseUrl({ stepSource: name, defaultExplorerBaseUrl, isOrder })
+  const baseUrl = getTxBaseUrl({ stepSource: name, defaultExplorerBaseUrl, isOrder, isBridge })
 
   if (!isSafeTxHash) {
     switch (name) {

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -369,6 +369,16 @@ export const tradeQuoteSlice = createSlice({
         state.tradeExecution[action.payload.id][key].swap.sellTxHash = sellTxHash
       },
     ),
+    setSwapBridgeTxHash: create.reducer(
+      (
+        state,
+        action: PayloadAction<{ hopIndex: number; bridgeTxHash: string; id: TradeQuote['id'] }>,
+      ) => {
+        const { hopIndex, bridgeTxHash } = action.payload
+        const key = hopIndex === 0 ? HopKey.FirstHop : HopKey.SecondHop
+        state.tradeExecution[action.payload.id][key].swap.bridgeTxHash = bridgeTxHash
+      },
+    ),
     setSwapBuyTxHash: create.reducer(
       (
         state,


### PR DESCRIPTION
## Description

Adds the concept of a bridge TX, and renders it on the trade pending/completion screen.

https://jam.dev/c/ad4b9ac1-4300-42f2-b95f-f46290c1625a

Unrelated, but also cleans up some affiliate logic whilst in the neighbourhood.

## Issue (if applicable)

Closes https://github.com/shapeshift/web/issues/9832

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Butter swaps, which contain bridge TXs

## Testing

Perform a Butter swap with a bridge step. A useful (cheap) pair I've found is ETH on Arbitrum and ETH on Optimism, though the minimum trade amount is about $9.

Note 3 TX links will show:

<img width="472" alt="Screenshot 2025-07-01 at 3 16 02 pm" src="https://github.com/user-attachments/assets/6d371c92-be4b-469a-bcbe-fe4660eb490a" />

Which should map to the same shown on the [Butter UI](https://www.butterswap.io/en/swap):

<img width="448" alt="Screenshot 2025-07-01 at 3 16 13 pm" src="https://github.com/user-attachments/assets/db3d7b0c-b87e-40ce-b9dd-13f2cbb1fdc3" />

### Engineering

👆

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

See above.