### PR TITLE
fix: wrong permit2 allowance step after signing permit2

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -364,8 +364,11 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
       // Awaiting Permit2 contract allowance grant
       if (
         firstHopPermit2.isRequired &&
-        hopExecutionState === HopExecutionState.AwaitingAllowanceApproval
-      )
+        [
+          HopExecutionState.AwaitingAllowanceApproval,
+          HopExecutionState.AwaitingPermit2Eip712Sign,
+        ].includes(hopExecutionState)
+      ) {
         return (
           <>
             <Text translation='trade.permit2Allowance.title' />
@@ -376,6 +379,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
             </Tooltip>
           </>
         )
+      }
 
       // Good ol' allowances
       return (

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -50,7 +50,6 @@ import {
   selectActiveQuoteErrors,
   selectHopExecutionMetadata,
 } from '@/state/slices/tradeQuoteSlice/selectors'
-import { HopExecutionState } from '@/state/slices/tradeQuoteSlice/types'
 import { useAppSelector, useSelectorWithArgs } from '@/state/store'
 
 const erroredStepIndicator = <WarningIcon color='red.500' />
@@ -362,13 +361,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
   const firstHopAllowanceApprovalTitle = useMemo(() => {
     const content = (() => {
       // Awaiting Permit2 contract allowance grant
-      if (
-        firstHopPermit2.isRequired &&
-        [
-          HopExecutionState.AwaitingAllowanceApproval,
-          HopExecutionState.AwaitingPermit2Eip712Sign,
-        ].includes(hopExecutionState)
-      ) {
+      if (firstHopPermit2.isRequired) {
         return (
           <>
             <Text translation='trade.permit2Allowance.title' />


### PR DESCRIPTION
## Description

Currently in all envs, the only moment permit2 allowance copy will be displayed is when awaiting for permit2 allowance Tx signing.
All follow-up steps will revert back to the generic allowance copy.
This PR fixes things so that it's consistently using the correct copy.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10292

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low to none

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do a ZRX trade for which you require permit2 allowance (can use revoke.cash to revoke your permit2 allowance as-needed)
- Ensure the permit2 allowance copy is consistent across all steps and up to swap complete

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
