### PR TITLE
fix: explore page asset lists wrong padding and height

### DIFF
--- a/src/components/AssetSearch/components/AssetList.tsx
+++ b/src/components/AssetSearch/components/AssetList.tsx
@@ -21,6 +21,7 @@ export type AssetData = {
   rowComponent?: FC<{ asset: Asset; index: number; data: AssetData }>
   isLoading?: boolean
   portalsAssets?: PortalsAssets
+  height?: string
 }
 
 type AssetListProps = AssetData & ListProps
@@ -32,11 +33,6 @@ const scrollbarStyle: CSSProperties = {
 
 const INCREASE_VIEWPORT_BY = { top: 100, bottom: 100 } as const
 
-const virtuosoStyle = {
-  height: '50vh',
-  ...scrollbarStyle,
-}
-
 export const AssetList: FC<AssetListProps> = ({
   assets,
   handleClick,
@@ -46,7 +42,16 @@ export const AssetList: FC<AssetListProps> = ({
   rowComponent = AssetRow,
   isLoading = false,
   portalsAssets,
+  height = '50vh',
 }) => {
+  const virtuosoStyle = useMemo(
+    () => ({
+      height,
+      ...scrollbarStyle,
+    }),
+    [height],
+  )
+
   const itemData = useMemo(
     () => ({
       assets,

--- a/src/components/AssetSearch/components/AssetRow.tsx
+++ b/src/components/AssetSearch/components/AssetRow.tsx
@@ -54,9 +54,6 @@ export const AssetRow: FC<{ asset: Asset; index: number; data: AssetData }> = me
         isDisabled={!isSupported && disableUnsupported}
         _focus={focus}
         width='100%'
-        height='auto'
-        minHeight='60px'
-        padding={4}
       >
         <Flex gap={4} alignItems='center' flex={1} minWidth={0}>
           <AssetIcon

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -200,6 +200,7 @@ export const Explore = memo(() => {
               handleClick={handleAssetClick}
               disableUnsupported={false}
               rowComponent={AssetSearchRow}
+              height='100vh'
             />
           )}
         </Box>

--- a/src/pages/Explore/ExploreCategory.tsx
+++ b/src/pages/Explore/ExploreCategory.tsx
@@ -273,6 +273,7 @@ export const ExploreCategory = () => {
               isCategoryQueryDataLoading ||
               isCategoryQueryDataFetching
             }
+            height='100vh'
           />
         </Box>
       </Main>

--- a/src/pages/Explore/components/CategoryCard.tsx
+++ b/src/pages/Explore/components/CategoryCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Skeleton, Text as CText, useColorModeValue } from '@chakra-ui/react'
+import { Box, Button, Text as CText, Flex, Skeleton, useColorModeValue } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import range from 'lodash/range'
 import { memo, useCallback, useMemo } from 'react'
@@ -179,7 +179,7 @@ export const CategoryCard = memo(
               asset={asset}
               data={assetSearchRowData}
               index={index}
-              py={8}
+              py={2}
               // We are not virtualizing so we don't use this prop but reuse the component for simplicity/reusability
               style={emptyStyle}
               color={assetTitleColor}

--- a/src/pages/Explore/components/CategoryCard.tsx
+++ b/src/pages/Explore/components/CategoryCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Text as CText, Flex, Skeleton, useColorModeValue } from '@chakra-ui/react'
+import { Box, Button, Flex, Skeleton, Text as CText, useColorModeValue } from '@chakra-ui/react'
 import type { Asset } from '@shapeshiftoss/types'
 import range from 'lodash/range'
 import { memo, useCallback, useMemo } from 'react'


### PR DESCRIPTION
## Description

Explore page page was buggy:
- Wrong padding on the assets on the categories page
- Wrong height on the asset list of search/category page

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted outside of any tickets

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="315" height="666" alt="image" src="https://github.com/user-attachments/assets/423f89ca-b90c-4112-8a25-3c4c68b6cfbc" />
<img width="323" height="656" alt="image" src="https://github.com/user-attachments/assets/d9cd35d5-6e4f-48b7-9801-7bda59b3a96a" />

vs prod
<img width="303" height="638" alt="image" src="https://github.com/user-attachments/assets/f87066bb-6dbb-4115-a4b4-6e63dbd0f8af" />
<img width="320" height="652" alt="image" src="https://github.com/user-attachments/assets/7fd79b55-4338-4ce2-ae4c-33ee37b312f1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  - Asset lists now support adjustable height, enabling full-viewport lists for smoother browsing.
  - Explore search and category views use full-height lists for improved scrolling and visibility.

* Style
  - Reduced vertical padding in category cards for denser layouts.
  - Asset row buttons now rely on standard sizing for more consistent appearance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->