### PR TITLE
fix: default to highest rune account on TCY page

### DIFF
--- a/src/pages/TCY/components/TCYHeader.tsx
+++ b/src/pages/TCY/components/TCYHeader.tsx
@@ -38,11 +38,11 @@ export const TCYHeader = ({ onAccountNumberChange }: TCYHeaderProps) => {
     selectAccountIdsByChainIdFilter(state, { chainId: thorchainChainId }),
   )
 
-  const [defaultAccountId, setDefaultAccountId] = useState<AccountId | undefined>(accountIds[0])
+  const [selectedAccountId, setSelectedAccountId] = useState<AccountId | undefined>(undefined)
 
   const handleChange = useCallback(
     (accountId: string) => {
-      setDefaultAccountId(accountId)
+      setSelectedAccountId(accountId)
       const accountNumber = selectAccountNumberByAccountId(store.getState(), { accountId })
       if (accountNumber === undefined) throw new Error('Account number not found')
       onAccountNumberChange(accountNumber)
@@ -57,16 +57,16 @@ export const TCYHeader = ({ onAccountNumberChange }: TCYHeaderProps) => {
       <Flex alignItems='center' gap={2}>
         <Text translation='common.activeAccount' fontWeight='medium' />
 
-        {defaultAccountId && <InlineCopyButton value={fromAccountId(defaultAccountId).account} />}
+        {selectedAccountId && <InlineCopyButton value={fromAccountId(selectedAccountId).account} />}
         <AccountDropdown
-          defaultAccountId={defaultAccountId}
+          autoSelectHighestBalance
           assetId={thorchainAssetId}
           onChange={handleChange}
           buttonProps={buttonProps}
         />
       </Flex>
     )
-  }, [accountIds, handleChange, defaultAccountId])
+  }, [accountIds, handleChange, selectedAccountId])
 
   return (
     <>


### PR DESCRIPTION
## Description

Default to the account with the highest rune on the TCY page rather than just the first account. 

The original ticket was to select the one with the highest stake balance. But doing that could be a bit unnecessarily expensive as we have to fetch the stake position for every account. I'm hoping selecting the account with the largest rune balance is a good enough heuristic that we can do without queries.

Not fully sure on this one though

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10158

## Risk

Low risk, just affects the account selection on TCY page which is already a bit dumb.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that when you land on the TCY page by default it selects your thorchain account with the most rune. 
* You'll need to have multiple thorchain accounts for this logic to do anything

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

:point_up: 

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

:point_up: 

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/13297c29-efc4-40b7-b487-2d8dfa50ee79
