### PR TITLE
fix: prevent trade input side component borders from being chopped off in light mode (#9966)

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderList.tsx
@@ -351,8 +351,18 @@ export const LimitOrderList: FC<LimitOrderListProps> = ({ cardProps, onBack }) =
     setOrderToCancel(order)
   }, [])
 
+  // Patch styling: border to remedy box shadow cut off in light mode
+  const isDarkMode = useColorModeValue(false, true)
+  const borderStyle = useMemo(
+    () =>
+      isDarkMode
+        ? {}
+        : { borderColor: 'border.base', borderWidth: '1px', borderBottomWidth: '2px' },
+    [isDarkMode],
+  )
+
   return (
-    <Card bg={cardBgProp} {...cardProps}>
+    <Card bg={cardBgProp} {...borderStyle} {...cardProps}>
       {onBack && (
         <CardHeader
           px={4}

--- a/src/components/MultiHopTrade/components/QuoteList/QuoteList.tsx
+++ b/src/components/MultiHopTrade/components/QuoteList/QuoteList.tsx
@@ -56,8 +56,24 @@ export const QuoteList: React.FC<QuoteListProps> = ({ onBack, isLoading, cardPro
 
   const sortByTextColor = useColorModeValue('blackAlpha.500', 'whiteAlpha.500')
 
+  // Patch styling: border to remedy box shadow cut off in light mode
+  const isDarkMode = useColorModeValue(false, true)
+  const borderStyle = useMemo(
+    () =>
+      isDarkMode
+        ? {}
+        : { borderColor: 'border.base', borderWidth: '1px', borderBottomWidth: '2px' },
+    [isDarkMode],
+  )
+
   return (
-    <Card {...cardProps} bg={cardBgProp} borderRadius={cardBorderRadius} height={cardHeight}>
+    <Card
+      {...borderStyle}
+      {...cardProps}
+      bg={cardBgProp}
+      borderRadius={cardBorderRadius}
+      height={cardHeight}
+    >
       <CardHeader px={4} pt={4} display='flex' alignItems='center' justifyContent='space-between'>
         <Flex alignItems={'center'} gap={2}>
           {onBack && <BackButton ml={-2} onClick={onBack} />}


### PR DESCRIPTION

## Description

Small adjustment to the trade input component to ensure our borders don't get cut off in light mode. See screenshot below for the current issue. 

<img width="1172" height="773" alt="image" src="https://github.com/user-attachments/assets/bc4c8347-9cbf-407b-ae47-a122d8127e1e" />

This fix doesn't fully fix the issue. It's an attempt to get 80% of the way there with 20% of the risk.

I attempted a few adjustments which properly "fixed" the issues but all required some substantial changes to the flex component architecture which I believe is too high risk for the benefits here. This is minimal risk and at least looks reasonable. 

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9966

## Risk

Low, the adjustments are limited to the introduction of a border. So no major changes to how the panel renders are expected.

Risk would be the swapper sidebar (quote list and limit order panel) rendering strangely.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test the Trade/Bridge input and the limit order input with a variety of screen sizes
* Tests resizing such that it opens and closes

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/5aca45ca-b5d5-4675-a13d-a841d4171446
