### PR TITLE
feat: spot notification center display actual amount

### DIFF
--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -389,12 +389,14 @@ export type Swap = {
   buyTxHash?: string
   statusMessage?: string | [string, Polyglot.InterpolationOptions] | undefined
   sellAccountId: AccountId
+  buyAccountId: AccountId | undefined
   receiveAddress: string | undefined
   swapperName: SwapperName
   sellAmountCryptoBaseUnit: string
   expectedBuyAmountCryptoBaseUnit: string
   sellAmountCryptoPrecision: string
   expectedBuyAmountCryptoPrecision: string
+  actualBuyAmountCryptoPrecision?: string | undefined
   txLink?: string
   metadata: SwapperSpecificMetadata
   isStreaming?: boolean

--- a/src/components/Layout/Header/ActionCenter/components/Notifications/SwapNotification.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Notifications/SwapNotification.tsx
@@ -53,7 +53,7 @@ export const SwapNotification = ({ handleClick, swapId, onClose }: SwapNotificat
       ),
       buyAmountAndSymbol: (
         <Amount.Crypto
-          value={swap.expectedBuyAmountCryptoPrecision}
+          value={swap.actualBuyAmountCryptoPrecision ?? swap.expectedBuyAmountCryptoPrecision}
           symbol={swap.buyAsset.symbol}
           fontSize='sm'
           fontWeight='bold'

--- a/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
@@ -71,7 +71,7 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
       ),
       buyAmountAndSymbol: (
         <Amount.Crypto
-          value={swap.expectedBuyAmountCryptoPrecision}
+          value={swap.actualBuyAmountCryptoPrecision ?? swap.expectedBuyAmountCryptoPrecision}
           symbol={swap.buyAsset.symbol}
           fontSize='sm'
           fontWeight='bold'

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
@@ -13,7 +13,10 @@ import { useGetTradeQuotes } from '@/components/MultiHopTrade/hooks/useGetTradeQ
 import { TradeRoutePaths } from '@/components/MultiHopTrade/types'
 import { assertUnreachable } from '@/lib/utils'
 import { swapSlice } from '@/state/slices/swapSlice/swapSlice'
-import { selectFirstHopSellAccountId } from '@/state/slices/tradeInputSlice/selectors'
+import {
+  selectFirstHopSellAccountId,
+  selectLastHopBuyAccountId,
+} from '@/state/slices/tradeInputSlice/selectors'
 import {
   selectActiveQuote,
   selectConfirmedTradeExecutionState,
@@ -78,6 +81,7 @@ export const useTradeButtonProps = ({
   })
 
   const sellAccountId = useAppSelector(selectFirstHopSellAccountId)
+  const buyAccountId = useAppSelector(selectLastHopBuyAccountId)
 
   const handleTradeConfirm = useCallback(() => {
     if (!activeQuote) return
@@ -91,6 +95,7 @@ export const useTradeButtonProps = ({
       createdAt: Date.now(),
       updatedAt: Date.now(),
       sellAccountId,
+      buyAccountId,
       receiveAddress: activeQuote.receiveAddress,
       source: firstStep.source,
       swapperName: activeQuote.swapperName,
@@ -126,7 +131,15 @@ export const useTradeButtonProps = ({
     dispatch(swapSlice.actions.setActiveSwapId(swap.id))
 
     dispatch(tradeQuoteSlice.actions.confirmTrade(activeQuote.id))
-  }, [dispatch, activeQuote, currentHopIndex, sellAccountId, relayerExplorerTxLink, relayerTxHash])
+  }, [
+    dispatch,
+    activeQuote,
+    currentHopIndex,
+    buyAccountId,
+    sellAccountId,
+    relayerExplorerTxLink,
+    relayerTxHash,
+  ])
 
   const executeTrade = useTradeExecution(currentHopIndex, activeTradeId)
 


### PR DESCRIPTION
## Description

Note: same as previously, that won't work with custom receive addies.
Think it's a nice first step, though, eventually we probably should leverage status endpoints to decode receive amounts, regardless of chain (i.e, we should be able to decode receive amounts for e.g UTXOs and a custom receive address, i.e an account we don't know about in app)

If anything, this keeps things consistent with current status screen, so I believe that's the perfect interim solution!

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10012

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/Medium - worst case scenario, we fallback to expected

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Give this a quick spin with CoW (surplus very likely) and other swappers and ensure the amount in the notification/action card match the actual trade status screen

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/fb41187f-6212-4488-a329-d010ef47e2da


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
