### PR TITLE
feat: complete swap action cards display approval Txs

### DIFF
--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -370,6 +370,7 @@ export type SwapperSpecificMetadata = {
   relayerExplorerTxLink: string | undefined
   relayerTxHash: string | undefined
   stepIndex: SupportedTradeQuoteStepIndex
+  quoteId: string
   streamingSwapMetadata: StreamingSwapMetadata | undefined
 }
 

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -213,7 +213,8 @@
     "streaming": "Streaming",
     "dca": "DCA",
     "boost": "Boost",
-    "viewOnExplorer": "View on explorer"
+    "viewOnExplorer": "View on explorer",
+    "approval": "Approval"
   },
   "consentBanner": {
     "body": "Our dApp uses anonymized click tracking to analyze performance and improve your experience. By using app.shapeshift.com, you agree to our tracking. Visit %{privateLink} if you don't want to be anonymously tracked. See our %{privacyPolicyLink} for more details.",

--- a/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
@@ -5,14 +5,53 @@ import { useTranslate } from 'react-polyglot'
 
 import { StreamingSwapDetails } from './StreamingSwapDetails'
 
+import { MiddleEllipsis } from '@/components/MiddleEllipsis/MiddleEllipsis'
+import { TxLabel } from '@/components/MultiHopTrade/components/TradeConfirm/TxLabel'
+import { Row } from '@/components/Row/Row'
+import type { SwapAction } from '@/state/slices/actionSlice/types'
+
 type SwapDetailsProps = {
   txLink?: string
   swap: Swap
+  action: SwapAction
 }
 
-export const SwapDetails: React.FC<SwapDetailsProps> = ({ txLink, swap }) => {
+export const SwapDetails: React.FC<SwapDetailsProps> = ({ txLink, action, swap }) => {
   const translate = useTranslate()
-  const { isStreaming } = swap
+  const { sellAsset, sellAccountId, isStreaming, swapperName, sellTxHash, buyTxHash } = swap
+  const { swapMetadata } = action
+
+  const txHash = buyTxHash || sellTxHash
+
+  // Early return if we have allowance approval txHash
+  if (swapMetadata?.allowanceApproval?.txHash) {
+    return (
+      <Stack gap={4}>
+        <Row fontSize='sm' alignItems='center'>
+          <Row.Label>{translate('common.approval')}</Row.Label>
+          <Row.Value>
+            <TxLabel
+              txHash={swapMetadata.allowanceApproval.txHash}
+              explorerBaseUrl={sellAsset.explorerTxLink}
+              accountId={sellAccountId}
+              stepSource={undefined} // no swapper base URL here, this is an allowance Tx
+              quoteSwapperName={swapperName}
+            />
+          </Row.Value>
+        </Row>
+        {txHash && (
+          <Row fontSize='sm' alignItems='center'>
+            <Row.Label>{translate('trade.hopTitle.swap', { swapperName })}</Row.Label>
+            <Row.Value>
+              <Link isExternal href={txLink} color='text.link'>
+                <MiddleEllipsis value={txHash} />
+              </Link>
+            </Row.Value>
+          </Row>
+        )}
+      </Stack>
+    )
+  }
 
   return (
     <Stack gap={4}>

--- a/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
@@ -150,7 +150,7 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
       description={description}
       icon={icon}
     >
-      <SwapDetails txLink={swap?.txLink} swap={swap} />
+      <SwapDetails txLink={swap?.txLink} swap={swap} action={action} />
     </ActionCard>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
@@ -117,6 +117,7 @@ export const useTradeButtonProps = ({
         relayerTxHash,
         relayTransactionMetadata: firstStep?.relayTransactionMetadata,
         stepIndex: currentHopIndex,
+        quoteId: activeQuote.id,
         streamingSwapMetadata: {
           maxSwapCount: firstStep.thorchainSpecific?.maxStreamingQuantity ?? 0,
           attemptedSwapCount: 0,

--- a/src/state/slices/actionSlice/types.ts
+++ b/src/state/slices/actionSlice/types.ts
@@ -2,6 +2,7 @@ import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { Asset, CowSwapQuoteId, OrderId } from '@shapeshiftoss/types'
 
 import type { LimitPriceByDirection } from '../limitOrderInputSlice/limitOrderInputSlice'
+import type { ApprovalExecutionMetadata } from '../tradeQuoteSlice/types'
 
 import type {
   LpConfirmedDepositQuote,
@@ -39,6 +40,7 @@ export enum ActionStatus {
 
 type ActionSwapMetadata = {
   swapId: string
+  allowanceApproval?: ApprovalExecutionMetadata | undefined
 }
 
 type ActionLimitOrderMetadata = {


### PR DESCRIPTION
## Description

First hop (pun intended) of moving logic over from `<ExpandedStepperSteps />` into swap action card. 

This brings approval Txs over to swapper action cards, paving the ground for having all trade execution Txs in swapper.

This does not yet:

- Do the "Execution Price" row thing just yet 
- Handle in-progress swap, e.g displaying pending approvals or Txs: as it currently stands, initiated swaps are not action cards, they only become so when the sell Tx is initiated. We will need to change this heuristic to make it work.
- Handle allowance resets nor permit2
- Handle displaying both the sell and buy Tx hashes/links if they differ, similar to swapper. Smol groundwork will be needed, as we currently only upsert a single txLink in `Swap`. 
  Ideally, and so as not to require a migration, we would follow the exact same pattern as here, where we leverage the trade quote execution state, allowing us to be backwards-compatible.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- tackles https://github.com/shapeshift/web/issues/10011

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/Medium, risk of broken swapper action cards, but we have explicit branching here so should be fairly safe!

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a swap that requires an approval
- Once swap is initiated (i.e toast/card exist for it), notice you see two rows (approval and Tx) in place of "View Transaction" previously
- Do a swap that does not require one
- Notice the card looks the same as before

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- No approval needed 

https://jam.dev/c/de45e429-b545-43ad-bfbe-ff35d0a12779

- Approval needed

https://jam.dev/c/c6584e9e-649a-4fc1-8479-1d6695614391


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
