### PR TITLE
fix: disable ruji/rune pooling until upstream issue is fixed

### DIFF
--- a/src/lib/utils/thorchain/hooks/useIsThorchainLpDepositEnabled.tsx
+++ b/src/lib/utils/thorchain/hooks/useIsThorchainLpDepositEnabled.tsx
@@ -1,5 +1,5 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { thorchainChainId } from '@shapeshiftoss/caip'
+import { rujiAssetId, thorchainChainId } from '@shapeshiftoss/caip'
 import { assetIdToThorPoolAssetId } from '@shapeshiftoss/swapper'
 
 import { useThorchainMimir } from './useThorchainMimir'
@@ -20,6 +20,9 @@ export const useIsLpDepositEnabled = (assetId: AssetId | undefined) => {
         // PAUSELPDEPOSIT- mimirs don't use the usual dot notation
         // e.g ETH.FLIP-0X826180541412D574CF1336D22C0C0A287822678A becomes PAUSELPDEPOSIT-ETH-FLIP-0X826180541412D574CF1336D22C0C0A287822678A
         const poolAssetId = (k.split('PAUSELPDEPOSIT-')[1] ?? '').replace('-', '.')
+
+        // TEMP - Monkey patch until upstream issue with RUJI/RUNE pool is fixed
+        if (assetId === rujiAssetId) return true
 
         return poolAssetId === thorchainAssetId && Boolean(v)
       })


### PR DESCRIPTION
## Description

This temporarily disables the RUNE/RUJI pool as there's an upstream issue causing it to not display positions and correct stats.

The actual "disabled" field comes from the server side. So this is a bit of a monkey patch added to the `useIsLpDepositEnabled` hook.

I've verified that the hook is purely used to block UI on the pools page.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10031 

## Risk

Low risk, this shouldn't effect anything except ruji/rune pooling

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Go to the pools page of the app and verify that RUJI/RUNE is marked as disabled
* Ensure that you can't add liquidity to the pool 

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="545" height="703" alt="image" src="https://github.com/user-attachments/assets/08c44217-4f58-40fb-bea4-39f7d75802fa" />

<img width="1061" height="601" alt="image" src="https://github.com/user-attachments/assets/7f636163-a052-46b3-af22-3c6cb855132c" />

<img width="1115" height="262" alt="image" src="https://github.com/user-attachments/assets/a4d90d2a-40ac-4028-9622-f95b7746a2a4" />
