### PR TITLE
fix: disable asym lp deposits for tcy and ruji

### DIFF
--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -1,7 +1,7 @@
 import type { RadioProps, TextProps } from '@chakra-ui/react'
 import { Box, Flex, HStack, Skeleton, Tooltip, useRadio, useRadioGroup } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { thorchainAssetId } from '@shapeshiftoss/caip'
+import { rujiAssetId, tcyAssetId, thorchainAssetId } from '@shapeshiftoss/caip'
 import type { JSX } from 'react'
 import React, { useCallback, useEffect, useMemo } from 'react'
 import { BiSolidBoltCircle, BiSolidPlusCircle, BiSolidXCircle } from 'react-icons/bi'
@@ -261,6 +261,14 @@ export const LpType = ({
       const currentSideBalances = balancesByPosition?.[option.value as AsymSide | 'sym']
 
       const isDisabled = (() => {
+        // https://gitlab.com/thorchain/thornode/-/issues/2214
+        if (
+          (assetId === tcyAssetId || assetId === rujiAssetId) &&
+          (option.value === AsymSide.Asset || option.value === AsymSide.Rune)
+        ) {
+          return true
+        }
+
         if (isDeposit && hasAsymRunePosition && option.value === 'sym') return true
         if (!isWithdraw) return false
 
@@ -313,6 +321,7 @@ export const LpType = ({
   }, [
     getRadioProps,
     makeAssetIdsOption,
+    assetId,
     translate,
     isWithdraw,
     isSymPositionType,


### PR DESCRIPTION
## Description

Disable the ability to select asym asset or asym rune thorchain lp deposits for TCY and RUJI.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://gitlab.com/thorchain/thornode/-/issues/2214

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure you cannot select asym rune or asym asset thorchain lp deposits for TCY and RUJI

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

## Screenshots (if applicable)

<img width="344" height="543" alt="image" src="https://github.com/user-attachments/assets/9ab6f2d3-eb48-4e2c-adb7-0133c8c9c99e" />

<img width="355" height="454" alt="image" src="https://github.com/user-attachments/assets/0eaea227-345d-48f5-93c2-ae455a0a8301" />
