### PR TITLE
feat: add filters to explore category pages

### DIFF
--- a/src/components/AssetListFiltersDialog/AssetListFiltersDialog.tsx
+++ b/src/components/AssetListFiltersDialog/AssetListFiltersDialog.tsx
@@ -4,8 +4,8 @@ import type { ChainId } from '@shapeshiftoss/caip'
 import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
-import { ChainOptionGroup } from './ChainOptionGroup'
-import { SortOptionGroup } from './SortOptionGroup'
+import { ChainOptionGroup } from '../MultiHopTrade/components/TradeInput/components/ChainOptionGroup'
+import { SortOptionGroup } from '../MultiHopTrade/components/TradeInput/components/SortOptionGroup'
 
 import { Dialog } from '@/components/Modal/components/Dialog'
 import { OrderDirection } from '@/components/OrderDropdown/types'
@@ -26,7 +26,7 @@ type HighlightedTokensFiltersDialogProps = {
   handleOrderChange: (order: OrderDirection) => void
   handleChainIdChange: (chainId: ChainId | 'all') => void
 }
-export const HighlightedTokensFiltersDialog = ({
+export const AssetListFiltersDialog = ({
   isOpen,
   onClose,
   selectedCategory,

--- a/src/components/AssetSearch/components/AssetList.tsx
+++ b/src/components/AssetSearch/components/AssetList.tsx
@@ -1,9 +1,10 @@
 import type { ListProps } from '@chakra-ui/react'
-import { Center, Flex, Skeleton } from '@chakra-ui/react'
+import { Center, Flex, Icon, Skeleton } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import { range } from 'lodash'
 import type { CSSProperties, FC } from 'react'
 import { useCallback, useEffect, useMemo, useRef } from 'react'
+import { FaRegCompass } from 'react-icons/fa6'
 import type { VerticalSize } from 'react-virtualized-auto-sizer'
 import AutoSizer from 'react-virtualized-auto-sizer'
 import type { ListChildComponentProps } from 'react-window'
@@ -106,7 +107,8 @@ export const AssetList: FC<AssetListProps> = ({
       }
       if (assets?.length === 0) {
         return (
-          <Center>
+          <Center flexDir='column' gap={2} mt={4}>
+            <Icon as={FaRegCompass} boxSize='24px' color='text.subtle' />
             <Text color='text.subtle' translation='common.noResultsFound' />
           </Center>
         )

--- a/src/components/MultiHopTrade/components/TradeInput/components/HighlightedTokens.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/HighlightedTokens.tsx
@@ -11,8 +11,8 @@ import { MdOutlineFilterAlt } from 'react-icons/md'
 import { RiExchangeFundsLine } from 'react-icons/ri'
 import type { Column, Row } from 'react-table'
 
+import { AssetListFiltersDialog } from '../../../../AssetListFiltersDialog/AssetListFiltersDialog'
 import { HighlightedTokensCategoryDialog } from './HighlightedTokensCategoryDialog'
-import { HighlightedTokensFiltersDialog } from './HighlightedTokensFiltersDialog'
 import { HighlightedTokensPriceCell } from './HighlightedTokensPriceCell'
 
 import type { OrderDirection } from '@/components/OrderDropdown/types'
@@ -329,7 +329,7 @@ export const HighlightedTokens = () => {
         handleCategoryChange={handleCategoryChange}
       />
 
-      <HighlightedTokensFiltersDialog
+      <AssetListFiltersDialog
         isOpen={isFiltersDialogOpen}
         onClose={handleCloseFiltersDialog}
         selectedCategory={selectedCategory}


### PR DESCRIPTION
## Description
Adding the same filters drawer we already have in the swapper, but for the category explore pages

Minus one thing that isn't possible from the ticket: infinite scroll, those categories most of the time are containing less assets than necessary, which means it would do nothing to try to load more anyway

Portals is different, we have more assets than expected, but sorting by volume is showing enough assets already and is probably filtering scams anyway, no need to overengineer the thing for now, to be decided in the future if we want to show more assets but for now I feel like it's a good quickwin to avoid this and reduce rate limiting while at it

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10110

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go on explore page
- Select any category (defi and others which are using coingecko under the hood)
- Try to use the filters, they should work as expected, like in the swapper
- Try to research while filtering, it should search in the current list

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/0e414522-bd21-4bbb-bddb-0aae4d8eb8c9
<img width="388" height="254" alt="image" src="https://github.com/user-attachments/assets/291282ae-5666-4a06-9107-46c2dda3508c" />
