### PR TITLE
feat: add a long press mechanism to open asset contextual menu on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "retry-axios": "^2.6.0",
     "scroll-into-view-if-needed": "^3.0.10",
     "styled-components": "^6.0.7",
+    "use-long-press": "^3.3.0",
     "uuid": "^9.0.0",
     "vaul": "^1.1.2",
     "viem": "^2.10.9",

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -8,8 +8,6 @@ import { FaCreditCard, FaEllipsisH } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
 import { useNavigate } from 'react-router-dom'
 
-import { MoreActionsDrawer } from './MoreActionsDrawer'
-
 import { SwapIcon } from '@/components/Icons/SwapIcon'
 import { FiatRampAction } from '@/components/Modals/FiatRamps/FiatRampsCommon'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
@@ -65,11 +63,11 @@ export const AssetActions: React.FC<AssetActionProps> = ({
   const navigate = useNavigate()
 
   const [isValidChainId, setIsValidChainId] = useState(true)
-  const [isMoreActionsOpen, setIsMoreActionsOpen] = useState(false)
   const chainAdapterManager = getChainAdapterManager()
   const send = useModal('send')
   const receive = useModal('receive')
   const fiatRamps = useModal('fiatRamps')
+  const assetActionsDrawer = useModal('assetActionsDrawer')
   const translate = useTranslate()
   const mixpanel = getMixPanel()
   const {
@@ -114,12 +112,8 @@ export const AssetActions: React.FC<AssetActionProps> = ({
   }, [assetId, navigate])
 
   const handleMoreClick = useCallback(() => {
-    setIsMoreActionsOpen(true)
-  }, [])
-
-  const handleMoreClose = useCallback(() => {
-    setIsMoreActionsOpen(false)
-  }, [])
+    assetActionsDrawer.open({ assetId })
+  }, [assetActionsDrawer, assetId])
 
   if (isMobile) {
     return (
@@ -189,7 +183,6 @@ export const AssetActions: React.FC<AssetActionProps> = ({
             />
           </Flex>
         </Flex>
-        <MoreActionsDrawer assetId={assetId} isOpen={isMoreActionsOpen} onClose={handleMoreClose} />
       </>
     )
   }

--- a/src/components/AssetHeader/AssetActionsDrawer.tsx
+++ b/src/components/AssetHeader/AssetActionsDrawer.tsx
@@ -6,10 +6,12 @@ import { useCallback, useMemo } from 'react'
 import { TbExternalLink, TbFlag, TbStar, TbStarFilled } from 'react-icons/tb'
 import { useTranslate } from 'react-polyglot'
 
+import { Display } from '../Display'
 import { DialogHeader } from '../Modal/components/DialogHeader'
 
 import { Dialog } from '@/components/Modal/components/Dialog'
 import { DialogBody } from '@/components/Modal/components/DialogBody'
+import { useModal } from '@/hooks/useModal/useModal'
 import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
 import { selectAssetById } from '@/state/slices/selectors'
 import { useAppDispatch, useAppSelector } from '@/state/store'
@@ -19,19 +21,14 @@ const fullStarIcon = <TbStarFilled />
 const linkIcon = <TbExternalLink />
 const flagIcon = <TbFlag />
 
-type MoreActionsDrawerProps = {
+export type AssetActionsDrawerProps = {
   assetId: AssetId
-  isOpen: boolean
-  onClose: () => void
 }
 
-export const MoreActionsDrawer: React.FC<MoreActionsDrawerProps> = ({
-  assetId,
-  isOpen,
-  onClose,
-}) => {
+export const AssetActionsDrawer: React.FC<AssetActionsDrawerProps> = ({ assetId }) => {
   const translate = useTranslate()
   const dispatch = useAppDispatch()
+  const { close: onClose, isOpen } = useModal('assetActionsDrawer')
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
 
@@ -77,59 +74,64 @@ export const MoreActionsDrawer: React.FC<MoreActionsDrawerProps> = ({
   }, [asset])
 
   return (
-    <Dialog isOpen={isOpen} onClose={onClose} height='auto'>
-      <DialogHeader padding={0} /> {/* For grab handle */}
-      <DialogBody
-        py={4}
-        px={0}
-        pb='calc(env(safe-area-inset-bottom) + var(--safe-area-inset-bottom))'
-      >
-        <Stack spacing={0}>
-          <Button
-            variant='ghost'
-            px={6}
-            leftIcon={isWatchlistMarked ? fullStarIcon : starIcon}
-            onClick={handleWatchAsset}
-            justifyContent='flex-start'
-            height={14}
-            size='lg'
-            fontSize='md'
-          >
-            {isWatchlistMarked ? translate('watchlist.remove') : translate('watchlist.add')}
-          </Button>
-          {explorerHref !== undefined && (
-            <Link href={explorerHref} isExternal>
-              <Button
-                variant='ghost'
-                px={6}
-                height={14}
-                leftIcon={linkIcon}
-                onClick={onClose}
-                justifyContent='flex-start'
-                size='lg'
-                fontSize='md'
-              >
-                {translate('common.viewOnExplorer')}
-              </Button>
-            </Link>
-          )}
-          <Button
-            variant='ghost'
-            px={6}
-            height={14}
-            color='red.400'
-            leftIcon={flagIcon}
-            onClick={handleToggleSpam}
-            justifyContent='flex-start'
-            size='lg'
-            fontSize='md'
-          >
-            {isSpamMarked
-              ? translate('assets.spam.reportAsNotSpam')
-              : translate('assets.spam.reportAsSpam')}
-          </Button>
-        </Stack>
-      </DialogBody>
-    </Dialog>
+    <Display.Mobile>
+      <Dialog isOpen={isOpen} onClose={onClose} height='auto'>
+        <DialogHeader padding={0} /> {/* For grab handle */}
+        <DialogBody
+          py={4}
+          px={0}
+          pb='calc(env(safe-area-inset-bottom) + var(--safe-area-inset-bottom))'
+        >
+          <Stack spacing={0}>
+            <Button
+              variant='ghost'
+              px={6}
+              leftIcon={isWatchlistMarked ? fullStarIcon : starIcon}
+              onClick={handleWatchAsset}
+              justifyContent='flex-start'
+              width='full'
+              height={14}
+              size='lg'
+              fontSize='md'
+            >
+              {isWatchlistMarked ? translate('watchlist.remove') : translate('watchlist.add')}
+            </Button>
+            {explorerHref !== undefined && (
+              <Link href={explorerHref} isExternal>
+                <Button
+                  variant='ghost'
+                  px={6}
+                  height={14}
+                  width='full'
+                  leftIcon={linkIcon}
+                  onClick={onClose}
+                  justifyContent='flex-start'
+                  size='lg'
+                  fontSize='md'
+                >
+                  {translate('common.viewOnExplorer')}
+                </Button>
+              </Link>
+            )}
+            <Button
+              variant='ghost'
+              px={6}
+              width='full'
+              height={14}
+              color='red.400'
+              leftIcon={flagIcon}
+              onClick={handleToggleSpam}
+              justifyContent='flex-start'
+              size='lg'
+              fontSize='md'
+            >
+              {isSpamMarked
+                ? translate('assets.spam.reportAsNotSpam')
+                : translate('assets.spam.reportAsSpam')}
+            </Button>
+          </Stack>
+        </DialogBody>
+      </Dialog>
+    </Display.Mobile>
   )
 }

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -14,6 +14,7 @@ import { ReactTableNoPager } from '@/components/ReactTable/ReactTableNoPager'
 import { AssetCell } from '@/components/StakingVaults/Cells'
 import { Text } from '@/components/Text'
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll/useInfiniteScroll'
+import { useModal } from '@/hooks/useModal/useModal'
 import { SparkLine } from '@/pages/Buy/components/Sparkline'
 import { useFetchFiatAssetMarketData } from '@/state/apis/fiatRamps/hooks'
 import {
@@ -41,6 +42,7 @@ export const MarketsTable: React.FC<MarketsTableProps> = memo(({ rows, onRowClic
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
   const marketDataUserCurrencyById = useAppSelector(selectMarketDataUserCurrency)
   const isAnyMarketDataLoading = useAppSelector(selectIsAnyMarketDataApiQueryPending)
+  const assetActionsDrawer = useModal('assetActionsDrawer')
 
   const assetIds = useMemo(() => rows.map(row => row.assetId), [rows])
 
@@ -142,12 +144,20 @@ export const MarketsTable: React.FC<MarketsTableProps> = memo(({ rows, onRowClic
     ],
     [handleTradeClick, marketDataUserCurrencyById, translate],
   )
+  const handleRowLongPress = useCallback(
+    (row: Row<Asset>) => {
+      const { assetId } = row.original
+      assetActionsDrawer.open({ assetId })
+    },
+    [assetActionsDrawer],
+  )
   return (
     <Stack px={paddingX} pb={6}>
       <ReactTableNoPager
         columns={columns}
         data={data}
         onRowClick={onRowClick}
+        onRowLongPress={handleRowLongPress}
         displayHeaders={isLargerThanMd}
         variant='clickable'
         isLoading={isAnyMarketDataLoading}

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -36,6 +36,9 @@ const CustomDrawerOverlay = styled(Drawer.Overlay)`
   inset: 0;
   background-color: rgba(0, 0, 0, 0.8);
   z-index: var(--chakra-zIndices-overlay);
+
+  user-select: none;
+  -webkit-user-select: none;
 `
 
 const DialogWindow: React.FC<DialogProps> = ({

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -39,6 +39,7 @@ const CustomDrawerOverlay = styled(Drawer.Overlay)`
 
   user-select: none;
   -webkit-user-select: none;
+  -webkit-touch-callout: none;
 `
 
 const DialogWindow: React.FC<DialogProps> = ({

--- a/src/components/MultiHopTrade/components/TradeInput/components/HighlightedTokens.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/HighlightedTokens.tsx
@@ -21,6 +21,7 @@ import { ResultsEmpty } from '@/components/ResultsEmpty'
 import { SortOptionsKeys } from '@/components/SortDropdown/types'
 import { AssetCell } from '@/components/StakingVaults/Cells'
 import { Text } from '@/components/Text'
+import { useModal } from '@/hooks/useModal/useModal'
 import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from '@/lib/mixpanel/types'
 import { isSome } from '@/lib/utils'
@@ -42,6 +43,7 @@ export const HighlightedTokens = () => {
   const assetsById = useAppSelector(selectAssets)
   const [isCategoryDialogOpen, setIsCategoryDialogOpen] = useState(false)
   const [isFiltersDialogOpen, setIsFiltersDialogOpen] = useState(false)
+  const assetActionsDrawer = useModal('assetActionsDrawer')
 
   const { selectedCategory, selectedOrder, selectedSort, selectedChainId } = useAppSelector(
     preferences.selectors.selectHighlightedTokensFilters,
@@ -207,6 +209,14 @@ export const HighlightedTokens = () => {
     [dispatch, selectedCategory, selectedChainId, selectedOrder, selectedSort],
   )
 
+  const handleRowLongPress = useCallback(
+    (row: Row<Asset>) => {
+      const { assetId } = row.original
+      assetActionsDrawer.open({ assetId })
+    },
+    [assetActionsDrawer],
+  )
+
   const handleOpenCategoriesDialog = useCallback(() => {
     setIsCategoryDialogOpen(true)
   }, [])
@@ -275,6 +285,7 @@ export const HighlightedTokens = () => {
           columns={columns}
           data={filteredAssets ?? []}
           onRowClick={handleRowClick}
+          onRowLongPress={handleRowLongPress}
           displayHeaders={false}
           variant='clickable'
           loadMore={noop}
@@ -284,14 +295,15 @@ export const HighlightedTokens = () => {
       </Flex>
     )
   }, [
+    isCategoryQueryDataLoading,
+    isPortalsAssetsLoading,
+    selectedCategory,
+    isCategoryQueryDataError,
+    isPortalsAssetsError,
     filteredAssets,
     columns,
     handleRowClick,
-    isCategoryQueryDataLoading,
-    isCategoryQueryDataError,
-    isPortalsAssetsLoading,
-    isPortalsAssetsError,
-    selectedCategory,
+    handleRowLongPress,
   ])
 
   const title = useMemo(() => {

--- a/src/components/ReactTable/InfiniteTable.tsx
+++ b/src/components/ReactTable/InfiniteTable.tsx
@@ -19,6 +19,10 @@ import InfiniteScroll from 'react-infinite-scroll-component'
 import { useTranslate } from 'react-polyglot'
 import type { Column, Row, TableState } from 'react-table'
 import { useExpanded, useSortBy, useTable } from 'react-table'
+import { useLongPress } from 'use-long-press'
+
+import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
+import { pulseAndroid } from '@/utils/pulseAndroid'
 
 type ReactTableProps<T extends {}> = {
   columns: Column<T>[]
@@ -27,6 +31,7 @@ type ReactTableProps<T extends {}> = {
   rowDataTestKey?: keyof T
   rowDataTestPrefix?: string
   onRowClick?: (row: Row<T>) => void
+  onRowLongPress?: (row: Row<T>) => void
   initialState?: Partial<TableState<{}>>
   renderSubComponent?: (row: Row<T>) => ReactNode
   renderEmptyComponent?: () => ReactNode
@@ -64,6 +69,7 @@ export const InfiniteTable = <T extends {}>({
   rowDataTestKey,
   rowDataTestPrefix,
   onRowClick,
+  onRowLongPress,
   initialState,
   renderSubComponent,
   renderEmptyComponent,
@@ -76,6 +82,10 @@ export const InfiniteTable = <T extends {}>({
   const translate = useTranslate()
   const tableRef = useRef<HTMLTableElement | null>(null)
   const hoverColor = useColorModeValue('black', 'white')
+  const longPressHandlers = useLongPress((_, { context: row }) => {
+    pulseAndroid()
+    onRowLongPress?.(row as Row<T>)
+  }, defaultLongPressConfig)
   const tableColumns = useMemo(
     () =>
       isLoading
@@ -102,7 +112,9 @@ export const InfiniteTable = <T extends {}>({
       return (
         <Fragment key={row.id}>
           <Tr
+            {...longPressHandlers(row)}
             {...row.getRowProps()}
+            sx={longPressSx}
             key={row.id}
             tabIndex={row.index}
             // we need to pass an arg here, so we need an anonymous function wrapper
@@ -146,6 +158,7 @@ export const InfiniteTable = <T extends {}>({
   }, [
     rows,
     prepareRow,
+    longPressHandlers,
     rowDataTestKey,
     rowDataTestPrefix,
     onRowClick,

--- a/src/components/ReactTable/ReactTable.tsx
+++ b/src/components/ReactTable/ReactTable.tsx
@@ -18,8 +18,11 @@ import { Fragment, useCallback, useEffect, useMemo, useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { Cell, Column, ColumnInstance, Row, TableState } from 'react-table'
 import { useExpanded, usePagination, useSortBy, useTable } from 'react-table'
+import { useLongPress } from 'use-long-press'
 
 import { RawText } from '@/components/Text'
+import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
+import { pulseAndroid } from '@/utils/pulseAndroid'
 
 type ReactTableProps<T extends {}> = {
   columns: Column<T>[]
@@ -28,6 +31,7 @@ type ReactTableProps<T extends {}> = {
   rowDataTestKey?: keyof T
   rowDataTestPrefix?: string
   onRowClick?: (row: Row<T>) => void
+  onRowLongPress?: (row: Row<T>) => void
   initialState?: Partial<TableState<T>>
   renderSubComponent?: (row: Row<T>) => ReactNode
   renderEmptyComponent?: () => ReactNode
@@ -67,6 +71,7 @@ const RowWrap = <T extends {}>({
   rowDataTestKey,
   rowDataTestPrefix,
   onRowClick,
+  onRowLongPress,
   renderSubComponent,
   visibleColumns,
 }: {
@@ -74,12 +79,18 @@ const RowWrap = <T extends {}>({
   rowDataTestKey: string | number | symbol | undefined
   rowDataTestPrefix?: string
   onRowClick?: (row: Row<T>) => void
+  onRowLongPress?: (row: Row<T>) => void
   renderSubComponent?: (row: Row<T>) => React.ReactNode
   visibleColumns: ColumnInstance<T>[]
 }) => {
   const handleClick = useCallback(() => {
     onRowClick?.(row)
   }, [onRowClick, row])
+
+  const longPressHandlers = useLongPress((_, { context: row }) => {
+    pulseAndroid()
+    onRowLongPress?.(row as Row<T>)
+  }, defaultLongPressConfig)
 
   const rowProps = useMemo(() => row.getRowProps(), [row])
 
@@ -94,6 +105,8 @@ const RowWrap = <T extends {}>({
     <Fragment>
       <Tr
         {...rowProps}
+        {...longPressHandlers(row)}
+        sx={longPressSx}
         key={row.id}
         tabIndex={row.index}
         onClick={handleClick}
@@ -123,6 +136,7 @@ export const ReactTable = <T extends {}>({
   rowDataTestKey,
   rowDataTestPrefix,
   onRowClick,
+  onRowLongPress,
   initialState,
   renderSubComponent,
   renderEmptyComponent,
@@ -186,6 +200,7 @@ export const ReactTable = <T extends {}>({
           rowDataTestKey={rowDataTestKey}
           rowDataTestPrefix={rowDataTestPrefix}
           onRowClick={onRowClick}
+          onRowLongPress={onRowLongPress}
           renderSubComponent={renderSubComponent}
           visibleColumns={visibleColumns}
         />
@@ -197,6 +212,7 @@ export const ReactTable = <T extends {}>({
     rowDataTestKey,
     rowDataTestPrefix,
     onRowClick,
+    onRowLongPress,
     renderSubComponent,
     visibleColumns,
   ])

--- a/src/components/ReactTable/ReactTableNoPager.tsx
+++ b/src/components/ReactTable/ReactTableNoPager.tsx
@@ -17,6 +17,10 @@ import { Fragment, useMemo, useRef } from 'react'
 import { useTranslate } from 'react-polyglot'
 import type { Column, IdType, Row, TableState } from 'react-table'
 import { useExpanded, useSortBy, useTable } from 'react-table'
+import { useLongPress } from 'use-long-press'
+
+import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
+import { pulseAndroid } from '@/utils/pulseAndroid'
 
 type ReactTableProps<T extends {}> = {
   columns: Column<T>[]
@@ -25,6 +29,7 @@ type ReactTableProps<T extends {}> = {
   rowDataTestKey?: keyof T
   rowDataTestPrefix?: string
   onRowClick?: (row: Row<T>) => void
+  onRowLongPress?: (row: Row<T>) => void
   initialState?: Partial<TableState<{}>>
   renderSubComponent?: (row: Row<T>) => ReactNode
   renderEmptyComponent?: () => ReactNode
@@ -47,6 +52,7 @@ export const ReactTableNoPager = <T extends {}>({
   rowDataTestKey,
   rowDataTestPrefix,
   onRowClick,
+  onRowLongPress,
   initialState,
   renderSubComponent,
   renderEmptyComponent,
@@ -56,6 +62,7 @@ export const ReactTableNoPager = <T extends {}>({
   const translate = useTranslate()
   const tableRef = useRef<HTMLTableElement | null>(null)
   const hoverColor = useColorModeValue('black', 'white')
+
   const tableColumns = useMemo(
     () =>
       isLoading
@@ -66,6 +73,12 @@ export const ReactTableNoPager = <T extends {}>({
         : columns,
     [columns, isLoading],
   )
+
+  const longPressHandlers = useLongPress((_, { context: row }) => {
+    pulseAndroid()
+    onRowLongPress?.(row as Row<T>)
+  }, defaultLongPressConfig)
+
   const { getTableProps, getTableBodyProps, headerGroups, rows, prepareRow, visibleColumns } =
     useTable<T>(
       {
@@ -83,6 +96,8 @@ export const ReactTableNoPager = <T extends {}>({
         <Fragment key={row.id}>
           <Tr
             {...row.getRowProps()}
+            {...longPressHandlers(row)}
+            sx={longPressSx}
             key={row.id}
             tabIndex={row.index}
             // we need to pass an arg here, so we need an anonymous function wrapper
@@ -126,6 +141,7 @@ export const ReactTableNoPager = <T extends {}>({
   }, [
     rows,
     prepareRow,
+    longPressHandlers,
     rowDataTestKey,
     rowDataTestPrefix,
     onRowClick,

--- a/src/components/RelatedAssets/RelatedAssets.tsx
+++ b/src/components/RelatedAssets/RelatedAssets.tsx
@@ -7,6 +7,7 @@ import type { Column, Row } from 'react-table'
 import { ReactTable } from '@/components/ReactTable/ReactTable'
 import { AssetCell } from '@/components/StakingVaults/Cells'
 import { Text } from '@/components/Text'
+import { useModal } from '@/hooks/useModal/useModal'
 import { selectRelatedAssetIds } from '@/state/slices/related-assets-selectors'
 import { selectAssets } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -20,6 +21,7 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
   const relatedAssetIds = useAppSelector(state =>
     selectRelatedAssetIds(state, relatedAssetIdsFilter),
   )
+  const assetActionsDrawer = useModal('assetActionsDrawer')
   const assets = useAppSelector(selectAssets)
   const navigate = useNavigate()
 
@@ -49,6 +51,14 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
     [navigate],
   )
 
+  const handleRowLongPress = useCallback(
+    (row: Row<AssetId>) => {
+      const assetId = row.original
+      assetActionsDrawer.open({ assetId })
+    },
+    [assetActionsDrawer],
+  )
+
   if (!relatedAssetIds.length) return null
 
   return (
@@ -63,6 +73,7 @@ export const RelatedAssets: React.FC<RelatedAssetsProps> = ({ assetId }) => {
           columns={columns}
           data={relatedAssetIds}
           onRowClick={handleRowClick}
+          onRowLongPress={handleRowLongPress}
           variant='clickable'
         />
       </CardBody>

--- a/src/constants/longPress.ts
+++ b/src/constants/longPress.ts
@@ -1,0 +1,30 @@
+import { LongPressEventType } from 'use-long-press'
+
+export const defaultLongPressConfig = { detect: LongPressEventType.Touch, cancelOnMovement: 8 }
+
+// These styles primarily prevent things like mobile highlight behaviours to allow for long press
+const isIOS = typeof window !== 'undefined' && /iPad|iPhone|iPod/.test(window.navigator.userAgent)
+const isAndroid = typeof window !== 'undefined' && /Android/.test(window.navigator.userAgent)
+
+export const longPressSx = {
+  // Apply universally first in case media query doesn't work
+  ...(isIOS || isAndroid
+    ? {
+        userSelect: 'none',
+        WebkitUserSelect: 'none',
+        MozUserSelect: 'none',
+        msUserSelect: 'none',
+        WebkitTouchCallout: 'none',
+        WebkitTapHighlightColor: 'transparent',
+      }
+    : {}),
+
+  '@media (hover: none) and (pointer: coarse)': {
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
+    MozUserSelect: 'none',
+    msUserSelect: 'none',
+    WebkitTouchCallout: 'none',
+    WebkitTapHighlightColor: 'transparent',
+  },
+}

--- a/src/constants/longPress.ts
+++ b/src/constants/longPress.ts
@@ -2,23 +2,7 @@ import { LongPressEventType } from 'use-long-press'
 
 export const defaultLongPressConfig = { detect: LongPressEventType.Touch, cancelOnMovement: 8 }
 
-// These styles primarily prevent things like mobile highlight behaviours to allow for long press
-const isIOS = typeof window !== 'undefined' && /iPad|iPhone|iPod/.test(window.navigator.userAgent)
-const isAndroid = typeof window !== 'undefined' && /Android/.test(window.navigator.userAgent)
-
 export const longPressSx = {
-  // Apply universally first in case media query doesn't work
-  ...(isIOS || isAndroid
-    ? {
-        userSelect: 'none',
-        WebkitUserSelect: 'none',
-        MozUserSelect: 'none',
-        msUserSelect: 'none',
-        WebkitTouchCallout: 'none',
-        WebkitTapHighlightColor: 'transparent',
-      }
-    : {}),
-
   '@media (hover: none) and (pointer: coarse)': {
     userSelect: 'none',
     WebkitUserSelect: 'none',

--- a/src/context/ModalProvider/ModalContainer.tsx
+++ b/src/context/ModalProvider/ModalContainer.tsx
@@ -197,6 +197,14 @@ const MobileWalletDialogModal = makeSuspenseful(
   ),
 )
 
+const AssetActionsDrawer = makeSuspenseful(
+  lazy(() =>
+    import('@/components/AssetHeader/AssetActionsDrawer').then(({ AssetActionsDrawer }) => ({
+      default: AssetActionsDrawer,
+    })),
+  ),
+)
+
 export const MODALS: Modals = {
   receive: ReceiveModal,
   qrCode: QrCodeModal,
@@ -221,6 +229,7 @@ export const MODALS: Modals = {
   manageAccounts: ManageAccountsModal,
   rateChanged: RateChangedModal,
   mobileWalletDialog: MobileWalletDialogModal,
+  assetActionsDrawer: AssetActionsDrawer,
 } as const
 
 export const modalReducer = (state: ModalState, action: ModalActions<keyof Modals>): ModalState => {

--- a/src/context/ModalProvider/types.ts
+++ b/src/context/ModalProvider/types.ts
@@ -2,6 +2,7 @@ import type { FC } from 'react'
 
 import type { CLOSE_MODAL, OPEN_MODAL } from './constants'
 
+import type { AssetActionsDrawerProps } from '@/components/AssetHeader/AssetActionsDrawer'
 import type { BackupPassphraseModalProps } from '@/components/Layout/Header/NavBar/Native/BackupPassphraseModal/BackupPassphraseModal'
 import type { MobileWalletDialogProps } from '@/components/MobileWalletDialog/MobileWalletDialog'
 import type { AssetSearchModalProps } from '@/components/Modals/AssetSearch/AssetSearchModal'
@@ -39,6 +40,7 @@ export type Modals = {
   ledgerOpenApp: FC<LedgerOpenAppModalProps>
   rateChanged: FC<RateChangedModalProps>
   mobileWalletDialog: FC<MobileWalletDialogProps>
+  assetActionsDrawer: FC<AssetActionsDrawerProps>
 }
 
 export type ModalActions<T extends keyof Modals> = OpenModalType<T> | CloseModalType

--- a/src/pages/Assets/Assets.tsx
+++ b/src/pages/Assets/Assets.tsx
@@ -13,6 +13,7 @@ import { SEO } from '@/components/Layout/Seo'
 import { MarketsTableVirtualized } from '@/components/MarketTableVirtualized/MarketsTableVirtualized'
 import { GlobalFilter } from '@/components/StakingVaults/GlobalFilter'
 import { RawText } from '@/components/Text'
+import { useModal } from '@/hooks/useModal/useModal'
 import { selectAssetsNoSpam } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -22,6 +23,7 @@ export const Assets = () => {
   const navigate = useNavigate()
   const assetsNoSpam = useAppSelector(selectAssetsNoSpam)
   const isSearching = useMemo(() => searchQuery.length > 0, [searchQuery])
+  const assetActionsDrawer = useModal('assetActionsDrawer')
 
   const filterRowsBySearchTerm = useCallback((rows: Asset[], filterValue: any) => {
     if (!filterValue) return rows
@@ -47,6 +49,15 @@ export const Assets = () => {
     },
     [navigate],
   )
+
+  const handleRowLongPress = useCallback(
+    (row: Row<Asset>) => {
+      const { assetId } = row.original
+      assetActionsDrawer.open({ assetId })
+    },
+    [assetActionsDrawer],
+  )
+
   return (
     <Main display='flex' flexDir='column' minHeight='calc(100vh - 72px)' isSubPage>
       <SEO title={translate('navBar.assets')} />
@@ -63,7 +74,11 @@ export const Assets = () => {
           </Flex>
         </PageHeader>
       </Display.Mobile>
-      <MarketsTableVirtualized rows={rows} onRowClick={handleRowClick} />
+      <MarketsTableVirtualized
+        rows={rows}
+        onRowClick={handleRowClick}
+        onRowLongPress={handleRowLongPress}
+      />
     </Main>
   )
 }

--- a/src/pages/Dashboard/components/AccountList/AccountTable.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
@@ -43,6 +43,7 @@ export const AccountTable = memo(() => {
   const loading = useSelector(selectIsPortfolioLoading)
   const rowData = useSelector(selectPortfolioAccountRows)
   const receive = useModal('receive')
+  const assetActionsDrawer = useModal('assetActionsDrawer')
   const sortedRows = useMemo(() => {
     return rowData.sort((a, b) => Number(b.fiatAmount) - Number(a.fiatAmount))
   }, [rowData])
@@ -179,6 +180,14 @@ export const AccountTable = memo(() => {
     [navigate],
   )
 
+  const handleRowLongPress = useCallback(
+    (row: Row<AccountRowData>) => {
+      const { assetId } = row.original
+      assetActionsDrawer.open({ assetId })
+    },
+    [assetActionsDrawer],
+  )
+
   return loading ? (
     loadingRows
   ) : (
@@ -186,6 +195,7 @@ export const AccountTable = memo(() => {
       columns={columns}
       data={data}
       onRowClick={handleRowClick}
+      onRowLongPress={handleRowLongPress}
       displayHeaders={isLargerThanMd}
       variant='clickable'
       renderEmptyComponent={renderEmptyComponent}

--- a/src/utils/pulseAndroid.ts
+++ b/src/utils/pulseAndroid.ts
@@ -1,0 +1,5 @@
+export function pulseAndroid() {
+  if ('vibrate' in navigator) {
+    navigator.vibrate(50) // 50ms vibration
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12092,6 +12092,7 @@ __metadata:
     ts-prune: ^0.10.3
     tsx: ^4.19.3
     typescript: ^5.2.2
+    use-long-press: ^3.3.0
     uuid: ^9.0.0
     vaul: ^1.1.2
     viem: ^2.10.9
@@ -34698,6 +34699,15 @@ pvutils@latest:
     "@types/react":
       optional: true
   checksum: e1681ffcac542a7536adda84c022652417463eb85eac95243860cba3ae9198aa36a8b8b11eb5d85217979648ecb00fd0e2727789dd023ac00b0cc94e4f76a511
+  languageName: node
+  linkType: hard
+
+"use-long-press@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "use-long-press@npm:3.3.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: f0066c1a0348e67f6f8619a23be50533395350c530f82f02d25287d216972048132d026f465cad5442571447fe8b02738948dadcebbde01a5a070801f5af0656
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This adds little context menu that show up wherever we have an asset list that can be triggered on long press.

Trade Asset Search is not included

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

part of #10144

## Risk

Medium risk, selecting assets on mobile could behave strangely. Asset context menu could pop up when we don't want it to. Affects "my crypto", "watchlist", "related assets" on the asset detail page, "trending tokens" on mobile swapper and the asset list when you click "explore more assets" from the watchlist

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Noting again the areas affected are: "my crypto", "watchlist", "related assets" on the asset detail page,  "trending tokens" on mobile swapper  and the asset list when you click "explore more assets" from the watchlist


On mobile:
* Test that you can long press on any of the above asset list on a given asset and the context menu shows up.
* Context menu items should work as expected
* Scrolling the assets should feel normal and not trigger the menu when you don't expect it
* Clicking assets should behave as normal

On desktop: 
Everything should behave the same as prod on the above equivalent pages.

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)



https://github.com/user-attachments/assets/c5b4498f-1580-4667-83f3-4ecc2a4751bf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Long-press gesture on table rows across asset and account views to open a mobile asset actions drawer.
  * Mobile-only asset actions drawer offering watchlist toggle, spam reporting, and explorer link.

* **Enhancements**
  * Haptic feedback on long-press for supported devices.
  * Centralized modal control for the asset actions drawer.
  * Improved touch styling and disabled text selection on modal overlays.

* **Bug Fixes**
  * Safe handling when no asset ID is available during long-press.

* **Chores**
  * Added dependency for long-press support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->