### PR TITLE
chore: add butter affiliate code + tweaks

### DIFF
--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.test.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.test.ts
@@ -1,5 +1,4 @@
 import { Ok } from '@sniptt/monads'
-import type { AxiosResponse } from 'axios'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { CommonTradeQuoteInput, SwapperDeps } from '../../../types'
@@ -41,7 +40,7 @@ vi.mock('../xhr', () => ({
 }))
 
 describe('getTradeQuote', () => {
-  it('should return a trade quote', async () => {
+  it('should not return a trade quote for same-chain swaps', async () => {
     const deps: SwapperDeps = {
       assetsById: { [ETH.assetId]: ETH },
       assertGetChainAdapter: () => vi.fn() as any,
@@ -68,17 +67,12 @@ describe('getTradeQuote', () => {
       quoteOrRate: 'quote',
     }
 
-    mocks.get.mockResolvedValue(Ok({ data: ROUTE_QUOTE } as unknown as AxiosResponse<any>))
-
     const result = await getTradeQuote(input, deps)
 
-    expect(result.isOk()).toBe(true)
-    const tradeQuote = result.unwrap()
-    // Use the actual returned value for the expected rate
-    expect(tradeQuote[0].rate).toBe('2296.409699')
-    // 1 WETH in base units
-    expect(tradeQuote[0].steps[0].sellAmountIncludingProtocolFeesCryptoBaseUnit).toBe(
-      '1000000000000000000',
-    )
+    expect(result.isOk()).toBe(false)
+    expect(result.isErr()).toBe(true)
+
+    const error = result.unwrapErr()
+    expect(error.message).toContain('Same-chain swaps are not supported by ButterSwap')
   })
 })

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.ts
@@ -1,6 +1,12 @@
 import { btcAssetId, btcChainId, solanaChainId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
-import { bn, bnOrZero, chainIdToFeeAssetId, fromBaseUnit, toBaseUnit } from '@shapeshiftoss/utils'
+import {
+  bnOrZero,
+  chainIdToFeeAssetId,
+  convertDecimalPercentageToBasisPoints,
+  fromBaseUnit,
+  toBaseUnit,
+} from '@shapeshiftoss/utils'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { TransactionMessage, VersionedTransaction } from '@solana/web3.js'
@@ -86,7 +92,7 @@ export const getTradeQuote = async (
   const slippageDecimal =
     slippageTolerancePercentageDecimal ??
     getDefaultSlippageDecimalPercentageForSwapper(SwapperName.ButterSwap)
-  const slippage = bn(slippageDecimal).times(10000).toString()
+  const slippage = convertDecimalPercentageToBasisPoints(slippageDecimal).toString()
 
   // Call ButterSwap /route API
   const routeResult = await getButterRoute({

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.ts
@@ -80,6 +80,16 @@ export const getTradeQuote = async (
     )
   }
 
+  // Disable same-chain swaps for ButterSwap
+  if (sellAsset.chainId === buyAsset.chainId) {
+    return Err(
+      makeSwapErrorRight({
+        message: `Same-chain swaps are not supported by ButterSwap`,
+        code: TradeQuoteError.UnsupportedTradePair,
+      }),
+    )
+  }
+
   if (!sendAddress) {
     return Err(
       makeSwapErrorRight({

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
@@ -75,6 +75,16 @@ export const getTradeRate = async (
     )
   }
 
+  // Disable same-chain swaps for ButterSwap, as we cannot collect affiliate fees for them
+  if (sellAsset.chainId === buyAsset.chainId) {
+    return Err(
+      makeSwapErrorRight({
+        message: `Same-chain swaps are not supported by ButterSwap`,
+        code: TradeQuoteError.UnsupportedTradePair,
+      }),
+    )
+  }
+
   const amount = bn(sellAmountIncludingProtocolFeesCryptoBaseUnit)
     .shiftedBy(-sellAsset.precision)
     .toString()

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
@@ -1,6 +1,12 @@
 import { btcAssetId, btcChainId, solanaChainId } from '@shapeshiftoss/caip'
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
-import { bn, bnOrZero, chainIdToFeeAssetId, toBaseUnit } from '@shapeshiftoss/utils'
+import {
+  bn,
+  bnOrZero,
+  chainIdToFeeAssetId,
+  convertDecimalPercentageToBasisPoints,
+  toBaseUnit,
+} from '@shapeshiftoss/utils'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 
@@ -78,7 +84,9 @@ export const getTradeRate = async (
   const slippageTolerancePercentageDecimal = getDefaultSlippageDecimalPercentageForSwapper(
     SwapperName.ButterSwap,
   )
-  const slippage = bn(slippageTolerancePercentageDecimal).times(10000).toString()
+  const slippage = convertDecimalPercentageToBasisPoints(
+    slippageTolerancePercentageDecimal,
+  ).toString()
 
   const result = await getButterRoute({
     sellAsset,

--- a/packages/swapper/src/swappers/ButterSwap/test-data/routeQuote.ts
+++ b/packages/swapper/src/swappers/ButterSwap/test-data/routeQuote.ts
@@ -33,7 +33,7 @@ export const ROUTE_QUOTE: RouteResponse = {
       gasEstimatedTarget: '1159118',
       timeEstimated: 0,
       hash: '0x0f63cad26f956f243062811c999eb8e4c441ddfd0940eb3f4d2e43c9f0f220bf',
-      entrance: 'butter+',
+      entrance: 'shapeshift',
       timestamp: 1750545317395,
       hasLiquidity: true,
       srcChain: {

--- a/packages/swapper/src/swappers/ButterSwap/utils/constants.ts
+++ b/packages/swapper/src/swappers/ButterSwap/utils/constants.ts
@@ -1,4 +1,4 @@
-const BUTTERSWAP_AFFILIATE = '' // TODO: add affiliate
+const BUTTERSWAP_AFFILIATE = 'shapeshift'
 
 export const makeButterSwapAffiliate = (affiliateBps: string): string | undefined => {
   if (!BUTTERSWAP_AFFILIATE) return undefined

--- a/packages/swapper/src/swappers/ButterSwap/xhr.ts
+++ b/packages/swapper/src/swappers/ButterSwap/xhr.ts
@@ -89,7 +89,7 @@ export const getButterRoute = async ({
     amount: sellAmountCryptoBaseUnit,
     type: 'exactIn',
     slippage,
-    entrance: 'Butter+',
+    entrance: 'shapeshift',
     affiliate,
   }
   const result = await butterService.get<RouteResponse>('/route', { params })


### PR DESCRIPTION
## Description

- Adds the `shapeshift` affiliate string to the Butter swapper
- Adds the `shapeshift` entrance
- Improves consistency by using the `convertDecimalPercentageToBasisPoints` helper
- Disables same-chain swaps on Butter, as we can't collect affiliate fees on them (yet)

## Issue (if applicable)

Closes #9834.

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Butter swaps

## Testing

Ensure Butter quote and rate requests both contain `shapeshift:55` in the affiliate param (note, only cross-chain swaps use an affiliate fee - we might want to disable same-chain butter swaps before go-live for this reason):

<img width="525" height="249" alt="Screenshot 2025-07-20 at 1 24 57 pm" src="https://github.com/user-attachments/assets/2236b4bf-05a9-4bda-9d04-9889d0c437da" />

Ensure Butter swaps go through. 

<img width="503" height="580" alt="Screenshot 2025-07-20 at 12 19 13 pm" src="https://github.com/user-attachments/assets/1533bd81-1754-452b-a14a-afa4a6dd429d" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.