### PR TITLE
feat: complete swap action cards display approvals

### DIFF
--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -370,6 +370,7 @@ export type SwapperSpecificMetadata = {
   relayerExplorerTxLink: string | undefined
   relayerTxHash: string | undefined
   stepIndex: SupportedTradeQuoteStepIndex
+  quoteId: string
   streamingSwapMetadata: StreamingSwapMetadata | undefined
 }
 

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -214,7 +214,8 @@
     "dca": "DCA",
     "boost": "Boost",
     "viewOnExplorer": "View on explorer",
-    "approval": "Approval"
+    "approval": "Approval",
+    "permit2Approval": "Permit2 Approval"
   },
   "consentBanner": {
     "body": "Our dApp uses anonymized click tracking to analyze performance and improve your experience. By using app.shapeshift.com, you agree to our tracking. Visit %{privateLink} if you don't want to be anonymously tracked. See our %{privacyPolicyLink} for more details.",

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -213,7 +213,8 @@
     "streaming": "Streaming",
     "dca": "DCA",
     "boost": "Boost",
-    "viewOnExplorer": "View on explorer"
+    "viewOnExplorer": "View on explorer",
+    "approval": "Approval"
   },
   "consentBanner": {
     "body": "Our dApp uses anonymized click tracking to analyze performance and improve your experience. By using app.shapeshift.com, you agree to our tracking. Visit %{privateLink} if you don't want to be anonymously tracked. See our %{privacyPolicyLink} for more details.",

--- a/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
@@ -5,14 +5,53 @@ import { useTranslate } from 'react-polyglot'
 
 import { StreamingSwapDetails } from './StreamingSwapDetails'
 
+import { MiddleEllipsis } from '@/components/MiddleEllipsis/MiddleEllipsis'
+import { TxLabel } from '@/components/MultiHopTrade/components/TradeConfirm/TxLabel'
+import { Row } from '@/components/Row/Row'
+import type { SwapAction } from '@/state/slices/actionSlice/types'
+
 type SwapDetailsProps = {
   txLink?: string
   swap: Swap
+  action: SwapAction
 }
 
-export const SwapDetails: React.FC<SwapDetailsProps> = ({ txLink, swap }) => {
+export const SwapDetails: React.FC<SwapDetailsProps> = ({ txLink, action, swap }) => {
   const translate = useTranslate()
-  const { isStreaming } = swap
+  const { sellAsset, sellAccountId, isStreaming, swapperName, sellTxHash, buyTxHash } = swap
+  const { swapMetadata } = action
+
+  const txHash = buyTxHash || sellTxHash
+
+  // Early return if we have allowance approval txHash
+  if (swapMetadata?.allowanceApproval?.txHash) {
+    return (
+      <Stack gap={4}>
+        <Row fontSize='sm' alignItems='center'>
+          <Row.Label>{translate('common.approval')}</Row.Label>
+          <Row.Value>
+            <TxLabel
+              txHash={swapMetadata.allowanceApproval.txHash}
+              explorerBaseUrl={sellAsset.explorerTxLink}
+              accountId={sellAccountId}
+              stepSource={undefined} // no swapper base URL here, this is an allowance Tx
+              quoteSwapperName={swapperName}
+            />
+          </Row.Value>
+        </Row>
+        {txHash && (
+          <Row fontSize='sm' alignItems='center'>
+            <Row.Label>{translate('trade.hopTitle.swap', { swapperName })}</Row.Label>
+            <Row.Value>
+              <Link isExternal href={txLink} color='text.link'>
+                <MiddleEllipsis value={txHash} />
+              </Link>
+            </Row.Value>
+          </Row>
+        )}
+      </Stack>
+    )
+  }
 
   return (
     <Stack gap={4}>

--- a/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
@@ -23,7 +23,6 @@ export const SwapDetails: React.FC<SwapDetailsProps> = ({ txLink, action, swap }
 
   const txHash = buyTxHash || sellTxHash
 
-  // Early return if we have allowance approval txHash
   if (swapMetadata?.allowanceApproval?.txHash) {
     return (
       <Stack gap={4}>

--- a/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Details/SwapDetails.tsx
@@ -27,7 +27,11 @@ export const SwapDetails: React.FC<SwapDetailsProps> = ({ txLink, action, swap }
     return (
       <Stack gap={4}>
         <Row fontSize='sm' alignItems='center'>
-          <Row.Label>{translate('common.approval')}</Row.Label>
+          <Row.Label>
+            {translate(
+              swapMetadata?.isPermit2Required ? 'common.permit2Approval' : 'common.approval',
+            )}
+          </Row.Label>
           <Row.Value>
             <TxLabel
               txHash={swapMetadata.allowanceApproval.txHash}

--- a/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/SwapActionCard.tsx
@@ -150,7 +150,7 @@ export const SwapActionCard = ({ action, isCollapsable = false }: SwapActionCard
       description={description}
       icon={icon}
     >
-      <SwapDetails txLink={swap?.txLink} swap={swap} />
+      <SwapDetails txLink={swap?.txLink} swap={swap} action={action} />
     </ActionCard>
   )
 }

--- a/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/components/ExpandedStepperSteps.tsx
@@ -406,6 +406,7 @@ export const ExpandedStepperSteps = ({ activeTradeQuote }: ExpandedStepperStepsP
     tradeQuoteFirstHop,
     activeTradeQuote.swapperName,
     translate,
+    firstHopPermit2,
   ])
 
   const firstHopPermit2SignTitle = useMemo(() => {

--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeButtonProps.tsx
@@ -117,6 +117,7 @@ export const useTradeButtonProps = ({
         relayerTxHash,
         relayTransactionMetadata: firstStep?.relayTransactionMetadata,
         stepIndex: currentHopIndex,
+        quoteId: activeQuote.id,
         streamingSwapMetadata: {
           maxSwapCount: firstStep.thorchainSpecific?.maxStreamingQuantity ?? 0,
           attemptedSwapCount: 0,

--- a/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
@@ -201,8 +201,6 @@ export const useSwapActionSubscriber = () => {
         hopIndex: swap.metadata.stepIndex,
       })?.allowanceApproval
 
-      console.log({ firstHopAllowanceApproval })
-
       if (status === TxStatus.Confirmed) {
         vibrate('heavy')
         dispatch(

--- a/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
@@ -67,7 +67,7 @@ export const useSwapActionSubscriber = () => {
   const activeSwapId = useAppSelector(swapSlice.selectors.selectActiveSwapId)
   const previousSwapStatus = usePrevious(activeSwapId ? swapsById[activeSwapId]?.status : undefined)
   const previousIsDrawerOpen = usePrevious(isDrawerOpen)
-  const tradeQuotes = useAppSelector(tradeQuoteSlice.selectSlice)
+  const tradeQuoteState = useAppSelector(tradeQuoteSlice.selectSlice)
 
   useEffect(() => {
     if (isDrawerOpen && !previousIsDrawerOpen) {
@@ -83,10 +83,13 @@ export const useSwapActionSubscriber = () => {
 
     if (!activeSwap) return
 
-    const firstHopAllowanceApproval = selectHopExecutionMetadata(store.getState(), {
+    const hopExecutionMetadata = selectHopExecutionMetadata(store.getState(), {
       tradeId: activeSwap.metadata.quoteId,
       hopIndex: activeSwap.metadata.stepIndex,
-    })?.allowanceApproval
+    })
+
+    const firstHopAllowanceApproval = hopExecutionMetadata?.allowanceApproval
+    const isPermit2Required = hopExecutionMetadata?.permit2?.isRequired
 
     if (activeSwap.status !== SwapStatus.Pending) return
     if (previousSwapStatus === activeSwap.status) return
@@ -107,10 +110,11 @@ export const useSwapActionSubscriber = () => {
         swapMetadata: {
           swapId: activeSwap.id,
           allowanceApproval: firstHopAllowanceApproval,
+          isPermit2Required,
         },
       }),
     )
-  }, [dispatch, translate, activeSwapId, swapsById, previousSwapStatus, tradeQuotes])
+  }, [dispatch, translate, activeSwapId, swapsById, previousSwapStatus, tradeQuoteState])
 
   const swapStatusHandler = useCallback(
     async (swap: Swap, action: SwapAction) => {
@@ -196,10 +200,14 @@ export const useSwapActionSubscriber = () => {
           : undefined
       })()
 
-      const firstHopAllowanceApproval = selectHopExecutionMetadata(store.getState(), {
+      const hopExecutionMetadata = selectHopExecutionMetadata(store.getState(), {
         tradeId: swap.metadata.quoteId,
         hopIndex: swap.metadata.stepIndex,
-      })?.allowanceApproval
+      })
+
+      const firstHopAllowanceApproval = hopExecutionMetadata?.allowanceApproval
+      console.log({ firstHopAllowanceApproval })
+      const isPermit2Required = hopExecutionMetadata?.permit2?.isRequired
 
       if (status === TxStatus.Confirmed) {
         vibrate('heavy')
@@ -209,6 +217,7 @@ export const useSwapActionSubscriber = () => {
             swapMetadata: {
               swapId: swap.id,
               allowanceApproval: firstHopAllowanceApproval,
+              isPermit2Required,
             },
             status:
               swap.swapperName === SwapperName.ArbitrumBridge &&
@@ -330,6 +339,8 @@ export const useSwapActionSubscriber = () => {
         buyTxHash,
       }
     },
+    // we explicitly want to be reactive on the tradeQuote slice here
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       dispatch,
       toast,
@@ -338,6 +349,7 @@ export const useSwapActionSubscriber = () => {
       openRatingModal,
       handleHasSeenRatingModal,
       mobileFeaturesCompatibility,
+      tradeQuoteState,
     ],
   )
 

--- a/src/state/slices/actionSlice/types.ts
+++ b/src/state/slices/actionSlice/types.ts
@@ -2,6 +2,7 @@ import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { Asset, CowSwapQuoteId, OrderId } from '@shapeshiftoss/types'
 
 import type { LimitPriceByDirection } from '../limitOrderInputSlice/limitOrderInputSlice'
+import type { ApprovalExecutionMetadata } from '../tradeQuoteSlice/types'
 
 import type {
   LpConfirmedDepositQuote,
@@ -39,6 +40,7 @@ export enum ActionStatus {
 
 type ActionSwapMetadata = {
   swapId: string
+  allowanceApproval?: ApprovalExecutionMetadata | undefined
 }
 
 type ActionLimitOrderMetadata = {

--- a/src/state/slices/actionSlice/types.ts
+++ b/src/state/slices/actionSlice/types.ts
@@ -41,6 +41,7 @@ export enum ActionStatus {
 type ActionSwapMetadata = {
   swapId: string
   allowanceApproval?: ApprovalExecutionMetadata | undefined
+  isPermit2Required?: boolean
 }
 
 type ActionLimitOrderMetadata = {


### PR DESCRIPTION
## Description

Stacked on top of https://github.com/shapeshift/web/pull/10291, doing the exact same, except for Permit2 specifically we now use "Permit2 Approval" copy instead of the regular "Approval"

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- tackles https://github.com/shapeshift/web/issues/10011

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Make a ZRX trade for which Permit2 approval is required 
- Ensure that after the trade is initiated and the action is visible in the action center, you see "Permit2 Approval" instead of "Approval" in the approval row

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Regular Approval

- Permit2 Approval


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
