### PR TITLE
fix: swapper and notification center polish

### DIFF
--- a/packages/chain-adapters/src/cosmossdk/mayachain/MayachainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/mayachain/MayachainChainAdapter.ts
@@ -216,9 +216,9 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.MayachainMa
     _: Partial<GetFeeDataInput<KnownChainIds.MayachainMainnet>>,
   ): Promise<FeeDataEstimate<KnownChainIds.MayachainMainnet>> {
     return {
-      fast: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '200000' } },
-      average: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '200000' } },
-      slow: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '200000' } },
+      fast: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '500000' } },
+      average: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '500000' } },
+      slow: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '500000' } },
     }
   }
 

--- a/packages/swapper/src/swappers/CowSwapper/constants.ts
+++ b/packages/swapper/src/swappers/CowSwapper/constants.ts
@@ -1,4 +1,6 @@
 export enum CowStatusMessage {
   Open = 'Order Placed',
   Fulfilled = 'Order Fulfilled',
+  Cancelled = 'Order Cancelled',
+  Expired = 'Order Expired',
 }

--- a/packages/swapper/src/swappers/CowSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/CowSwapper/endpoints.ts
@@ -21,7 +21,7 @@ import {
 import { CowStatusMessage } from './constants'
 import { getCowSwapTradeQuote } from './getCowSwapTradeQuote/getCowSwapTradeQuote'
 import { getCowSwapTradeRate } from './getCowSwapTradeRate/getCowSwapTradeRate'
-import type { CowSwapGetTradesResponse } from './types'
+import type { CowSwapGetTradesResponse, CowSwapOrdersResponse } from './types'
 import { cowService } from './utils/cowService'
 import { getValuesFromQuoteResponse } from './utils/helpers/helpers'
 
@@ -133,6 +133,7 @@ export const cowApi: SwapperApi = {
       fetchIsSmartContractAddressQuery,
       address,
     })
+
     if (maybeSafeTransactionStatus) return maybeSafeTransactionStatus
 
     const network = assertGetCowNetwork(chainId)
