### PR TITLE
fix: mobile app clear cache tap

### DIFF
--- a/src/components/Modals/Settings/ClearCache.tsx
+++ b/src/components/Modals/Settings/ClearCache.tsx
@@ -68,11 +68,6 @@ export const ClearCache = () => {
       }
       // clear store
       await persistor.purge()
-      // send them back to the connect wallet route in case the bug was something to do with the current page
-      // and so they can reconnect their native wallet to avoid the app looking broken in an infinite loading state
-      if (isMobileApp) {
-        browserNavigate('/connect-mobile-wallet', { replace: true })
-      }
       // reload the page
       isMobileApp ? reloadWebview() : window.location.reload()
     } catch (e) {}

--- a/src/components/Modals/Settings/ClearCache.tsx
+++ b/src/components/Modals/Settings/ClearCache.tsx
@@ -17,7 +17,6 @@ import { useNavigate } from 'react-router-dom'
 import { SlideTransition } from '@/components/SlideTransition'
 import { RawText } from '@/components/Text'
 import { reloadWebview } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
-import { useBrowserRouter } from '@/hooks/useBrowserRouter/useBrowserRouter'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { isMobile as isMobileApp } from '@/lib/globals'
 import { selectEnabledWalletAccountIds } from '@/state/slices/selectors'
@@ -55,7 +54,6 @@ export const ClearCache = () => {
   const dispatch = useAppDispatch()
   const requestedAccountIds = useAppSelector(selectEnabledWalletAccountIds)
   const translate = useTranslate()
-  const { navigate: browserNavigate } = useBrowserRouter()
   const navigate = useNavigate()
   const { disconnect } = useWallet()
   const goBack = useCallback(() => navigate(-1), [navigate])
@@ -71,7 +69,7 @@ export const ClearCache = () => {
       // reload the page
       isMobileApp ? reloadWebview() : window.location.reload()
     } catch (e) {}
-  }, [browserNavigate, disconnect])
+  }, [disconnect])
 
   const handleClearTxHistory = useCallback(() => {
     dispatch(txHistory.actions.clear())


### PR DESCRIPTION
## Description

Pretty staightforward fix - we did *not* need this, app already automagically redirects to the new mobile wallet connect screen on cache clear, by virtue of disconnecting.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9893

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Confirm "Clear cache" button doesn't produce a crash

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- Run this branch with web locally and with expo set to localhost

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- Set mobile app env to release when you test this in release

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
