### PR TITLE
feat: useRfoxBridge align fetchTradeStatus() usage

### DIFF
--- a/packages/swapper/src/swappers/ArbitrumBridgeSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ArbitrumBridgeSwapper/endpoints.ts
@@ -1,7 +1,7 @@
 import type { ParentToChildMessageReader, ParentToChildMessageReaderClassic } from '@arbitrum/sdk'
 import { ParentToChildMessageStatus, ParentTransactionReceipt } from '@arbitrum/sdk'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { arbitrumChainId, ethChainId } from '@shapeshiftoss/caip'
+import { arbitrumChainId } from '@shapeshiftoss/caip'
 import { evm } from '@shapeshiftoss/chain-adapters'
 import { getEthersV5Provider } from '@shapeshiftoss/contracts'
 import type { EvmChainId } from '@shapeshiftoss/types'
@@ -289,7 +289,7 @@ export const arbitrumBridgeApi: SwapperApi = {
 
     const childTxStatus = await checkEvmSwapStatus({
       txHash: maybeBuyTxHash,
-      chainId: ethChainId,
+      chainId: arbitrumChainId,
       assertGetEvmChainAdapter,
       address,
       fetchIsSmartContractAddressQuery,

--- a/packages/swapper/src/swappers/ArbitrumBridgeSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ArbitrumBridgeSwapper/endpoints.ts
@@ -1,7 +1,7 @@
 import type { ParentToChildMessageReader, ParentToChildMessageReaderClassic } from '@arbitrum/sdk'
 import { ParentToChildMessageStatus, ParentTransactionReceipt } from '@arbitrum/sdk'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { arbitrumChainId } from '@shapeshiftoss/caip'
+import { arbitrumChainId, ethChainId } from '@shapeshiftoss/caip'
 import { evm } from '@shapeshiftoss/chain-adapters'
 import { getEthersV5Provider } from '@shapeshiftoss/contracts'
 import type { EvmChainId } from '@shapeshiftoss/types'
@@ -289,7 +289,7 @@ export const arbitrumBridgeApi: SwapperApi = {
 
     const childTxStatus = await checkEvmSwapStatus({
       txHash: maybeBuyTxHash,
-      chainId: arbitrumChainId,
+      chainId: ethChainId,
       assertGetEvmChainAdapter,
       address,
       fetchIsSmartContractAddressQuery,

--- a/src/lib/tradeExecution.ts
+++ b/src/lib/tradeExecution.ts
@@ -59,7 +59,7 @@ export const fetchTradeStatus = async ({
   sellTxHash: string
   sellAssetChainId: string
   address: string | undefined
-  swap: Swap
+  swap: Swap | undefined
   stepIndex: SupportedTradeQuoteStepIndex
   config: ReturnType<typeof getConfig>
 }) => {

--- a/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
+++ b/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
@@ -24,7 +24,7 @@ import { fetchIsSmartContractAddressQuery } from '@/hooks/useIsSmartContractAddr
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { fromBaseUnit } from '@/lib/math'
 import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
-import { fetchTradeStatus, tradeStatusQueryKey } from '@/lib/tradeExecution'
+import { fetchTradeStatus } from '@/lib/tradeExecution'
 import { assertGetChainAdapter } from '@/lib/utils'
 import { assertGetCosmosSdkChainAdapter } from '@/lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, signAndBroadcast } from '@/lib/utils/evm'

--- a/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
+++ b/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
@@ -24,6 +24,7 @@ import { fetchIsSmartContractAddressQuery } from '@/hooks/useIsSmartContractAddr
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { fromBaseUnit } from '@/lib/math'
 import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
+import { fetchTradeStatus } from '@/lib/tradeExecution'
 import { assertGetChainAdapter } from '@/lib/utils'
 import { assertGetCosmosSdkChainAdapter } from '@/lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, signAndBroadcast } from '@/lib/utils/evm'
@@ -270,9 +271,10 @@ export const useRfoxBridge = ({ confirmedQuote }: UseRfoxBridgeProps): UseRfoxBr
     queryFn:
       l1TxHash && sellAsset?.chainId
         ? () =>
-            arbitrumBridgeApi.checkTradeStatus({
-              txHash: l1TxHash,
-              chainId: sellAsset.chainId,
+            fetchTradeStatus({
+              swapper: arbitrumBridgeApi,
+              sellTxHash: l1TxHash,
+              sellAssetChainId: sellAsset.chainId,
               stepIndex: 0,
               address: fromAccountId(confirmedQuote.sellAssetAccountId).account,
               swap: undefined,

--- a/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
+++ b/src/pages/RFOX/components/Stake/Bridge/hooks/useRfoxBridge.ts
@@ -24,7 +24,7 @@ import { fetchIsSmartContractAddressQuery } from '@/hooks/useIsSmartContractAddr
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { fromBaseUnit } from '@/lib/math'
 import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
-import { fetchTradeStatus } from '@/lib/tradeExecution'
+import { fetchTradeStatus, tradeStatusQueryKey } from '@/lib/tradeExecution'
 import { assertGetChainAdapter } from '@/lib/utils'
 import { assertGetCosmosSdkChainAdapter } from '@/lib/utils/cosmosSdk'
 import { assertGetEvmChainAdapter, signAndBroadcast } from '@/lib/utils/evm'

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -382,6 +382,9 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
 
   const validateHasEnoughStakingAssetFeeBalance = useCallback(
     (input: string) => {
+      // Do NOT do ETH.ARB balance checks here if the user is going to bridge.
+      // Fees will be on mainnet, and estimate on the next step
+      if (isBridgeRequired) return true
       // Staking asset fee asset still loading, assume enough balance not to have a flash of error state on first render
       if (!stakingAssetFeeAsset) return true
       if (bnOrZero(input).isZero()) return true
@@ -410,6 +413,7 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     amountUserCurrency,
     stakeFees,
     trigger,
+    isBridgeRequired,
   ])
 
   const amountFieldInputRules = useMemo(() => {

--- a/src/pages/RFOX/components/Stake/StakeInput.tsx
+++ b/src/pages/RFOX/components/Stake/StakeInput.tsx
@@ -400,7 +400,13 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
 
       return true
     },
-    [stakingAssetFeeAsset, stakingAssetFeeAssetBalanceCryptoPrecision, approvalFees, stakeFees],
+    [
+      stakingAssetFeeAsset,
+      stakingAssetFeeAssetBalanceCryptoPrecision,
+      approvalFees,
+      stakeFees,
+      isBridgeRequired,
+    ],
   )
   // Trigger re-validation since react-hook-form validation methods are fired onChange and not in a component-reactive manner
   useEffect(() => {
@@ -413,7 +419,6 @@ export const StakeInput: React.FC<StakeInputProps & StakeRouteProps> = ({
     amountUserCurrency,
     stakeFees,
     trigger,
-    isBridgeRequired,
   ])
 
   const amountFieldInputRules = useMemo(() => {


### PR DESCRIPTION
## Description

One usage of `swapperCheckTradeStatus()` still existed directly as opposed to the new `fetchTradeStatus()` - this aligns it.

While at it, fixes 
- borked bridge final checks which were broken to start with. 
- wrong "Insufficient ETH.ARB" messaging when bridging

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9716
closes https://github.com/shapeshift/web/issues/9956
closes https://github.com/shapeshift/web/issues/9955

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Status checks are still performed for RFOX bridge
- Status checks are now happy until success for RFOX bridge (and in swapper, too) 
- If you don't have ETH.ARB on your account, there is *no* insuficcient ETH.ARB error, fees checks are done in the bridge step explicitly

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^ 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^ 

## Screenshots (if applicable)


<img width="486" height="658" alt="image" src="https://github.com/user-attachments/assets/70244220-4267-4cb8-94d1-d2820aa0df27" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
