### PR TITLE
fix: add background to the trade summary so it doesn't look crazy with confetti banner

### DIFF
--- a/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
+++ b/src/components/MultiHopTrade/components/SpotTradeSuccess/SpotTradeSuccess.tsx
@@ -11,6 +11,7 @@ import {
   Icon,
   Stack,
   useDisclosure,
+  useMediaQuery,
 } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { TransferType } from '@shapeshiftoss/unchained-client'
@@ -39,6 +40,7 @@ import {
 } from '@/state/slices/tradeQuoteSlice/selectors'
 import { serializeTxIndex } from '@/state/slices/txHistorySlice/utils'
 import { useAppSelector } from '@/state/store'
+import { breakpoints } from '@/theme/theme'
 
 export type SpotTradeSuccessProps = {
   handleBack: () => void
@@ -172,6 +174,8 @@ export const SpotTradeSuccess = ({
     actualBuyAmountCryptoPrecision,
   ])
 
+  const [isSmallerThanMd] = useMediaQuery(`(max-width: ${breakpoints.md})`, { ssr: false })
+
   if (!(buyAsset && sellAsset)) return null
 
   return (
@@ -208,6 +212,7 @@ export const SpotTradeSuccess = ({
             px={cardFooterPx}
             position={footerPosition}
             bottom='var(--mobile-nav-offset)'
+            backgroundColor={isSmallerThanMd ? 'background.surface.base' : undefined}
           >
             <SlideTransition>
               <HStack width='full' justifyContent='space-between'>


### PR DESCRIPTION

## Description

Add a background colour to the sticky mobile trade summary to avoid text overlap on squished screens

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9825 

## Risk

Low risk, colour could look weird

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Do a trade that often results in the "You got more" confetti banner. I found Eth on Arb -> Fox on Arb to be somewhat reliable. 
* Expand and collapse the trade summary section on both desktop and mobile. Make sure colours look ok and text doesn't overlap
* Test on particularly small mobile screens

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

:point_up: 

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

:point_up: 


- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/884d32d5-1ac1-41ea-93c3-c00c4b80b4ec