### PR TITLE
fix: trade quote card don't display quote tags if there is no quote

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuote.tsx
@@ -198,9 +198,9 @@ export const TradeQuote: FC<TradeQuoteProps> = memo(
             <Skeleton isLoaded={!isLoading}>
               <Flex alignItems='center' gap={2}>
                 <TradeQuoteBadges
-                  isBestRate={isBestRate}
-                  isFastest={isFastest}
-                  isLowestGas={isLowestGas}
+                  isBestRate={quote && isBestRate}
+                  isFastest={quote && isFastest}
+                  isLowestGas={quote && isLowestGas}
                   quoteDisplayOption={quoteDisplayOption}
                 />
                 {errorIndicator}


### PR DESCRIPTION
## Description

Spotted this one while testing Butter and noticed we were displaying quote tags... without a quote. Fixed by not displaying them if so!

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Play with this PR and a few diff quotes and ensure we still look gucci
- Rates that fail with an error that yields no rate (e.g minimum not met) should not display tags
- Rates that fail with an error but still yield a rate (e.g not enough funds) should still display tags if applicable

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

- this diff


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
