### PR TITLE
fix: dupe position in RUNE and asym rune

### DIFF
--- a/src/pages/ThorChainLP/components/LpType.tsx
+++ b/src/pages/ThorChainLP/components/LpType.tsx
@@ -222,7 +222,6 @@ export const LpType = ({
     }
 
     const runeBalances: PositionBalances = (() => {
-      if (hasSymPosition) return displayAmounts('sym')
       if (hasAsymRunePosition) return displayAmounts(AsymSide.Rune)
       return newPosition
     })()


### PR DESCRIPTION
## Description

Fixes asym position appearing as a dupe in asym RUNE card

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10254

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Have a sym position for a given pool 
- Go to add liquidity and select that pool 
- Ensure position doesn't appear twice

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop 


<img width="508" height="768" alt="Screenshot 2025-08-11 at 20 48 16" src="https://github.com/user-attachments/assets/4bc8dc0a-e000-41c5-aca9-52b06d299626" />



- this diff

<img width="488" height="760" alt="Screenshot 2025-08-11 at 20 53 54" src="https://github.com/user-attachments/assets/2a59e990-0ecb-4bc0-9ba5-fbf78b6d5fc9" />



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected Rune balance display: for users with a symmetric-only position (no asymmetric Rune), the interface now shows the updated “new position” state instead of symmetric amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->