### PR TITLE
fix: don't show the no quote results when we have results

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -150,9 +150,11 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
   useEffect(() => {
     if (availableQuotes.length === 0) {
       setBlockShowNoResults(true)
-      setTimeout(() => {
+      const timeoutId = setTimeout(() => {
         setBlockShowNoResults(false)
       }, 500)
+
+      return () => clearTimeout(timeoutId)
     }
   }, [availableQuotes])
 

--- a/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/TradeQuotes/TradeQuotes.tsx
@@ -143,19 +143,18 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
     onBack,
   ])
 
-  const [showNoResult, setShowNoResults] = useState(false)
+  const [blockShowNoResult, setBlockShowNoResults] = useState(false)
 
   // This is dumb but there's a state where the quotes get cleared and rates request hasn't been kicked off yet (not loading)
   // We don't want to flash the no results so we wait 500ms before showing it
   useEffect(() => {
-    if (availableQuotes.length > 0 && showNoResult) {
-      setShowNoResults(false)
-    } else if (availableQuotes.length === 0 && !showNoResult) {
+    if (availableQuotes.length === 0) {
+      setBlockShowNoResults(true)
       setTimeout(() => {
-        setShowNoResults(true)
+        setBlockShowNoResults(false)
       }, 500)
     }
-  }, [availableQuotes, showNoResult])
+  }, [availableQuotes])
 
   const unavailableQuotes = useMemo(() => {
     if (isTradeQuoteRequestAborted) {
@@ -202,7 +201,7 @@ export const TradeQuotes: React.FC<TradeQuotesProps> = memo(({ onBack }) => {
         <Flex flexDirection='column' gap={2} flexGrow='1'>
           <LayoutGroup>{availableQuotes}</LayoutGroup>
 
-          {showNoResult && !isBatchTradeRateQueryLoading ? (
+          {!blockShowNoResult && availableQuotes.length === 0 && !isBatchTradeRateQueryLoading ? (
             <Flex height='100%' whiteSpace='normal' alignItems='center' justifyContent='center'>
               <Flex
                 maxWidth='300px'


### PR DESCRIPTION
## Description

Patch job fix for no results UI showing up on the quotes UI.

We rework the debounce logic so that instead of debouncinig the source of truth UI state for whether or not we show the no results. We instead just add a debounce blocker variable which is a bit more robust.

Context for the initial introduction of the logic here https://github.com/shapeshift/web/pull/10154/files#r2250142868

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10210 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that trade quote loader shows when it should
* Test that the no quotes available doesn't flash before the loader appears
* Test that we correctly show no quotes available when there's no results


<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

☝️

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

☝️

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/5341aee0-6fde-4165-8654-1df0a874f9d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display logic for the "no results" message in trade quotes, reducing unnecessary flashes during brief loading states. The message now appears only after a short delay when no quotes are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->