### PR TITLE
fix: rfox container remove px on mobile

### DIFF
--- a/src/pages/RFOX/RFOX.tsx
+++ b/src/pages/RFOX/RFOX.tsx
@@ -12,14 +12,13 @@ import { RFOXProvider } from '@/pages/RFOX/hooks/useRfoxContext'
 
 const direction: StackDirection = { base: 'column-reverse', xl: 'row' }
 const maxWidth = { base: '100%', md: '450px' }
-const mainPx = { base: 0, md: 4 }
 const mainPaddingBottom = { base: 16, md: 8 }
 
 const rFOXHeader = <RFOXHeader />
 
 export const RFOX: React.FC = () => (
   <RFOXProvider>
-    <Main pb={mainPaddingBottom} headerComponent={rFOXHeader} px={mainPx} isSubPage>
+    <Main pb={mainPaddingBottom} headerComponent={rFOXHeader} px={4} isSubPage>
       <Stack alignItems='flex-start' spacing={4} mx='auto' direction={direction}>
         <Stack spacing={4} flex='1 1 0%' width='full'>
           <Overview />

--- a/src/pages/RFOX/RFOX.tsx
+++ b/src/pages/RFOX/RFOX.tsx
@@ -12,13 +12,14 @@ import { RFOXProvider } from '@/pages/RFOX/hooks/useRfoxContext'
 
 const direction: StackDirection = { base: 'column-reverse', xl: 'row' }
 const maxWidth = { base: '100%', md: '450px' }
+const mainPx = { base: 0, md: 4 }
 const mainPaddingBottom = { base: 16, md: 8 }
 
 const rFOXHeader = <RFOXHeader />
 
 export const RFOX: React.FC = () => (
   <RFOXProvider>
-    <Main pb={mainPaddingBottom} headerComponent={rFOXHeader} px={4} isSubPage>
+    <Main pb={mainPaddingBottom} headerComponent={rFOXHeader} px={mainPx} isSubPage>
       <Stack alignItems='flex-start' spacing={4} mx='auto' direction={direction}>
         <Stack spacing={4} flex='1 1 0%' width='full'>
           <Overview />

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -1,4 +1,4 @@
-import { CardBody, CardFooter, Collapse, Skeleton, Stack } from '@chakra-ui/react'
+import { CardBody, CardFooter, Collapse, Skeleton, Stack, useMediaQuery } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
 import {
   foxAssetId,
@@ -53,6 +53,7 @@ import {
   selectPortfolioCryptoPrecisionBalanceByFilter,
 } from '@/state/slices/selectors'
 import { useAppDispatch, useAppSelector } from '@/state/store'
+import { breakpoints } from '@/theme/theme'
 
 const formControlProps = {
   borderRadius: 0,
@@ -88,6 +89,8 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
   const dispatch = useAppDispatch()
   const translate = useTranslate()
   const navigate = useNavigate()
+  const [isSmallerThanMd] = useMediaQuery(`(max-width: ${breakpoints.md})`, { ssr: false })
+
   const {
     state: { isConnected, wallet },
   } = useWallet()
@@ -350,6 +353,12 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     [setSelectedStakingAssetId],
   )
 
+  const assetSelectButtonProps = useMemo(() => {
+    return {
+      maxWidth: isSmallerThanMd ? '100%' : undefined,
+    }
+  }, [isSmallerThanMd])
+
   const assetSelectComponent = useMemo(() => {
     return (
       <TradeAssetSelect
@@ -358,9 +367,18 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
         onAssetChange={handleAssetChange}
         assetIds={stakingAssetIds}
         onlyConnectedChains={true}
+        buttonProps={assetSelectButtonProps}
+        showChainDropdown={!isSmallerThanMd}
       />
     )
-  }, [selectedStakingAsset?.assetId, handleStakingAssetClick, handleAssetChange, stakingAssetIds])
+  }, [
+    assetSelectButtonProps,
+    handleAssetChange,
+    handleStakingAssetClick,
+    isSmallerThanMd,
+    selectedStakingAsset?.assetId,
+    stakingAssetIds,
+  ])
 
   const validateHasEnoughStakingAssetFeeBalance = useCallback(
     (input: string) => {


### PR DESCRIPTION
## Description

We were lacking space because of that 4 x-padding (i.e 16px), which we can't do on base breakpoints else input will be sad and disappear. Still not optimal in terms of space, but at least the input is visible now.
Basically aligns with places like `<BorrowInput />` which use similar 100% vw for asset selection on mobile, though I think ideally, what we would like here is to move to a *real* mobile design similar to the new swapper one by large @neomaking

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9904

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to RFOX page on mobile 
- Ensure that the input is visible

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/c8ec4727-7a40-435b-b0fb-24067cb94273


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
