### PR TITLE
fix: trade page active routes

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -155,6 +155,7 @@ export const routes: Route[] = [
     priority: 2,
     main: TradeTab,
     category: RouteCategory.Featured,
+    relatedPaths: ['/trade', '/limit', '/claim'],
     routes: [
       {
         path: TRADE_ROUTE_ASSET_SPECIFIC,

--- a/src/Routes/helpers.ts
+++ b/src/Routes/helpers.ts
@@ -25,6 +25,7 @@ export type Route = {
   isViewOnly?: boolean
   category?: RouteCategory
   menuRightComponent?: React.ReactNode
+  relatedPaths?: string[]
 } & (
   | {
       mobileNav: boolean

--- a/src/components/Layout/Header/NavBar/MobileNavLink.tsx
+++ b/src/components/Layout/Header/NavBar/MobileNavLink.tsx
@@ -13,21 +13,40 @@ type MobileNavLinkProps = ButtonProps &
     order?: number
   }
 export const MobileNavLink = memo((props: MobileNavLinkProps) => {
-  const { label, shortLabel, path, icon, order, disable: _disable, ...rest } = props
+  const { label, shortLabel, path, icon, order, disable: _disable, relatedPaths, ...rest } = props
   const translate = useTranslate()
   const location = useLocation()
   const navigate = useNavigate()
+
   const isActive = useMemo(() => {
-    const match = matchPath(
-      {
-        path,
-        end: false,
-        caseSensitive: false,
-      },
-      location.pathname,
-    )
+    if (!relatedPaths?.length) {
+      const match = matchPath(
+        {
+          path,
+          end: false,
+          caseSensitive: false,
+        },
+        location.pathname,
+      )
+
+      return !!match
+    }
+
+    const match = relatedPaths.find(tradingPath => {
+      const match = matchPath(
+        {
+          path: tradingPath,
+          end: false,
+          caseSensitive: false,
+        },
+        location.pathname,
+      )
+
+      return !!match
+    })
+
     return !!match
-  }, [path, location.pathname])
+  }, [location.pathname, path, relatedPaths])
 
   const handleClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {

--- a/src/components/Layout/Header/NavBar/NavBar.tsx
+++ b/src/components/Layout/Header/NavBar/NavBar.tsx
@@ -7,7 +7,6 @@ import { Link as ReactRouterLink, matchPath, useLocation } from 'react-router-do
 
 import { MainNavLink } from './MainNavLink'
 
-import { TradeRoutePaths } from '@/components/MultiHopTrade/types'
 import { Text } from '@/components/Text'
 import { usePlugins } from '@/context/PluginProvider/PluginProvider'
 import type { Route } from '@/Routes/helpers'
@@ -102,23 +101,18 @@ export const NavBar = (props: NavBarProps) => {
                   },
                   pathname,
                 ) ||
-                (item.path === TradeRoutePaths.Input &&
-                  (!!matchPath(
-                    {
-                      path: '/limit',
-                      end: false,
-                      caseSensitive: false,
-                    },
-                    pathname,
-                  ) ||
-                    !!matchPath(
-                      {
-                        path: '/claim',
-                        end: false,
-                        caseSensitive: false,
-                      },
-                      pathname,
-                    )))
+                (item.relatedPaths &&
+                  !!item.relatedPaths.find(
+                    relatedPath =>
+                      !!matchPath(
+                        {
+                          path: relatedPath,
+                          end: false,
+                          caseSensitive: false,
+                        },
+                        pathname,
+                      ),
+                  ))
               }
             />
           ))}


### PR DESCRIPTION
## Description

Trade route was not active if going to limit or claim tab, on both desktop and mobile

Added a notion of `relatedPaths` to our routes, and checking if one of the related path is active to activate the button or not, so one button can have multiple active paths, will be very useful specially for mobile as we have a lot of routes that will activate the same navigation button (defi, trade, any other routes...)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9901

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- On mobile and desktop, check that claim and limit tab is activating the `Trade` nav link, as well as the trade routes

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="595" alt="image" src="https://github.com/user-attachments/assets/8fd3ede0-50eb-4c49-aeb5-62fddcce1cef" />
<img width="790" alt="image" src="https://github.com/user-attachments/assets/8bafdd12-d028-4fa3-bbc3-59e22d54faca" />
<img width="289" alt="image" src="https://github.com/user-attachments/assets/d9b89dbd-961e-42a0-88b7-af4d40d582f9" />
<img width="312" alt="image" src="https://github.com/user-attachments/assets/86abed6b-bc70-43c4-940a-168dd58f73a4" />
