### PR TITLE
fix: dont submit the trade form on tab button touch

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputHeader.tsx
@@ -146,6 +146,7 @@ export const SharedTradeInputHeader = ({
               fontSize='md'
               sx={mobileButtonsStyle}
               onClick={handleClickTrade}
+              type='button'
             >
               {translate('navBar.market')}
             </Box>
@@ -162,6 +163,7 @@ export const SharedTradeInputHeader = ({
                 ml={-2}
                 sx={mobileButtonsStyle}
                 onClick={handleClickLimitOrder}
+                type='button'
               >
                 {translate('limitOrder.heading')}
               </Box>
@@ -179,6 +181,7 @@ export const SharedTradeInputHeader = ({
                 ml={-2}
                 sx={mobileButtonsStyle}
                 onClick={handleClickClaim}
+                type='button'
               >
                 {translate('bridge.claim')}
               </Box>


### PR DESCRIPTION
## Description

Tabs buttons were submitting forms as they were defaulted to `type="submit"` sending to the confirm screen if the user clicks on the market tab

By changing the type to `button` it stops this behavior

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9899

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- use a big amount in the swapper on mobile
- Click on the "Market" tab button
- It shouldn't redirect to the confirm screen
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/67f25a4d-617e-4342-a687-1292456ab75a