### PR TITLE
fix: rip out flakey quote loader debounce

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -13,7 +13,7 @@ import { dogeAssetId } from '@shapeshiftoss/caip'
 import { TradeQuoteError as SwapperTradeQuoteError } from '@shapeshiftoss/swapper'
 import { LayoutGroup, motion } from 'framer-motion'
 import type { InterpolationOptions } from 'node-polyglot'
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { FaDog } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 
@@ -36,6 +36,7 @@ import {
   selectEnabledSwappersIgnoringCrossAccountTrade,
   selectIsSwapperResponseAvailable,
   selectIsTradeQuoteRequestAborted,
+  selectIsTradeQuotesInitialised,
   selectSortedTradeQuotes,
   selectUserAvailableTradeQuotes,
   selectUserUnavailableTradeQuotes,
@@ -80,6 +81,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
   const isBatchTradeRateQueryLoading = useAppSelector(selectIsBatchTradeRateQueryLoading)
   const hasQuotes =
     availableTradeQuotesDisplayCache.length > 0 || unavailableTradeQuotesDisplayCache.length > 0
+  const isQuotesInitialized = useAppSelector(selectIsTradeQuotesInitialised)
 
   const bestQuotesByCategory = useMemo(
     () => getBestQuotesByCategory(availableTradeQuotesDisplayCache),
@@ -143,20 +145,6 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
     onBack,
   ])
 
-  const [showNoResult, setShowNoResults] = useState(false)
-
-  // This is dumb but there's a state where the quotes get cleared and rates request hasn't been kicked off yet (not loading)
-  // We don't want to flash the no results so we wait 500ms before showing it
-  useEffect(() => {
-    if (availableQuotes.length > 0 && showNoResult) {
-      setShowNoResults(false)
-    } else if (availableQuotes.length === 0 && !showNoResult) {
-      setTimeout(() => {
-        setShowNoResults(true)
-      }, 500)
-    }
-  }, [availableQuotes, showNoResult])
-
   const unavailableQuotes = useMemo(() => {
     if (isTradeQuoteRequestAborted) {
       return []
@@ -202,7 +190,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
         <Flex flexDirection='column' gap={2} flexGrow='1'>
           <LayoutGroup>{availableQuotes}</LayoutGroup>
 
-          {showNoResult && !isBatchTradeRateQueryLoading ? (
+          {availableQuotes.length === 0 && isQuotesInitialized && !isBatchTradeRateQueryLoading ? (
             <Flex height='100%' whiteSpace='normal' alignItems='center' justifyContent='center'>
               <Flex
                 maxWidth='300px'

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -35,6 +35,7 @@ export const initialTradeExecutionState = {
 }
 
 export const initialState: TradeQuoteSliceState = {
+  isQuotesInitialized: false,
   activeQuoteMeta: undefined,
   confirmedQuote: undefined,
   activeStep: undefined,

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -72,6 +72,11 @@ const selectTradeQuotes = createDeepEqualOutputSelector(
   tradeQuoteSlice => tradeQuoteSlice.tradeQuotes,
 )
 
+export const selectIsTradeQuotesInitialised = createSelector(
+  tradeQuoteSlice.selectSlice,
+  tradeQuoteSlice => tradeQuoteSlice.isQuotesInitialized,
+)
+
 export const selectEnabledSwappersIgnoringCrossAccountTrade = createSelector(
   preferences.selectors.selectFeatureFlags,
   featureFlags => {

--- a/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
+++ b/src/state/slices/tradeQuoteSlice/tradeQuoteSlice.ts
@@ -38,11 +38,13 @@ export const tradeQuoteSlice = createSlice({
         }>,
       ) => {
         const { swapperName, quotesById } = action.payload
+        state.isQuotesInitialized = true
         state.tradeQuotes[swapperName] = quotesById ?? {}
       },
     ),
     upsertTradeQuotes: create.reducer(
       (state, action: PayloadAction<Record<SwapperName, Record<string, ApiQuote>>>) => {
+        state.isQuotesInitialized = true
         Object.entries(action.payload).forEach(([swapperName, quotesById]) => {
           state.tradeQuotes[swapperName as SwapperName] = quotesById ?? {}
         })

--- a/src/state/slices/tradeQuoteSlice/types.ts
+++ b/src/state/slices/tradeQuoteSlice/types.ts
@@ -12,6 +12,7 @@ import type { ApiQuote } from '@/state/apis/swapper/types'
 export type ActiveQuoteMeta = { swapperName: SwapperName; identifier: string }
 
 export type TradeQuoteSliceState = {
+  isQuotesInitialized: Boolean
   activeStep: number | undefined // Make sure to actively check for undefined vs. falsy here. 0 is the first step, undefined means no active step yet
   activeQuoteMeta: ActiveQuoteMeta | undefined // the selected quote metadata used to find the active quote in the api responses
   confirmedQuote: TradeQuote | TradeRate | undefined // the quote being executed

--- a/src/test/mocks/store.ts
+++ b/src/test/mocks/store.ts
@@ -297,6 +297,7 @@ export const mockStore: ReduxState = {
     selectedSellAssetChainId: 'All',
   },
   tradeQuote: {
+    isQuotesInitialized: false,
     activeQuoteMeta: undefined,
     confirmedQuote: undefined,
     activeStep: undefined,


### PR DESCRIPTION
## Description

Swaps out flakey useEffect deounce show no results in the swapper for a deterministic state based approach. We mark the trade quote slice with a "quotes not initialised" flag when it's been cleared (or created) and has yet to receive a quote result. 

From a conceptual level. If we're cleared or just created the tradeQuoteSlice then the quotes have "not been initialized". Once we receive our first set of quotes or rates, then it's considered "initialized". 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10210 

## Risk

Medium risk, could not show the "no results" page when it should be shown if implemented incorrectly.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that trade quote loader shows when it should
* Test that the no quotes available doesn't flash before the loader appears
* Test that we correctly show no quotes available when there's no results

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

:point_up: 

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

:point_up: 

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/b4da204e-072e-4510-bd65-74581b52eb4f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of the "no quotes available" message to show only when appropriate, preventing premature or delayed appearance.

* **Chores**
  * Enhanced state management for trade quotes initialization to ensure accurate UI updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->