### PR TITLE
feat: thorchain lp default to sym for TCY/RUJI

### DIFF
--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -18,7 +18,14 @@ import {
   usePrevious,
 } from '@chakra-ui/react'
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { fromAccountId, fromAssetId, thorchainAssetId, thorchainChainId } from '@shapeshiftoss/caip'
+import {
+  fromAccountId,
+  fromAssetId,
+  rujiAssetId,
+  tcyAssetId,
+  thorchainAssetId,
+  thorchainChainId,
+} from '@shapeshiftoss/caip'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import {
   assetIdToThorPoolAssetId,
@@ -251,6 +258,11 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
 
   const getDefaultOpportunityType = useCallback(
     (assetId: AssetId) => {
+      // https://gitlab.com/thorchain/thornode/-/issues/2214
+      if (assetId === tcyAssetId || assetId === rujiAssetId) {
+        return 'sym'
+      }
+
       const walletSupportsRune = walletSupportsChain({
         checkConnectedAccountIds: accountIdsByChainId[thorchainChainId] ?? [],
         chainId: thorchainChainId,


### PR DESCRIPTION
## Description

How many monkey patches do y'all like? Yes.

Pretty much the exact same monkey patch that disabled TCY/RUNE explicitly, brought over to the default opportunity logic.

https://github.com/shapeshift/web/blob/b5bfe2cbc2365301bc9b204911dfee2719712c8a/src/pages/ThorChainLP/components/LpType.tsx#L264-L270

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10044

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to TCY/RUJI pools without a position yet for these
- Ensure sym is the default option

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/1898809d-225b-432a-b561-2ac7ad036e4b


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new asset types when determining opportunity options in the Add Liquidity interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->