### PR TITLE
feat: reduce amount of single EVM contract address market XHRs

### DIFF
--- a/src/lib/portals/types.ts
+++ b/src/lib/portals/types.ts
@@ -12,6 +12,7 @@ export type TokenInfo = {
   platform: string
   network: string
   liquidity: number
+  totalSupply: string | undefined
   metrics: {
     apy?: string
     volumeUsd1d?: string


### PR DESCRIPTION
## Description

Portals /v2/account endpoints already gives us list of holdings for a given address, including associated meta for the tokens.

So this allows us to hit a single endpoint (well, a few i.e once per EVM address and chain) instead of the current `findByAssetId()` RTK query logic, which feels saner.

Note this doesn't use the `AsyncQueue` from previous, since this is inherently a lot less requests.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/Medium risk of borked market-data

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test with/out a nuked cache and ensure market-data still looks sane across the board (beware of rate limits while testing this)

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

<img width="1728" height="998" alt="Screenshot 2025-07-16 at 15 39 58" src="https://github.com/user-attachments/assets/70cf357a-1970-4164-ae07-9134789bf64a" />

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
