### PR TITLE
feat: add long press to explore page and ios haptics

### DIFF
--- a/src/components/AssetSearch/components/AssetList.tsx
+++ b/src/components/AssetSearch/components/AssetList.tsx
@@ -20,6 +20,7 @@ import type { PortalsAssets } from '@/pages/Markets/hooks/usePortalsAssetsQuery'
 export type AssetData = {
   assets: Asset[]
   handleClick: (asset: Asset) => void
+  handleLongPress?: (asset: Asset) => void
   disableUnsupported?: boolean
   hideZeroBalanceAmounts?: boolean
   rowComponent?: FC<ListChildComponentProps<AssetData>>
@@ -37,6 +38,7 @@ const scrollbarStyle: CSSProperties = {
 export const AssetList: FC<AssetListProps> = ({
   assets,
   handleClick,
+  handleLongPress,
   disableUnsupported = false,
   hideZeroBalanceAmounts = true,
   rowComponent = AssetRow,
@@ -75,11 +77,19 @@ export const AssetList: FC<AssetListProps> = ({
     () => ({
       assets,
       handleClick,
+      handleLongPress,
       disableUnsupported,
       hideZeroBalanceAmounts,
       portalsAssets,
     }),
-    [assets, disableUnsupported, handleClick, hideZeroBalanceAmounts, portalsAssets],
+    [
+      assets,
+      disableUnsupported,
+      handleClick,
+      handleLongPress,
+      hideZeroBalanceAmounts,
+      portalsAssets,
+    ],
   )
 
   const renderContent = useCallback(

--- a/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
+++ b/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
@@ -18,10 +18,10 @@ import { VolumeCell } from './VolumeCell'
 
 import { Text } from '@/components/Text'
 import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
+import { vibrate } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
 import { isMobile as isMobileApp } from '@/lib/globals'
 import { useFetchFiatAssetMarketData } from '@/state/apis/fiatRamps/hooks'
 import { breakpoints } from '@/theme/theme'
-import { pulseAndroid } from '@/utils/pulseAndroid'
 
 const ROW_HEIGHT = 70
 
@@ -84,7 +84,7 @@ export const MarketsTableVirtualized: React.FC<MarketsTableVirtualizedProps> = m
     const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
 
     const longPressHandlers = useLongPress((_, { context: row }) => {
-      pulseAndroid()
+      vibrate('heavy')
       onRowLongPress?.(row as Row<Asset>)
     }, defaultLongPressConfig)
 

--- a/src/components/ReactTable/InfiniteTable.tsx
+++ b/src/components/ReactTable/InfiniteTable.tsx
@@ -22,7 +22,7 @@ import { useExpanded, useSortBy, useTable } from 'react-table'
 import { useLongPress } from 'use-long-press'
 
 import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
-import { pulseAndroid } from '@/utils/pulseAndroid'
+import { vibrate } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
 
 type ReactTableProps<T extends {}> = {
   columns: Column<T>[]
@@ -83,7 +83,7 @@ export const InfiniteTable = <T extends {}>({
   const tableRef = useRef<HTMLTableElement | null>(null)
   const hoverColor = useColorModeValue('black', 'white')
   const longPressHandlers = useLongPress((_, { context: row }) => {
-    pulseAndroid()
+    vibrate('heavy')
     onRowLongPress?.(row as Row<T>)
   }, defaultLongPressConfig)
   const tableColumns = useMemo(

--- a/src/components/ReactTable/ReactTable.tsx
+++ b/src/components/ReactTable/ReactTable.tsx
@@ -22,7 +22,7 @@ import { useLongPress } from 'use-long-press'
 
 import { RawText } from '@/components/Text'
 import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
-import { pulseAndroid } from '@/utils/pulseAndroid'
+import { vibrate } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
 
 type ReactTableProps<T extends {}> = {
   columns: Column<T>[]
@@ -88,7 +88,7 @@ const RowWrap = <T extends {}>({
   }, [onRowClick, row])
 
   const longPressHandlers = useLongPress((_, { context: row }) => {
-    pulseAndroid()
+    vibrate('heavy')
     onRowLongPress?.(row as Row<T>)
   }, defaultLongPressConfig)
 

--- a/src/components/ReactTable/ReactTableNoPager.tsx
+++ b/src/components/ReactTable/ReactTableNoPager.tsx
@@ -20,7 +20,7 @@ import { useExpanded, useSortBy, useTable } from 'react-table'
 import { useLongPress } from 'use-long-press'
 
 import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
-import { pulseAndroid } from '@/utils/pulseAndroid'
+import { vibrate } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
 
 type ReactTableProps<T extends {}> = {
   columns: Column<T>[]
@@ -75,7 +75,7 @@ export const ReactTableNoPager = <T extends {}>({
   )
 
   const longPressHandlers = useLongPress((_, { context: row }) => {
-    pulseAndroid()
+    vibrate('heavy')
     onRowLongPress?.(row as Row<T>)
   }, defaultLongPressConfig)
 

--- a/src/pages/Explore/components/AssetSearchRow.tsx
+++ b/src/pages/Explore/components/AssetSearchRow.tsx
@@ -6,10 +6,13 @@ import { memo, useCallback, useMemo } from 'react'
 import { RiArrowLeftDownLine, RiArrowRightUpLine } from 'react-icons/ri'
 import { useTranslate } from 'react-polyglot'
 import type { ListChildComponentProps } from 'react-window'
+import { useLongPress } from 'use-long-press'
 
 import { Amount } from '@/components/Amount/Amount'
 import { AssetIcon } from '@/components/AssetIcon'
 import type { AssetData } from '@/components/AssetSearch/components/AssetList'
+import { defaultLongPressConfig, longPressSx } from '@/constants/longPress'
+import { vibrate } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { middleEllipsis } from '@/lib/utils'
@@ -34,7 +37,7 @@ type AssetSearchRowProps = ListChildComponentProps<AssetData> &
 
 export const AssetSearchRow: FC<AssetSearchRowProps> = memo(
   ({
-    data: { handleClick, disableUnsupported, assets, portalsAssets },
+    data: { handleClick, handleLongPress, disableUnsupported, assets, portalsAssets },
     index,
     style,
     showNetworkIcon,
@@ -43,6 +46,11 @@ export const AssetSearchRow: FC<AssetSearchRowProps> = memo(
     const translate = useTranslate()
     const color = useColorModeValue('text.subtle', 'whiteAlpha.500')
     const textColor = useColorModeValue('black', 'white')
+    const longPressHandlers = useLongPress((_, { context: row }) => {
+      vibrate('heavy')
+      handleLongPress?.(row as Asset)
+    }, defaultLongPressConfig)
+
     const {
       state: { wallet },
     } = useWallet()
@@ -147,6 +155,8 @@ export const AssetSearchRow: FC<AssetSearchRowProps> = memo(
         style={style}
         _focus={focus}
         {...rest}
+        {...longPressHandlers(asset)}
+        sx={longPressSx}
       >
         <Flex gap={4} alignItems='center'>
           <AssetIcon

--- a/src/pages/Explore/components/CategoryCard.tsx
+++ b/src/pages/Explore/components/CategoryCard.tsx
@@ -11,6 +11,7 @@ import { AssetSearchRow } from './AssetSearchRow'
 import { OrderDirection } from '@/components/OrderDropdown/types'
 import { SortOptionsKeys } from '@/components/SortDropdown/types'
 import { Text } from '@/components/Text'
+import { useModal } from '@/hooks/useModal/useModal'
 import { isSome } from '@/lib/utils'
 import { MarketsCategories } from '@/pages/Markets/constants'
 import { CATEGORY_TO_QUERY_HOOK } from '@/pages/Markets/hooks/useCoingeckoData'
@@ -37,6 +38,7 @@ export const CategoryCard = ({
   const assetsById = useAppSelector(selectAssets)
   const assetTitleColor = useColorModeValue('black', 'white')
   const translate = useTranslate()
+  const assetActionsDrawer = useModal('assetActionsDrawer')
 
   const categoryHook =
     category === MarketsCategories.OneClickDefi
@@ -94,9 +96,12 @@ export const CategoryCard = ({
     return {
       assets: filteredAssets,
       handleClick: (asset: Asset) => navigate(`/assets/${asset.assetId}`),
+      handleLongPress: ({ assetId }: Asset) => {
+        assetActionsDrawer.open({ assetId })
+      },
       portalsAssets,
     }
-  }, [filteredAssets, portalsAssets, navigate])
+  }, [filteredAssets, portalsAssets, navigate, assetActionsDrawer])
 
   const handleSeeMoreClick = useCallback(() => {
     navigate(`/explore/category/${category}`)

--- a/src/utils/pulseAndroid.ts
+++ b/src/utils/pulseAndroid.ts
@@ -1,5 +1,0 @@
-export function pulseAndroid() {
-  if ('vibrate' in navigator) {
-    navigator.vibrate(50) // 50ms vibration
-  }
-}


### PR DESCRIPTION
## Description

Add long press asset menu to explore page and migrate android only vibrate to new fancy haptics (thanks @NeOMakinG)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10245 

## Risk

Low risk, might lose vibrate on long press, might do weird stuff to explore page.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that the explore page still looks and feels the same as production
* Test long pressing on asset rows in explore. Asset menu drawer should pop up
* Test that haptic feedback works on long press. Note that will only work on proper device builds, not expo go

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

:point_up: 

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

:point_up: 

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/user-attachments/assets/df42e5c0-a7c6-4a27-8de1-4b7f74a46037




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added optional long-press on asset rows (search & explore) for per-asset actions; normal tap behavior unchanged.
  - Long-press on assets in Category cards opens the asset actions drawer.

- Refactor
  - Standardized long-press haptic to a heavier vibration across tables and lists for consistent feedback.

- Chores
  - Removed a legacy vibration utility no longer used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->