### PR TITLE
fix: rfox pending/confirmed rfox claims display Tx link instead of claim button

### DIFF
--- a/src/components/Layout/Header/ActionCenter/components/RfoxClaimActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/RfoxClaimActionCard.tsx
@@ -7,6 +7,7 @@ import {
   Flex,
   HStack,
   Icon,
+  Link,
   Stack,
   useDisclosure,
 } from '@chakra-ui/react'
@@ -23,10 +24,11 @@ import { ActionStatusTag } from './ActionStatusTag'
 import { AssetIconWithBadge } from '@/components/AssetIconWithBadge'
 import { RawText } from '@/components/Text'
 import { bn } from '@/lib/bignumber/bignumber'
+import { getTxLink } from '@/lib/getTxLink'
 import { RfoxRoute } from '@/pages/RFOX/types'
 import type { RfoxClaimAction } from '@/state/slices/actionSlice/types'
 import { ActionStatus } from '@/state/slices/actionSlice/types'
-import { selectAssetById } from '@/state/slices/selectors'
+import { selectAssetById, selectFeeAssetByChainId } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
 dayjs.extend(relativeTime)
@@ -50,6 +52,10 @@ export const RfoxClaimActionCard = ({ action }: RfoxClaimActionCardProps) => {
 
   const stakingAsset = useAppSelector(state =>
     selectAssetById(state, action.rfoxClaimActionMetadata.request.stakingAssetId),
+  )
+
+  const feeAsset = useAppSelector(state =>
+    selectFeeAssetByChainId(state, stakingAsset?.chainId ?? ''),
   )
 
   const formattedDate = useMemo(() => {
@@ -121,6 +127,42 @@ export const RfoxClaimActionCard = ({ action }: RfoxClaimActionCardProps) => {
     translate,
   ])
 
+  const details = useMemo(() => {
+    if (!(stakingAsset && feeAsset)) return null
+
+    if (action.status === ActionStatus.ClaimAvailable)
+      return (
+        <Stack gap={4}>
+          <Button width='full' colorScheme='green' onClick={handleClaimClick}>
+            {translate('actionCenter.claim')}
+          </Button>
+        </Stack>
+      )
+
+    if (!action.rfoxClaimActionMetadata.txHash) return null
+
+    const txLink = getTxLink({
+      txId: action.rfoxClaimActionMetadata.txHash,
+      chainId: stakingAsset.chainId,
+      defaultExplorerBaseUrl: feeAsset.explorerTxLink,
+      address: undefined,
+      maybeSafeTx: undefined,
+    })
+
+    return (
+      <Button width='full' as={Link} isExternal href={txLink}>
+        {translate('actionCenter.viewTransaction')}
+      </Button>
+    )
+  }, [
+    action.rfoxClaimActionMetadata.txHash,
+    action.status,
+    feeAsset,
+    handleClaimClick,
+    stakingAsset,
+    translate,
+  ])
+
   return (
     <Stack
       spacing={4}
@@ -160,11 +202,7 @@ export const RfoxClaimActionCard = ({ action }: RfoxClaimActionCardProps) => {
           <Collapse in={isOpen}>
             <Card bg='transparent' mt={4} boxShadow='none'>
               <CardBody px={0} py={0}>
-                <Stack gap={4}>
-                  <Button width='full' colorScheme='green' onClick={handleClaimClick}>
-                    {translate('actionCenter.claim')}
-                  </Button>
-                </Stack>
+                {details}
               </CardBody>
             </Card>
           </Collapse>


### PR DESCRIPTION
## Description

Pretty much what the long PR title says!

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted in release

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- RFOX claim available notifications still have a claim button 
- RFOX claim pending/confirmed Txs have "View Transaction" button instead

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/b7689706-c537-4977-b932-cf7c6594a877


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
