### PR TITLE
fix: always upsert accounts if no account is enable

### DIFF
--- a/src/context/AppProvider/hooks/useAccountsFetchQuery.tsx
+++ b/src/context/AppProvider/hooks/useAccountsFetchQuery.tsx
@@ -164,7 +164,8 @@ export const useAccountsFetchQuery = () => {
               if (
                 (!enabledPortfolioAccounts[accountId]?.hasActivity &&
                   !portfolioAccounts[accountId]) ||
-                isSnapStatusUpdated
+                isSnapStatusUpdated ||
+                Object.keys(enabledPortfolioAccounts).length === 0
               ) {
                 dispatch(portfolioSlice.actions.upsertPortfolio(portfolio))
 


### PR DESCRIPTION
## Description

There is a case where `portfolioAccount` has been fetched (probably because of the first `getAccounts`, so accounts are not enabled but fetched already, we want to ensure that we enabled them at least one time before stopping to auto enable accounts, by checking if at least 1 account is enabled

So: this fix intent is to always fetch accounts if absolutely 0 accounts are enabled, as it means that the initial load hasn't been done!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9946

## Risk
Medium, account disovery could be spamming requests for no reasons (but well, shouldn't!)
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- I think the easiest way to do that is to disabled absolutely every account but BASE isn't shown as it's flacky, then refresh the page, see that account discovery is running and auto enabling accounts!
- Try to import a wallet a few time after clearing your cache, you shouldn't face the 0 account bug with infinite loading or 0 balance!
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering
n/a
<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations
n/a
- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
I had a state where the app was borken, without any accounts activated, refreshed with this fix and account was shown! 

https://jam.dev/c/8073b004-e94f-4fe1-8ad5-3bb66d1890f0