### PR TITLE
fix: adjust swapper height media query

### DIFF
--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInput.tsx
@@ -36,7 +36,7 @@ type SharedTradeInputProps = {
 const cardBorderRadius = { base: '0', md: '2xl' }
 const cardMinHeight = {
   base: 'calc(100vh - var(--mobile-nav-offset) - env(safe-area-inset-top) - var(--safe-area-inset-top))',
-  md: 'initial',
+  sm: 'initial',
 }
 const cardBgProp = { base: 'background.surface.base', md: 'background.surface.raised.accent' }
 
@@ -54,6 +54,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
   onSubmit,
   isStandalone,
 }) => {
+  const [isSmallerThanMd] = useMediaQuery(`(max-width: ${breakpoints.md})`, { ssr: false })
   const [isSmallerThanXl] = useMediaQuery(`(max-width: ${breakpoints.xl})`, { ssr: false })
   const inputWidth = useSharedWidth(tradeInputRef)
   const hasUserEnteredAmount = useAppSelector(selectHasUserEnteredAmount)
@@ -78,7 +79,7 @@ export const SharedTradeInput: React.FC<SharedTradeInputProps> = ({
               bg={cardBgProp}
               borderRadius={cardBorderRadius}
               minHeight={cardMinHeight}
-              height={!hasUserEnteredAmount && isSmallerThanXl ? cardMinHeight.base : 'initial'}
+              height={!hasUserEnteredAmount && isSmallerThanMd ? cardMinHeight.base : 'initial'}
             >
               <SharedTradeInputHeader
                 initialTab={tradeInputTab}


### PR DESCRIPTION
## Description

A swapper height media query was a bit too early, so the height was too big on tablet mainly, we need to reduce it to md so the height is higher only on mobile allowing for tokens list to be displayed while tabled has the normal design

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted by jibbles outside of any scopes

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Using the responsive on the swapper without any amount entered, check the width starting from 770, the swapper shouldn't be higher than expected

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="843" height="845" alt="image" src="https://github.com/user-attachments/assets/166d4cc5-9e86-4b84-8b77-38671227b492" />


vs 

<img width="842" height="858" alt="image" src="https://github.com/user-attachments/assets/24c03e70-b371-4b39-9555-761f5a8f1856" />
