### PR TITLE
fix: ensure we dont show network fees infinite loading on no input

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2827,8 +2827,6 @@
     },
     "stakeInput": {
       "amount": "Amount",
-      "networkFee": "Network Fee",
-      "networkFeeTooltip": "Network Fee",
       "stake": "Stake",
       "amountPlaceholder": "Enter amount"
     },

--- a/src/pages/TCY/components/Stake/StakeInput.tsx
+++ b/src/pages/TCY/components/Stake/StakeInput.tsx
@@ -18,6 +18,7 @@ import { ButtonWalletPredicate } from '@/components/ButtonWalletPredicate/Button
 import { TradeAssetInput } from '@/components/MultiHopTrade/components/TradeAssetInput'
 import { Row } from '@/components/Row/Row'
 import { RawText } from '@/components/Text'
+import { useWallet } from '@/hooks/useWallet/useWallet'
 import { toBaseUnit } from '@/lib/math'
 import { THOR_PRECISION } from '@/lib/utils/thorchain/constants'
 import { useIsChainHalted } from '@/lib/utils/thorchain/hooks/useIsChainHalted'
@@ -61,6 +62,10 @@ export const StakeInput: React.FC<TCYRouteProps & { activeAccountNumber: number 
 }) => {
   const translate = useTranslate()
   const navigate = useNavigate()
+  const {
+    state: { isConnected },
+  } = useWallet()
+
   const selectedStakingAsset = useAppSelector(state => selectAssetById(state, tcyAssetId))
   const { isChainHalted, isFetching: isChainHaltedFetching } = useIsChainHalted(thorchainChainId)
   const {
@@ -137,11 +142,6 @@ export const StakeInput: React.FC<TCYRouteProps & { activeAccountNumber: number 
     setFieldName(fieldName === 'fiatAmount' ? 'amountCryptoPrecision' : 'fiatAmount')
   }, [fieldName])
 
-  const tooltipBody = useCallback(
-    () => <RawText>{translate('TCY.stakeInput.networkFeeTooltip')}</RawText>,
-    [translate],
-  )
-
   const handleStake = useCallback(() => {
     navigate(TCYStakeRoute.Confirm)
   }, [navigate])
@@ -207,14 +207,16 @@ export const StakeInput: React.FC<TCYRouteProps & { activeAccountNumber: number 
         px={4}
         py={4}
       >
-        <Row px={2} fontSize='sm' Tooltipbody={tooltipBody}>
-          <Row.Label>{translate('TCY.stakeInput.networkFee')}</Row.Label>
-          <Row.Value>
-            <Skeleton isLoaded={!!estimatedFeesData}>
-              <Amount.Fiat value={estimatedFeesData?.txFeeFiat ?? 0} />
-            </Skeleton>
-          </Row.Value>
-        </Row>
+        {!bnOrZero(amountCryptoPrecision).isZero() && isConnected && (
+          <Row px={2} fontSize='sm'>
+            <Row.Label>{translate('trade.networkFee')}</Row.Label>
+            <Row.Value>
+              <Skeleton isLoaded={!!estimatedFeesData}>
+                <Amount.Fiat value={estimatedFeesData?.txFeeFiat ?? 0} />
+              </Skeleton>
+            </Row.Value>
+          </Row>
+        )}
         <ButtonWalletPredicate
           isValidWallet={true}
           colorScheme={isValid ? 'blue' : 'red'}

--- a/src/pages/TCY/components/Unstake/UnstakeInput.tsx
+++ b/src/pages/TCY/components/Unstake/UnstakeInput.tsx
@@ -31,6 +31,7 @@ import { ButtonWalletPredicate } from '@/components/ButtonWalletPredicate/Button
 import { TradeAssetInput } from '@/components/MultiHopTrade/components/TradeAssetInput'
 import { Row } from '@/components/Row/Row'
 import { RawText } from '@/components/Text'
+import { useWallet } from '@/hooks/useWallet/useWallet'
 import { bn } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit, toBaseUnit } from '@/lib/math'
 import { fromThorBaseUnit } from '@/lib/utils/thorchain'
@@ -74,6 +75,9 @@ export const UnstakeInput: React.FC<TCYRouteProps & { activeAccountNumber: numbe
 }) => {
   const translate = useTranslate()
   const navigate = useNavigate()
+  const {
+    state: { isConnected },
+  } = useWallet()
   const { isChainHalted, isFetching: isChainHaltedFetching } = useIsChainHalted(thorchainChainId)
   const selectedStakingAsset = useAppSelector(state => selectAssetById(state, tcyAssetId))
   const {
@@ -176,11 +180,6 @@ export const UnstakeInput: React.FC<TCYRouteProps & { activeAccountNumber: numbe
     setFieldName(fieldName === 'fiatAmount' ? 'amountCryptoPrecision' : 'fiatAmount')
   }, [fieldName])
 
-  const tooltipBody = useCallback(
-    () => <RawText>{translate('trade.networkFee')}</RawText>,
-    [translate],
-  )
-
   const handleUnstake = useCallback(() => {
     navigate(TCYUnstakeRoute.Confirm)
   }, [navigate])
@@ -259,14 +258,16 @@ export const UnstakeInput: React.FC<TCYRouteProps & { activeAccountNumber: numbe
         bg='background.surface.raised.base'
         borderBottomRadius='xl'
       >
-        <Row px={2} fontSize='sm' Tooltipbody={tooltipBody}>
-          <Row.Label>{translate('trade.networkFee')}</Row.Label>
-          <Row.Value>
-            <Skeleton isLoaded={!!estimatedFeesData}>
-              <Amount.Fiat value={estimatedFeesData?.txFeeFiat ?? 0} />
-            </Skeleton>
-          </Row.Value>
-        </Row>
+        {isConnected && (
+          <Row px={2} fontSize='sm'>
+            <Row.Label>{translate('trade.networkFee')}</Row.Label>
+            <Row.Value>
+              <Skeleton isLoaded={!!estimatedFeesData}>
+                <Amount.Fiat value={estimatedFeesData?.txFeeFiat ?? 0} />
+              </Skeleton>
+            </Row.Value>
+          </Row>
+        )}
         <ButtonWalletPredicate
           isValidWallet={true}
           colorScheme={isValid ? 'blue' : 'red'}


### PR DESCRIPTION
## Description

On the TCY page currently before you input any numbers into stake, it will show loading in the network fees forever which looks weird.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10101

## Risk

Low

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that TCY staking and unstaking shows network fees when you both have a wallet connected and have an input.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

:point_up: 

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

:point_up: 

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/ad5bd423-f776-4435-a405-1c1b8ce3f389


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The network fee row in staking and unstaking screens is now only shown when your wallet is connected and an amount is entered.

* **Style**
  * The tooltip for the network fee row has been removed for a cleaner interface.

* **Chores**
  * Updated translations to remove the unused network fee tooltip text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->