### PR TITLE
feat: disable asym deposits on staged THOR LPs

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -166,7 +166,7 @@
     "disabled": "Disabled",
     "staged": "Staged",
     "poolHalted": "Pool Halted",
-    "disabledAsymStagedDeposits": "Pool Staged",
+    "poolStaged": "Pool Staged",
     "chainHalted": "Chain Halted",
     "poolDisabled": "Pool Disabled",
     "prices": "Prices",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -166,6 +166,7 @@
     "disabled": "Disabled",
     "staged": "Staged",
     "poolHalted": "Pool Halted",
+    "disabledAsymStagedDeposits": "Pool Staged",
     "chainHalted": "Chain Halted",
     "poolDisabled": "Pool Disabled",
     "prices": "Prices",

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1423,20 +1423,27 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     [actualRuneDepositAmountCryptoPrecision, hasEnoughRuneBalance],
   )
 
+  const isStagedAsymDeposit = useMemo(
+    () => pool?.status === 'staged' && opportunityType !== 'sym',
+    [opportunityType, pool?.status],
+  )
+
   const errorCopy = useMemo(() => {
     // Wallet not connected is *not* an error
     if (!isConnected) return
     // Order matters here. Since we're dealing with two assets potentially, we want to show the most relevant error message possible i.e
     // 1. chain halted
-    // 2. pool halted/disabled
-    // 3. Asset unsupported by wallet
-    // 4. smart contract deposits disabled
-    // 5. pool asset balance
-    // 6. pool asset fee balance, since gas would usually be more expensive on the pool asset fee side vs. RUNE side
-    // 7. RUNE balance
-    // 8. RUNE fee balance
+    // 2. cannot add single sided liquidity while a pool is staged
+    // 3. pool halted/disabled
+    // 4. Asset unsupported by wallet
+    // 5. smart contract deposits disabled
+    // 6. pool asset balance
+    // 7. pool asset fee balance, since gas would usually be more expensive on the pool asset fee side vs. RUNE side
+    // 8. RUNE balance
+    // 9. RUNE fee balance
     // Not enough *pool* asset, but possibly enough *fee* asset
     if (isChainHalted) return translate('common.chainHalted')
+    if (isStagedAsymDeposit) return translate('common.disabledAsymStagedDeposits')
     if (isTradingActive === false) return translate('common.poolHalted')
     if (!walletSupportsOpportunity) return translate('common.unsupportedNetwork')
     if (!isThorchainLpDepositFlagEnabled) return translate('common.poolDisabled')
@@ -1474,6 +1481,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     translate,
     walletSupportsOpportunity,
     isThorchainLpDepositEnabledForPool,
+    isStagedAsymDeposit,
   ])
 
   const confirmCopy = useMemo(() => {
@@ -1654,7 +1662,8 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
           size='lg'
           colorScheme={errorCopy ? 'red' : 'blue'}
           isDisabled={Boolean(
-            disabledSymDepositAfterRune ||
+            isStagedAsymDeposit ||
+              disabledSymDepositAfterRune ||
               isTradingActive === false ||
               isChainHalted ||
               !isThorchainLpDepositFlagEnabled ||

--- a/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
+++ b/src/pages/ThorChainLP/components/AddLiquidity/AddLiquidityInput.tsx
@@ -1443,7 +1443,7 @@ export const AddLiquidityInput: React.FC<AddLiquidityInputProps> = ({
     // 9. RUNE fee balance
     // Not enough *pool* asset, but possibly enough *fee* asset
     if (isChainHalted) return translate('common.chainHalted')
-    if (isStagedAsymDeposit) return translate('common.disabledAsymStagedDeposits')
+    if (isStagedAsymDeposit) return translate('common.poolStaged')
     if (isTradingActive === false) return translate('common.poolHalted')
     if (!walletSupportsOpportunity) return translate('common.unsupportedNetwork')
     if (!isThorchainLpDepositFlagEnabled) return translate('common.poolDisabled')


### PR DESCRIPTION
## Description

i.e avoids ending up with a failed Tx like the below:

https://viewblock.io/thorchain/tx/A6B6E799102F2C0C187FFAD3C4E1291BA95175827F326BCB261D4D339B2507AB

See https://gitlab.com/thorchain/thornode/-/blob/develop/x/thorchain/handler_add_liquidity.go#L394-396

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Pick a staged THOR pool 
- Try to deposit sym, notice we're happy 
- Try to deposit asym - notice you're unable to and get a "Pool Staged" error

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^


## Screenshots (if applicable)

<img width="301" height="98" alt="Screenshot 2025-08-11 at 18 02 52" src="https://github.com/user-attachments/assets/0c6a58f8-0d75-4f3e-bf0a-a58bdf671b6e" />
<img width="510" height="774" alt="Screenshot 2025-08-11 at 18 03 53" src="https://github.com/user-attachments/assets/f785e365-658e-451b-ad09-c727070252af" />
<img width="519" height="738" alt="Screenshot 2025-08-11 at 18 03 57" src="https://github.com/user-attachments/assets/97159c41-77a3-48ca-a03a-5c14cb678159" />
<img width="514" height="729" alt="Screenshot 2025-08-11 at 18 04 02" src="https://github.com/user-attachments/assets/85b01b31-4b10-4980-80ab-e683b41ceb75" />



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prevent asymmetric deposits when a pool is in a staged state: deposit action is disabled and a clear error message is shown.
  * Adds a new UI status label “Pool Staged” to improve clarity during staged pool periods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->