### PR TITLE
fix: mobile home bottom and asset menu safe areas

### DIFF
--- a/src/components/AssetHeader/MoreActionsDrawer.tsx
+++ b/src/components/AssetHeader/MoreActionsDrawer.tsx
@@ -79,7 +79,11 @@ export const MoreActionsDrawer: React.FC<MoreActionsDrawerProps> = ({
   return (
     <Dialog isOpen={isOpen} onClose={onClose} height='auto'>
       <DialogHeader padding={0} /> {/* For grab handle */}
-      <DialogBody py={4} px={0}>
+      <DialogBody
+        py={4}
+        px={0}
+        pb='calc(env(safe-area-inset-bottom) + var(--safe-area-inset-bottom))'
+      >
         <Stack spacing={0}>
           <Button
             variant='ghost'

--- a/src/pages/ConnectWallet/MobileConnect.tsx
+++ b/src/pages/ConnectWallet/MobileConnect.tsx
@@ -303,7 +303,7 @@ export const MobileConnect = () => {
               <LanguageSelector size='sm' />
             </Stack>
             <SlideTransitionY key='content'>
-              <Stack px={6} spacing={6} position='relative' zIndex='4'>
+              <Stack px={6} spacing={6} position='relative' zIndex='4' pb={4}>
                 <AnimatePresence mode='wait' initial={false}>
                   <motion.div
                     layout


### PR DESCRIPTION
## Description

Fixes the home bottom spacing and the asset menu drawer bottom safe area, specially for android phones!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://discord.com/channels/554694662431178782/1334642494897655840/1402989917037924424

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Using an android with the 3 buttons enabled (npx expo run:android)
Verify that the home page has some spacing at the bottom, and the asset mark a spam menu isn't going under the 3 buttons
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="347" height="673" alt="image" src="https://github.com/user-attachments/assets/870f7428-2e6c-455b-bfe9-bd829471e8af" />
<img width="330" height="670" alt="image" src="https://github.com/user-attachments/assets/0392aa55-e03e-497b-87f3-14d45466e72c" />


vs previously:
<img width="328" height="227" alt="image" src="https://github.com/user-attachments/assets/337d5c6a-c140-45e7-848c-cba8435ebb7e" />
<img width="346" height="260" alt="image" src="https://github.com/user-attachments/assets/5ca570b8-2775-4062-a56b-b14c5b400f6a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved bottom padding to better accommodate device safe areas and enhance content visibility on devices with display cutouts or rounded corners.
  * Adjusted vertical spacing within wallet connection screens for a more consistent appearance on mobile devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->