### PR TITLE
fix: better mobile wallet login loaders

### DIFF
--- a/src/pages/ConnectWallet/MobileConnect.tsx
+++ b/src/pages/ConnectWallet/MobileConnect.tsx
@@ -91,6 +91,17 @@ export const MobileConnect = () => {
   }, [setDefaultRoute, onOpen])
 
   const query = useQuery<{ returnUrl: string }>()
+
+  useEffect(() => {
+    if (state.isLoadingLocalWallet) {
+      setIsWaitingForRedirection(true)
+    }
+
+    if (!state.isLoadingLocalWallet && !hasWallet) {
+      setIsWaitingForRedirection(false)
+    }
+  }, [state.isLoadingLocalWallet, hasWallet])
+
   useEffect(() => {
     // This handles reloading an asset's account page on Native/KeepKey. Without this, routing will break.
     // /:accountId/:assetId really is /:accountId/:chainId/:assetSubId e.g /accounts/eip155:1:0xmyPubKey/eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
@@ -110,8 +121,8 @@ export const MobileConnect = () => {
         })
       : query?.returnUrl
     if (hasWallet) {
-      setIsWaitingForRedirection(false)
       navigate(path ?? TradeRoutePaths.Input)
+      setIsWaitingForRedirection(false)
     }
   }, [navigate, hasWallet, query, state, dispatch, setIsWaitingForRedirection])
 
@@ -198,19 +209,23 @@ export const MobileConnect = () => {
         <BodyStack>
           <Stack textAlign='center' spacing={2}>
             <Heading>{translate('connectWalletPage.welcomeBack')}</Heading>
-            <BodyText>{translate('connectWalletPage.mobileSelectBody')}</BodyText>
+            {!isWaitingForRedirection && !state.isLoadingLocalWallet ? (
+              <BodyText>{translate('connectWalletPage.mobileSelectBody')}</BodyText>
+            ) : null}
           </Stack>
           <Stack>
-            {isWaitingForRedirection ? (
+            {isWaitingForRedirection || state.isLoadingLocalWallet ? (
               <Center py={6}>
                 <Spinner />
               </Center>
             ) : (
-              <MobileWalletList onIsWaitingForRedirection={handleIsWaitingForRedirection} />
+              <>
+                <MobileWalletList onIsWaitingForRedirection={handleIsWaitingForRedirection} />
+                <Button size='lg-multiline' variant='outline' onClick={handleToggleWallets}>
+                  {translate('connectWalletPage.createOrImport')}
+                </Button>
+              </>
             )}
-            <Button size='lg-multiline' variant='outline' onClick={handleToggleWallets}>
-              {translate('connectWalletPage.createOrImport')}
-            </Button>
             {error && (
               <Alert status='error'>
                 <AlertIcon />
@@ -233,6 +248,7 @@ export const MobileConnect = () => {
     wallets,
     isWaitingForRedirection,
     handleIsWaitingForRedirection,
+    state.isLoadingLocalWallet,
   ])
 
   return (

--- a/src/pages/ConnectWallet/components/WalletList.tsx
+++ b/src/pages/ConnectWallet/components/WalletList.tsx
@@ -69,6 +69,7 @@ export const MobileWalletList: React.FC<MobileWalletDialogProps> = ({
 
         const revoker: RevocableWallet | null = await (async () => {
           try {
+            onIsWaitingForRedirection?.(true)
             const walletRevoker = await getWallet(deviceId)
             return walletRevoker
           } catch {
@@ -77,6 +78,7 @@ export const MobileWalletList: React.FC<MobileWalletDialogProps> = ({
         })()
 
         if (!revoker) {
+          onIsWaitingForRedirection?.(false)
           setIsInitializingWallet(false)
           return
         }
@@ -112,7 +114,6 @@ export const MobileWalletList: React.FC<MobileWalletDialogProps> = ({
           localWallet.setLocalWallet({ type: KeyManager.Mobile, deviceId })
           localWallet.setLocalNativeWalletName(item?.label ?? 'label')
           revoker.revoke()
-          onIsWaitingForRedirection?.(true)
         } catch (e) {
           setError('walletProvider.shapeShift.load.error.pair')
         }
@@ -193,7 +194,7 @@ export const MobileWalletList: React.FC<MobileWalletDialogProps> = ({
     isInitializingWallet,
   ])
 
-  return isLoading ? (
+  return isLoading || state.isLoadingLocalWallet ? (
     <Center py={6}>
       <Spinner />
     </Center>


### PR DESCRIPTION
## Description

What I found so far: reconnecting works as expected if you disable strict mode, I couldn't end in a state where my wallet wasn't connected automatically, with strict mode is launch the `load` function from `ModalProvider` 2 times, the second one is cancelling the biometric which is disconnecting the wallet, the second one fail at getting the wallet because it has been previously disconnected by the first tick, without strict mode it's executed only one time, if the biometric is success, we're good to go!

What I fixed:
When the user is initially loading the local wallet (remembered previous wallet), there is a loader
When the user is cancelling the biometric from here, loader disappear and wallet list appears
When the user disconnect from a wallet, then select a new one, there is a loading until it's redirected
When the user disconnect from a wallet, then select a new one, then fail at biometric, loading disappear and the wallet list is shown

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9647

## Risk
High, it could block the loading states of wallets on mobile, which would be a real issue for our revenues/users
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
Be super nitpick on this one about testing:
- Monkey patch the strict mode, comment it from `src/index.ts`
- Use android or iOS, it works the same on both, but prefer to test both if you can
-- Prefer using `npx expo run:ios` and `npx expo run:android` to test native builds
- Select a wallet, enter biometric, the app works
- Close the app
- Open the app again, you should be automatically logged to your wallet, notice the sexy loading state while being redirected
- Disconnect from wallet
- Select your wallet, but cancel biometric, notice the loading state is not working here as you cancelled biometric
- Select your wallet, be successful at entering biometric, notice the loading state is shown if you have time to see it
- Close the app
- Open the app again, fail at biometric or cancel it, notice the loading state is not here and you can select a wallet
- Test a fresh app without a wallet in cache, to ensure new users can create wallet as usually

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

iOS
https://jam.dev/c/b021559f-3ce9-45f6-a689-f4acacdcbc10

Android
https://jam.dev/c/7f7bcefc-9e4d-4fac-9ac2-00e52d177133

Fresh app
<img width="342" height="679" alt="image" src="https://github.com/user-attachments/assets/9f96ea8b-d990-4382-9883-e692ab0e12f6" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved synchronization between loading, redirection, and wallet selection states for a smoother user experience.
  * The spinner and wallet list now update more accurately based on wallet loading and redirection status.
  * "Create or Import" button is now displayed only when appropriate, alongside the wallet list.

* **Bug Fixes**
  * Resolved inconsistencies in displaying the spinner and wallet list during wallet loading and redirection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->