### PR TITLE
fix: ensure generic transaction query invalidation doesnt over invalidate or silently fail

### DIFF
--- a/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
+++ b/src/pages/RFOX/components/ChangeAddress/ChangeAddressConfirm.tsx
@@ -44,6 +44,7 @@ import {
   ActionStatus,
   ActionType,
   GenericTransactionDisplayType,
+  GenericTransactionQueryId,
 } from '@/state/slices/actionSlice/types'
 import {
   selectAccountNumberByAccountId,
@@ -186,6 +187,7 @@ export const ChangeAddressConfirm: React.FC<
           updatedAt: Date.now(),
           transactionMetadata: {
             displayType: GenericTransactionDisplayType.RFOX,
+            queryId: GenericTransactionQueryId.RFOX,
             txHash: txId,
             chainId: stakingAsset.chainId,
             accountId: confirmedQuote.stakingAssetAccountId,

--- a/src/pages/RFOX/components/Stake/hooks/useRfoxStake.tsx
+++ b/src/pages/RFOX/components/Stake/hooks/useRfoxStake.tsx
@@ -33,6 +33,7 @@ import {
   ActionStatus,
   ActionType,
   GenericTransactionDisplayType,
+  GenericTransactionQueryId,
 } from '@/state/slices/actionSlice/types'
 import {
   selectAccountNumberByAccountId,
@@ -249,6 +250,7 @@ export const useRfoxStake = ({
           updatedAt: Date.now(),
           transactionMetadata: {
             displayType: GenericTransactionDisplayType.RFOX,
+            queryId: GenericTransactionQueryId.RFOX,
             txHash: txId,
             chainId: stakingAsset.chainId,
             accountId: stakingAssetAccountId,

--- a/src/pages/RFOX/components/Unstake/hooks/useRfoxUnstake.tsx
+++ b/src/pages/RFOX/components/Unstake/hooks/useRfoxUnstake.tsx
@@ -32,6 +32,7 @@ import {
   ActionStatus,
   ActionType,
   GenericTransactionDisplayType,
+  GenericTransactionQueryId,
 } from '@/state/slices/actionSlice/types'
 import {
   selectAccountNumberByAccountId,
@@ -178,6 +179,7 @@ export const useRfoxUnstake = ({
           updatedAt: Date.now(),
           transactionMetadata: {
             displayType: GenericTransactionDisplayType.RFOX,
+            queryId: GenericTransactionQueryId.RFOX,
             amountCryptoPrecision,
             cooldownPeriod,
             message: 'RFOX.unstakePending',

--- a/src/pages/TCY/components/Stake/StakeConfirm.tsx
+++ b/src/pages/TCY/components/Stake/StakeConfirm.tsx
@@ -22,6 +22,7 @@ import {
   ActionStatus,
   ActionType,
   GenericTransactionDisplayType,
+  GenericTransactionQueryId,
 } from '@/state/slices/actionSlice/types'
 import { selectAssetById } from '@/state/slices/assetsSlice/selectors'
 import { selectMarketDataByFilter } from '@/state/slices/marketDataSlice/selectors'
@@ -82,6 +83,7 @@ export const StakeConfirm: React.FC = () => {
           type: ActionType.Deposit,
           transactionMetadata: {
             displayType: GenericTransactionDisplayType.TCY,
+            queryId: GenericTransactionQueryId.TCY,
             txHash: txid,
             chainId: thorchainChainId,
             accountId,

--- a/src/pages/TCY/components/Unstake/UnstakeConfirm.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeConfirm.tsx
@@ -23,6 +23,7 @@ import {
   ActionStatus,
   ActionType,
   GenericTransactionDisplayType,
+  GenericTransactionQueryId,
 } from '@/state/slices/actionSlice/types'
 import { selectAssetById } from '@/state/slices/assetsSlice/selectors'
 import { selectMarketDataByFilter } from '@/state/slices/marketDataSlice/selectors'
@@ -92,6 +93,7 @@ export const UnstakeConfirm: React.FC = () => {
           type: ActionType.Withdraw,
           transactionMetadata: {
             displayType: GenericTransactionDisplayType.TCY,
+            queryId: GenericTransactionQueryId.TCY,
             txHash: txid,
             chainId: thorchainChainId,
             accountId,

--- a/src/pages/TCY/queries/useTcyStaker.tsx
+++ b/src/pages/TCY/queries/useTcyStaker.tsx
@@ -2,36 +2,19 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import axios from 'axios'
-import { useMemo } from 'react'
 
 import { getConfig } from '@/config'
-import {
-  ActionStatus,
-  ActionType,
-  GenericTransactionDisplayType,
-} from '@/state/slices/actionSlice/types'
-import { selectWalletGenericTransactionActionsSorted } from '@/state/slices/selectors'
-import { useAppSelector } from '@/state/store'
 
 type TcyStaker = {
   amount: string
   asset: string
 }
 
+export const getTcyStakerQueryKey = (accountId: AccountId | undefined) => ['tcy-staker', accountId]
+
 export const useTcyStaker = (accountId: AccountId | undefined) => {
-  const allGenericActions = useAppSelector(selectWalletGenericTransactionActionsSorted)
-
-  const completeTcyStakingActionCount = useMemo(() => {
-    return allGenericActions.filter(
-      action =>
-        action.transactionMetadata.displayType === GenericTransactionDisplayType.TCY &&
-        [ActionType.Withdraw, ActionType.Deposit].includes(action.type) &&
-        action.status === ActionStatus.Complete,
-    ).length
-  }, [allGenericActions])
-
   return useSuspenseQuery({
-    queryKey: ['tcy-staker', accountId, completeTcyStakingActionCount],
+    queryKey: getTcyStakerQueryKey(accountId),
     queryFn: async (): Promise<TcyStaker | null> => {
       if (!accountId) return null
 

--- a/src/state/slices/actionSlice/types.ts
+++ b/src/state/slices/actionSlice/types.ts
@@ -69,8 +69,14 @@ export enum GenericTransactionDisplayType {
   Approve = 'Approve',
 }
 
+export enum GenericTransactionQueryId {
+  RFOX = 'rFOX',
+  TCY = 'TCY',
+}
+
 type ActionGenericTransactionMetadata = {
   displayType: GenericTransactionDisplayType
+  queryId?: GenericTransactionQueryId
   message: string
   accountId: AccountId
   txHash: string


### PR DESCRIPTION
## Description

Currently our logic for cache invalidation after complete pending actions in the action center only works for rFox transactions. Example here of the logic dying in the background on a TCY transaction.

<img width="1265" height="1119" alt="image" src="https://github.com/user-attachments/assets/65ef20cd-5de3-4f97-9a66-c07b649a461e" />

This change adds the idea of a "queryId" to the generic transactions which represents what query data we want to invalidate. This prevent over invalidation or crashes caused by invalidating query keys that don't make sense for a given transaction.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10113 

## Risk

Low 

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that TCY staking and unstaking updates the balance
* Test that rFox staking and unstaking updates the balance
* Ensure no errors pop up in the console like the one in the description during a TCY or rFox stake

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/a0338d6e-8897-4b35-83f8-70dbe38a0a02

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved transaction processing by introducing targeted updates for staking and unstaking activities, resulting in more efficient data refreshes for RFOX and TCY assets.

* **Refactor**
  * Simplified how staking data is refreshed by removing unnecessary dependencies and streamlining query logic.

* **Chores**
  * Added new metadata fields to support more precise transaction tracking and updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->