### PR TITLE
fix: make fox farming flow redirect go back to start of modal flow

### DIFF
--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Claim/ClaimConfirm.tsx
@@ -193,7 +193,7 @@ export const ClaimConfirm = ({ accountId, assetId, amount, onBack }: ClaimConfir
         assets,
       )
 
-      navigate('/fox')
+      navigate(-1)
     } catch (error) {
       console.error(error)
       toast({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Deposit/components/Confirm.tsx
@@ -201,7 +201,7 @@ export const Confirm: React.FC<StepComponentProps & { accountId: AccountId | und
         assets,
       )
 
-      navigate('/fox')
+      navigate(-1)
     } catch (error) {
       console.error(error)
       toast({

--- a/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
+++ b/src/features/defi/providers/fox-farming/components/FoxFarmingManager/Withdraw/components/Confirm.tsx
@@ -193,7 +193,7 @@ export const Confirm: React.FC<ConfirmProps> = ({ accountId, onNext }) => {
         assets,
       )
 
-      navigate('/fox')
+      navigate(-1)
     } catch (error) {
       console.error(error)
     }


### PR DESCRIPTION
## Description

Stops fox farming deposit, claim and withdrawal flow from redirecting back to the fox page which can be jarring if you're not managing the pool from that page. Instead, mimic cancel operation that goes back to the start of the flow.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that claim, withdraw and deposit operations on fox farming take you back to the start of the modal flow once the notification has been kicked off.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/6d72572f-d166-4615-a9f2-313215439cc6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated navigation after claim, deposit, and withdrawal actions to return users to the previous screen instead of redirecting to a fixed route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->