### PR TITLE
feat: enable butter same chain swaps

### DIFF
--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeQuote.ts
@@ -72,16 +72,6 @@ export const getTradeQuote = async (
     )
   }
 
-  // Disable same-chain swaps for ButterSwap
-  if (sellAsset.chainId === buyAsset.chainId) {
-    return Err(
-      makeSwapErrorRight({
-        message: `Same-chain swaps are not supported by ButterSwap`,
-        code: TradeQuoteError.UnsupportedTradePair,
-      }),
-    )
-  }
-
   if (!sendAddress) {
     return Err(
       makeSwapErrorRight({

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.test.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { GetTradeRateInput, SwapperDeps } from '../../../types'
 import { BTC, ETH, USDC_MAINNET, WETH } from '../../utils/test-data/assets'
 import ethBtcRoute from '../test-data/eth-btc.json'
+import { ROUTE_QUOTE } from '../test-data/routeQuote'
 import { butterService } from '../utils/butterSwapService'
 import { getTradeRate } from './getTradeRate'
 
@@ -17,7 +18,7 @@ vi.mock('../utils/butterSwapService', () => ({
 }))
 
 describe('getTradeRate', () => {
-  it('should not return a trade rate for same-chain swaps', async () => {
+  it('should return a trade rate', async () => {
     const deps: SwapperDeps = {
       assetsById: { [ETH.assetId]: ETH },
       assertGetChainAdapter: () => vi.fn() as any,
@@ -45,13 +46,15 @@ describe('getTradeRate', () => {
       supportsEIP1559: false, // TODO - upstream type bug? this is a literal false in the type def
     }
 
+    vi.mocked(butterService.get).mockResolvedValue(
+      Ok({ data: ROUTE_QUOTE } as unknown as AxiosResponse),
+    )
+
     const result = await getTradeRate(input, deps)
 
-    expect(result.isOk()).toBe(false)
-    expect(result.isErr()).toBe(true)
-
-    const error = result.unwrapErr()
-    expect(error.message).toContain('Same-chain swaps are not supported by ButterSwap')
+    expect(result.isOk()).toBe(true)
+    const tradeRate = result.unwrap()
+    expect(tradeRate[0].rate).toBe('2296.409699')
   })
 
   it('should return a correct trade rate and steps for a multi-hop ETH->BTC route', async () => {
@@ -86,6 +89,7 @@ describe('getTradeRate', () => {
     vi.mocked(butterService.get).mockResolvedValue(
       Ok({ data: ethBtcRoute } as unknown as AxiosResponse),
     )
+
     const result = await getTradeRate(input, deps)
 
     expect(result.isOk()).toBe(true)

--- a/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/ButterSwap/swapperApi/getTradeRate.ts
@@ -62,16 +62,6 @@ export const getTradeRate = async (
     )
   }
 
-  // Disable same-chain swaps for ButterSwap, as we cannot collect affiliate fees for them
-  if (sellAsset.chainId === buyAsset.chainId) {
-    return Err(
-      makeSwapErrorRight({
-        message: `Same-chain swaps are not supported by ButterSwap`,
-        code: TradeQuoteError.UnsupportedTradePair,
-      }),
-    )
-  }
-
   const amount = bn(sellAmountIncludingProtocolFeesCryptoBaseUnit)
     .shiftedBy(-sellAsset.precision)
     .toString()

--- a/packages/swapper/src/swappers/ButterSwap/xhr.ts
+++ b/packages/swapper/src/swappers/ButterSwap/xhr.ts
@@ -76,11 +76,16 @@ export const getButterRoute = async ({
     if (sellAssetIsNative) return zeroAddress
     return sellAssetAddressRaw
   })()
+
   const buyAssetAddress = (() => {
     if (buyAsset.chainId === solanaChainId && buyAssetIsNative) return SOLANA_NATIVE_ADDRESS
     if (buyAssetIsNative) return zeroAddress
     return buyAssetAddressRaw
   })()
+
+  const isSameChainSolanaSwap =
+    sellAsset.chainId === solanaChainId && buyAsset.chainId === solanaChainId
+
   const params = {
     fromChainId: butterFromChainId,
     tokenInAddress: sellAssetAddress,
@@ -91,6 +96,8 @@ export const getButterRoute = async ({
     slippage,
     entrance: 'shapeshift',
     affiliate,
+    // This is only required to collect affiliate fees for same-chain Solana swaps. For EVM swaps the default referrer address (EVM) of the affiliate code is used.
+    ...(isSameChainSolanaSwap && { referrer: 'TODO' }),
   }
   const result = await butterService.get<RouteResponse>('/route', { params })
   if (result.isErr()) return Err(result.unwrapErr())


### PR DESCRIPTION
## Description

Enables Butter same-chain swaps. We initially disabled this because they were not supported with affiliate fees.
This is has since been fixed.

⚠️ Leaving in draft until a Solana address is received from the DFC.

## Issue (if applicable)

N/A

## Risk

> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Butter swaps.

## Testing

Same-chain Butter swaps should be enabled.
Test both EVM and Solana same-chain swaps.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A