### PR TITLE
fix: show tcy in global search

### DIFF
--- a/src/state/slices/common-selectors.ts
+++ b/src/state/slices/common-selectors.ts
@@ -1,5 +1,5 @@
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { fromAccountId, isNft } from '@shapeshiftoss/caip'
+import { fromAccountId, isNft, tcyAssetId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { Asset, PartialRecord } from '@shapeshiftoss/types'
 import orderBy from 'lodash/orderBy'
@@ -296,8 +296,10 @@ export const selectAssetsBySearchQuery = createCachedSelector(
 
     // Filters by low market-cap to avoid spew
     const filteredAssets = sortedAssets.filter(asset => {
+      // We don't have the market cap for TCY, but we want to show it
+      if (asset.assetId === tcyAssetId) return true
       const marketCap = marketDataUsd[asset.assetId]?.marketCap
-      return !marketCap || bnOrZero(marketCap).gte(1000)
+      return !marketCap || bnOrZero(marketCap).gte(10000)
     })
     const matchedAssets = matchSorter(filteredAssets, searchQuery, {
       keys: [


### PR DESCRIPTION
## Description
For some reasons, we don't have the TCY market cap, seems like our providers aren't providing it, but we want to show it anyway

The right fix would be to have them from our providers...

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted in https://discord.com/channels/554694662431178782/1334642494897655840/1391797340897022044

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to search TCY using cmd+k
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="438" alt="image" src="https://github.com/user-attachments/assets/2059e02e-a5a7-4116-94e5-799df2e32e1d" />
