### PR TITLE
feat: stop refetching vp on every EVM Tx

### DIFF
--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -1,7 +1,6 @@
-import type { AccountId, ChainId } from '@shapeshiftoss/caip'
+import type { AccountId } from '@shapeshiftoss/caip'
 import { ethChainId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type { Transaction } from '@shapeshiftoss/chain-adapters'
-import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useEffect, useState } from 'react'
@@ -118,17 +117,6 @@ export const useTransactionsSubscriber = () => {
     [],
   )
 
-  const maybeRefetchVotingPower = useCallback(
-    ({ status }: Transaction, chainId: ChainId) => {
-      if (!isConnected) return
-      // Only refetch voting power for EVM ChainIds. Refetching at Tx history provider is so we can refetch voting power on a best-effort basis,
-      // and we should probably do some king of interval refetching instead of relying on Tx history
-      if (!isEvmChainId(chainId)) return
-      if (status !== TxStatus.Confirmed) return
-    },
-    [isConnected],
-  )
-
   /**
    * unsubscribe and cleanup logic
    */
@@ -179,7 +167,6 @@ export const useTransactionsSubscriber = () => {
               getAccount.initiate({ accountId, upsertOnFetch: true }, { forceRefetch: true }),
             )
 
-            maybeRefetchVotingPower(msg, chainId)
             maybeRefetchOpportunities(msg, accountId)
 
             // upsert any new nft assets if detected
@@ -201,7 +188,6 @@ export const useTransactionsSubscriber = () => {
     isConnected,
     isSubscribed,
     maybeRefetchOpportunities,
-    maybeRefetchVotingPower,
     portfolioAccountMetadata,
     portfolioLoadingStatus,
     wallet,


### PR DESCRIPTION
## Description

Pretty much what it says on the box, this was there because of vp for swapper, which is not required anymore.
Only place we still use this is FOX Page FOX governance, which already does a force refetch on mount. 
The only "regression" would be if you stay on the FOX page and somehow have a Tx that increases/decreases your FOX VP, you wouldn't see it update in real time, which IMO is perfectly acceptable and not worth doing those heavy queries on every EVM Tx.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- FOX Page FOX governance vp is still displayed

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<img width="1391" alt="image" src="https://github.com/user-attachments/assets/52960340-9b55-40ef-bc65-f4f9634aad2a" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
