### PR TITLE
fix: triple the number of prerendered items in the assets page

### DIFF
--- a/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
+++ b/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
@@ -86,8 +86,8 @@ export const MarketsTableVirtualized: React.FC<MarketsTableVirtualizedProps> = m
       count: Math.min(rows.length, 3000),
       getScrollElement: () => parentRef.current,
       estimateSize: () => ROW_HEIGHT,
-      // Render approximately 1vh (or more if on mobile) of items in advance to avoid blank page flickers when scrolling
-      overscan: 26,
+      // Render approximately 3vh (or more if on mobile) of items in advance to avoid blank page flickers when scrolling
+      overscan: 40,
     })
 
     // Only fetch market data for visible rows

--- a/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
+++ b/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
@@ -87,7 +87,7 @@ export const MarketsTableVirtualized: React.FC<MarketsTableVirtualizedProps> = m
       getScrollElement: () => parentRef.current,
       estimateSize: () => ROW_HEIGHT,
       // Render approximately 1vh (or more if on mobile) of items in advance to avoid blank page flickers when scrolling
-      overscan: 13,
+      overscan: 26,
     })
 
     // Only fetch market data for visible rows


### PR DESCRIPTION
## Description

Let's double the assets we prerender on the asset page, so if you scroll normally, you are never going to see assets icons loading

Note to the reviewers: If we will like the heuristic is too small, we can always prerender a lot more items, I'm quite sure maybe 100 rows can be easy to prerender for most phones, this could even improve it and never seeing any loading state

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10021

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Scroll like a human would do on the `/assets` page on mobile, you shouldn't see icons loading (except if you have an extremely slow connection, it could happen
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/fbc9fa39-8649-48da-b6fc-e744a7dff0be

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved scrolling performance in the markets table by increasing the number of pre-rendered rows for smoother navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->