### PR TITLE
feat: mobile features versions compatibility

### DIFF
--- a/src/context/WalletProvider/MobileWallet/mobileMessageHandlers.ts
+++ b/src/context/WalletProvider/MobileWallet/mobileMessageHandlers.ts
@@ -15,6 +15,7 @@ type Command =
   | 'getWalletCount'
   | 'reloadWebview'
   | 'requestStoreReview'
+  | 'getAppVersion'
 
 export type HapticLevel = 'light' | 'medium' | 'heavy' | 'soft' | 'rigid'
 
@@ -61,10 +62,18 @@ type Message =
   | {
       cmd: 'requestStoreReview'
     }
+  | {
+      cmd: 'getAppVersion'
+    }
 
 export type MessageFromMobileApp = {
   id: number
   result: unknown
+}
+
+export type MobileAppVersion = {
+  version: string
+  build: string
 }
 
 /**
@@ -220,4 +229,11 @@ export const mobileVibrate = (level: HapticLevel): Promise<void> => {
  */
 export const requestStoreReview = (): Promise<boolean> => {
   return postMessage<boolean>({ cmd: 'requestStoreReview' })
+}
+
+/**
+ * Get the app version from the mobile app.
+ */
+export const requestAppVersion = (): Promise<MobileAppVersion> => {
+  return postMessage<MobileAppVersion>({ cmd: 'getAppVersion' })
 }

--- a/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
@@ -17,6 +17,7 @@ import { useTranslate } from 'react-polyglot'
 import { isMobile } from '../../lib/globals'
 import { preferences } from '../../state/slices/preferencesSlice/preferencesSlice'
 import { fetchIsSmartContractAddressQuery } from '../useIsSmartContractAddress/useIsSmartContractAddress'
+import { MobileFeature, useMobileFeaturesCompatibility } from '../useMobileFeaturesCompatibility'
 import { useModal } from '../useModal/useModal'
 import { useNotificationToast } from '../useNotificationToast'
 import { useWallet } from '../useWallet/useWallet'
@@ -45,6 +46,7 @@ export const useSwapActionSubscriber = () => {
   const { isDrawerOpen, openActionCenter } = useActionCenterContext()
   const hasSeenRatingModal = useAppSelector(preferences.selectors.selectHasSeenRatingModal)
   const { open: openRatingModal } = useModal('rating')
+  const mobileFeaturesCompatibility = useMobileFeaturesCompatibility()
 
   const dispatch = useAppDispatch()
   const translate = useTranslate()
@@ -236,7 +238,10 @@ export const useSwapActionSubscriber = () => {
           position: isMobile && !hasSeenRatingModal ? 'top' : 'bottom-right',
         })
 
-        if (!hasSeenRatingModal) {
+        if (
+          !hasSeenRatingModal &&
+          mobileFeaturesCompatibility[MobileFeature.RatingModal].isCompatible
+        ) {
           openRatingModal({})
           handleHasSeenRatingModal()
         }
@@ -312,6 +317,7 @@ export const useSwapActionSubscriber = () => {
       hasSeenRatingModal,
       openRatingModal,
       handleHasSeenRatingModal,
+      mobileFeaturesCompatibility,
     ],
   )
 

--- a/src/hooks/useMobileFeaturesCompatibility.ts
+++ b/src/hooks/useMobileFeaturesCompatibility.ts
@@ -1,0 +1,46 @@
+import { useQuery } from '@tanstack/react-query'
+import { useMemo } from 'react'
+import semver from 'semver'
+
+import { requestAppVersion } from '../context/WalletProvider/MobileWallet/mobileMessageHandlers'
+import { isMobile } from '../lib/globals'
+
+export enum MobileFeature {
+  RatingModal = 'rating-modal',
+}
+
+export const minimumMobileFeatureMinimumVersions: Record<MobileFeature, string> = {
+  [MobileFeature.RatingModal]: '3.3.1',
+}
+
+type MobileFeatureInfo = {
+  version: string | undefined
+  isCompatible: boolean
+}
+
+type MobileFeaturesMap = Record<MobileFeature, MobileFeatureInfo>
+
+export const useMobileFeaturesCompatibility = (): MobileFeaturesMap => {
+  const { data: mobileAppVersion } = useQuery({
+    queryKey: ['mobile-features-versions'],
+    queryFn: requestAppVersion,
+  })
+
+  const features = useMemo((): MobileFeaturesMap => {
+    return Object.values(MobileFeature).reduce((acc, feature) => {
+      acc[feature] = {
+        version: mobileAppVersion?.version,
+        isCompatible:
+          !isMobile ||
+          Boolean(
+            mobileAppVersion?.version &&
+              semver.gte(mobileAppVersion.version, minimumMobileFeatureMinimumVersions[feature]),
+          ),
+      }
+
+      return acc
+    }, {} as MobileFeaturesMap)
+  }, [mobileAppVersion])
+
+  return features
+}


### PR DESCRIPTION
## Description

Adds a hook and message to verify the current version of the mobile app, allowing us to disable a feature until the user use the version published on the store compatible with the current version

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10277 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Best way is to monkey patch and check the value of the hook with expo go and :
```diff
diff --git a/src/hooks/useMobileFeaturesCompatibility.ts b/src/hooks/useMobileFeaturesCompatibility.ts
index 6e12f0990d..f821525a00 100644
--- a/src/hooks/useMobileFeaturesCompatibility.ts
+++ b/src/hooks/useMobileFeaturesCompatibility.ts
@@ -42,5 +42,7 @@ export const useMobileFeaturesCompatibility = (): MobileFeaturesMap => {
     }, {} as MobileFeaturesMap)
   }, [mobileAppVersion])
 
+  alert(JSON.stringify(features))
+
   return features
 }
```
- Or use expo go and see that the rating modal is working (you may need to monkey patch to remove the setting safe guard
- 
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
If the message handler isn't here yet: 
<img width="358" height="238" alt="image" src="https://github.com/user-attachments/assets/68fb002a-1350-4dad-a91e-c9de36ecdf9a" />

If the message is here and version is compatible: 
<img width="315" height="155" alt="image" src="https://github.com/user-attachments/assets/c239b9e6-887a-4aeb-9d0f-48c86a31ce38" />

If the version isn't compatible:
<img width="318" height="195" alt="image" src="https://github.com/user-attachments/assets/d1475a23-9eac-4c73-acad-f8f967a2bc19" />