@@ -140,20 +141,46 @@ export const cowApi: SwapperApi = {
     // with cow we aren't able to get the tx hash until it's already completed, so we must use the
     // order uid to fetch the trades and use their existence as indicating "complete"
     // https://docs.cow.fi/tutorials/how-to-submit-orders-via-the-api/6.-checking-order-status
-    const maybeTradesResponse = await cowService.get<CowSwapGetTradesResponse>(
+    const tradesResponse = await cowService.get<CowSwapGetTradesResponse>(
       `${config.VITE_COWSWAP_BASE_URL}/${network}/api/v1/trades`,
       { params: { orderUid: txHash } },
     )
 
-    if (maybeTradesResponse.isErr()) throw maybeTradesResponse.unwrapErr()
-    const { data: trades } = maybeTradesResponse.unwrap()
-    const buyTxHash = trades[0]?.txHash
+    if (tradesResponse.isErr()) throw tradesResponse.unwrapErr()
+    const { data: trades } = tradesResponse.unwrap()
 
-    if (buyTxHash) {
-      return {
-        status: TxStatus.Confirmed,
-        buyTxHash,
-        message: CowStatusMessage.Fulfilled,
+    if (trades.length) {
+      const buyTxHash = trades[0]?.txHash
+
+      if (buyTxHash) {
+        return {
+          status: TxStatus.Confirmed,
+          buyTxHash,
+          message: CowStatusMessage.Fulfilled,
+        }
+      }
+    } else {
+      const ordersResponse = await cowService.get<CowSwapOrdersResponse>(
+        `${config.VITE_COWSWAP_BASE_URL}/${network}/api/v1/orders/${txHash}`,
+      )
+
+      if (ordersResponse.isErr()) throw ordersResponse.unwrapErr()
+      const { data: order } = ordersResponse.unwrap()
+
+      switch (order.status) {
+        case 'cancelled':
+          return {
+            status: TxStatus.Failed,
+            buyTxHash: undefined,
+            message: CowStatusMessage.Cancelled,
+          }
+        case 'expired':
+          return {
+            status: TxStatus.Failed,
+            buyTxHash: undefined,
+            message: CowStatusMessage.Expired,
+          }
+        default:
       }
     }
 

--- a/packages/swapper/src/swappers/CowSwapper/types.ts
+++ b/packages/swapper/src/swappers/CowSwapper/types.ts
@@ -5,9 +5,9 @@ export type CowSwapGetTradesResponse = {
   txHash: string
 }[]
 
-export type CowSwapGetTransactionsResponse = {
+export type CowSwapOrdersResponse = {
   status: 'presignaturePending' | 'open' | 'fulfilled' | 'cancelled' | 'expired'
-}[]
+}
 
 export type AffiliateAppDataFragment = {
   partnerFee?: {

--- a/packages/swapper/src/swappers/MayachainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/MayachainSwapper/endpoints.ts
@@ -88,7 +88,10 @@ export const mayachainApi: SwapperApi = {
   getCosmosSdkTransactionFees: input => cosmossdk.getCosmosSdkTransactionFees(input),
   checkTradeStatus: input => {
     const { config } = input
-    const url = `${config.VITE_MAYACHAIN_NODE_URL}/mayachain`
-    return checkTradeStatus({ ...input, url, nativeChain: 'MAYA' })
+
+    const nodeUrl = `${config.VITE_MAYACHAIN_NODE_URL}/mayachain`
+    const apiUrl = `${config.VITE_UNCHAINED_MAYACHAIN_HTTP_URL}/api/v1`
+
+    return checkTradeStatus({ ...input, nodeUrl, apiUrl, nativeChain: 'MAYA' })
   },
 }

--- a/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ThorchainSwapper/endpoints.ts
@@ -97,7 +97,10 @@ export const thorchainApi: SwapperApi = {
   getCosmosSdkTransactionFees: input => cosmossdk.getCosmosSdkTransactionFees(input),
   checkTradeStatus: input => {
     const { config } = input
-    const url = `${config.VITE_THORCHAIN_NODE_URL}/thorchain`
-    return checkTradeStatus({ ...input, url, nativeChain: 'THOR' })
+
+    const nodeUrl = `${config.VITE_THORCHAIN_NODE_URL}/thorchain`
+    const apiUrl = `${config.VITE_UNCHAINED_THORCHAIN_HTTP_URL}/api/v1`
+
+    return checkTradeStatus({ ...input, nodeUrl, apiUrl, nativeChain: 'THOR' })
   },
 }

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -37,6 +37,7 @@ import type { makeSwapperAxiosServiceMonadic } from './utils'
 // TODO: Rename all properties in this type to be camel case and not react specific
 export type SwapperConfig = {
   VITE_UNCHAINED_THORCHAIN_HTTP_URL: string
+  VITE_UNCHAINED_MAYACHAIN_HTTP_URL: string
   VITE_UNCHAINED_COSMOS_HTTP_URL: string
   VITE_THORCHAIN_NODE_URL: string
   VITE_MAYACHAIN_NODE_URL: string
@@ -362,8 +363,10 @@ export type SwapExecutionMetadata = {
 
 export type SwapperSpecificMetadata = {
   chainflipSwapId: number | undefined
-  stepIndex: SupportedTradeQuoteStepIndex
   relayTransactionMetadata: RelayTransactionMetadata | undefined
+  relayerExplorerTxLink: string | undefined
+  relayerTxHash: string | undefined
+  stepIndex: SupportedTradeQuoteStepIndex
   streamingSwapMetadata: StreamingSwapMetadata | undefined
 }
 
@@ -381,12 +384,11 @@ export type Swap = {
   sellAsset: Asset
   buyAsset: Asset
   status: SwapStatus
+  source: SwapSource
   sellTxHash?: string
-  relayerTxHash?: string
-  relayerExplorerTxLink?: string | undefined
   buyTxHash?: string
   statusMessage?: string | [string, Polyglot.InterpolationOptions] | undefined
-  sellAccountId: AccountId | undefined
+  sellAccountId: AccountId
   receiveAddress: string | undefined
   swapperName: SwapperName
   sellAmountCryptoBaseUnit: string

--- a/src/lib/tradeExecution.ts
+++ b/src/lib/tradeExecution.ts
@@ -186,8 +186,8 @@ export class TradeExecution {
           if (
             relayerTxHash &&
             relayerExplorerTxLink &&
-            !updatedSwap.relayerTxHash &&
-            !updatedSwap.relayerExplorerTxLink
+            !updatedSwap.metadata.relayerTxHash &&
+            !updatedSwap.metadata.relayerExplorerTxLink
           ) {
             const relayerTxDetailsArgs: RelayerTxDetailsArgs = {
               stepIndex,


### PR DESCRIPTION
## Description

Fixes a handful of issues surrounding swapper trade status detection, failing transaction and notification center issues.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9824 (https://github.com/shapeshift/web/commit/595c873f305f1729c84767fd19b519044f25d957)
closes https://github.com/shapeshift/web/issues/9822 (https://github.com/shapeshift/web/commit/9bf2b275aa4460f6aff8ab08ba968206303a5141 and https://github.com/shapeshift/web/commit/9f90d77c046cbd6189fb88ee47ac3fddfd9bdabd)
closes https://github.com/shapeshift/web/issues/9823 (https://github.com/shapeshift/web/pull/9872/commits/2d3684df295d3db86028a3fc6121c9c2bf1fc7d7)

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Medium

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure trades from CACAO -> any asset work (the one that failed was specifically a CACAO -> BTC streaming swap)
- Ensure swap notifications don't get stuck in pending status (currently fox -> eth on cowswap will expire after 30 mins and will now show failed)
- Ensure tx links in the action center route to the desired destination for all swappers (I did not have enough funds to test chainflip)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

You can also test failed CACAO swaps with:
```
--- a/packages/chain-adapters/src/cosmossdk/mayachain/MayachainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/mayachain/MayachainChainAdapter.ts
@@ -216,9 +216,9 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.MayachainMa
     _: Partial<GetFeeDataInput<KnownChainIds.MayachainMainnet>>,
   ): Promise<FeeDataEstimate<KnownChainIds.MayachainMainnet>> {
     return {
-      fast: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '500000' } },
-      average: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '500000' } },
-      slow: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '500000' } },
+      fast: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '100000' } },
+      average: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '100000' } },
+      slow: { txFee: NATIVE_FEE, chainSpecific: { gasLimit: '100000' } },
     }
   }
```

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)

![failedcacao](https://github.com/user-attachments/assets/89b3f0b1-d2ef-42e7-8f17-edfa1de01937)
![image](https://github.com/user-attachments/assets/5ae5b8a2-3952-4039-9598-2c79e4ddaeb7)
