### PR TITLE
fix: tcy stake inconsistency

### DIFF
--- a/src/hooks/useLocalStorage/useLocalStorage.test.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.test.ts
@@ -1,25 +1,101 @@
 import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useLocalStorage } from './useLocalStorage'
 
-afterEach(() => {
-  const { result } = renderHook(() => useLocalStorage<Record<string, string>>('testString', null))
-  const [, setLocalValue] = result.current
-  act(() => setLocalValue(null))
+// Mock localStorage
+const mockLocalStorage = (() => {
+  let store: Record<string, string> = {}
+
+  return {
+    getItem: vi.fn((key: string) => store[key] || null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key]
+    }),
+    clear: vi.fn(() => {
+      store = {}
+    }),
+  }
+})()
+
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
 })
 
-describe('useLocalStorage hook', () => {
-  it('should be null if not set', () => {
-    expect(localStorage.getItem('testString')).toBe(null)
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    mockLocalStorage.clear()
+    vi.clearAllMocks()
   })
 
-  it('should store string values', () => {
-    const { result } = renderHook(() => useLocalStorage<Record<string, string>>('testString', null))
-    const [, setLocalValue] = result.current
-    act(() => setLocalValue({ testValue: 'This is a test' }))
-    expect(JSON.parse(localStorage.getItem('testString') || '{}')).toStrictEqual({
-      testValue: 'This is a test',
+  it('should return initial value when localStorage is empty', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default-value'))
+
+    expect(result.current[0]).toBe('default-value')
+    expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key')
+  })
+
+  it('should return stored value from localStorage when available', () => {
+    mockLocalStorage.setItem('test-key', JSON.stringify('stored-value'))
+
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default-value'))
+
+    expect(result.current[0]).toBe('stored-value')
+    expect(mockLocalStorage.getItem).toHaveBeenCalledWith('test-key')
+  })
+
+  it('should update both state and localStorage when setValue is called', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'initial-value'))
+
+    act(() => {
+      result.current[1]('new-value')
     })
+
+    expect(result.current[0]).toBe('new-value')
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('test-key', JSON.stringify('new-value'))
+  })
+
+  it('should handle function updates correctly', () => {
+    const { result } = renderHook(() => useLocalStorage('counter', 0))
+
+    act(() => {
+      result.current[1]((prev: number) => prev + 1)
+    })
+
+    expect(result.current[0]).toBe(1)
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('counter', JSON.stringify(1))
+
+    act(() => {
+      result.current[1]((prev: number) => prev * 2)
+    })
+
+    expect(result.current[0]).toBe(2)
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('counter', JSON.stringify(2))
+  })
+
+  it('should handle complex objects and arrays', () => {
+    const testObject = { name: 'John', age: 30, hobbies: ['reading', 'coding'] }
+
+    const { result } = renderHook(() => useLocalStorage('user-data', testObject))
+
+    const updatedObject = { ...testObject, age: 31 }
+
+    act(() => {
+      result.current[1](updatedObject)
+    })
+
+    expect(result.current[0]).toEqual(updatedObject)
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+      'user-data',
+      JSON.stringify(updatedObject),
+    )
+
+    // Test that it can read the complex object back
+    const { result: result2 } = renderHook(() => useLocalStorage('user-data', {}))
+
+    expect(result2.current[0]).toEqual(updatedObject)
   })
 })

--- a/src/hooks/useLocalStorage/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage/useLocalStorage.ts
@@ -1,42 +1,53 @@
-import type { Dispatch } from 'react'
-import { useCallback, useEffect, useState } from 'react'
+import { useState } from 'react'
+
+type SetValueArg<T> = T | ((val: T) => T)
 
 export function useLocalStorage<T>(
   key: string,
-  initialValue: T | null,
-): [T | null, Dispatch<T | null>] {
-  const [value, setValue] = useState<T | null>(initialValue)
-  const [stringValue, setStringValue] = useState<string>('')
+  initialValue: T,
+): [T, (val: SetValueArg<T>) => void] {
+  // State to store our value
+  // Pass initial state function to useState so logic is only executed once
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue
+    }
 
-  const setItem = (newValue: T | null) => {
-    const json = JSON.stringify(newValue)
-    setStringValue(json)
-    setValue(newValue)
-    window.localStorage.setItem(key, json)
+    try {
+      const item = window.localStorage.getItem(key)
+      if (item === null) {
+        return initialValue
+      }
+
+      // Attempt to parse, but if it fails, return the raw string
+      try {
+        return JSON.parse(item)
+      } catch {
+        return item as unknown as T
+      }
+    } catch (error) {
+      console.warn(`Error reading localStorage key "${key}":`, error)
+      return initialValue
+    }
+  })
+
+  // Return a wrapped version of useState's setter function that ...
+  // ... persists the new value to localStorage.
+  const setValue = (value: SetValueArg<T>): void => {
+    try {
+      // Allow value to be a function so we have same API as useState
+      const valueToStore = value instanceof Function ? value(storedValue) : value
+      // Save state
+      setStoredValue(valueToStore)
+      // Save to local storage
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore))
+      }
+    } catch (error) {
+      // A more advanced implementation would handle the error case
+      console.log(error)
+    }
   }
 
-  useEffect(() => {
-    const existingValue = window.localStorage.getItem(key)
-    if (stringValue !== existingValue) {
-      setStringValue(existingValue || '')
-      setValue(existingValue ? JSON.parse(existingValue) : null)
-    }
-  }, [key, stringValue])
-
-  const handleStorage = useCallback(
-    (event: StorageEvent) => {
-      if (event.key === key && event.newValue !== stringValue) {
-        setStringValue(event.newValue || '')
-        setValue(event.newValue ? JSON.parse(event.newValue) : null)
-      }
-    },
-    [key, stringValue],
-  )
-
-  useEffect(() => {
-    window.addEventListener('storage', handleStorage)
-    return () => window.removeEventListener('storage', handleStorage)
-  }, [handleStorage])
-
-  return [value, setItem]
+  return [storedValue, setValue]
 }

--- a/src/pages/TCY/tcy.tsx
+++ b/src/pages/TCY/tcy.tsx
@@ -86,17 +86,20 @@ export const TCY = () => {
   const { data: currentStaker } = useTcyStaker(currentAccountId)
 
   // Only fetch default account to compare if use selects something
-  const compareTargetAccountId =
-    userSelectedAccountNumber !== undefined ? defaultTcyAccountId : undefined
-  const { data: defaultStaker } = useTcyStaker(compareTargetAccountId)
+  const { data: defaultStaker } = useTcyStaker(defaultTcyAccountId)
 
   useEffect(() => {
-    if (!currentAccountId || !currentStaker || !userSelectedAccountNumber) return
+    if (!currentAccountId || !currentStaker || !walletInfo) return
 
     const currentAmount = bnOrZero(fromBaseUnit(currentStaker.amount ?? '0', THOR_PRECISION))
-    const defaultAmount = bnOrZero(fromBaseUnit(defaultStaker?.amount ?? '0', THOR_PRECISION))
+    const defaultAmount = defaultStaker
+      ? bnOrZero(fromBaseUnit(defaultStaker.amount ?? '0', THOR_PRECISION))
+      : undefined
 
-    if (currentAmount.gt(defaultAmount) && walletInfo !== null) {
+    if (
+      defaultTcyAccountId === undefined ||
+      (defaultAmount !== undefined && currentAmount.gt(defaultAmount))
+    ) {
       setWalletIdToDefaultTcyAccountId({
         ...walletIdToDefaultTcyAccountId,
         [walletInfo.deviceId]: currentAccountId,
@@ -106,6 +109,7 @@ export const TCY = () => {
     currentAccountId,
     currentStaker,
     defaultStaker,
+    defaultTcyAccountId,
     dispatch,
     setWalletIdToDefaultTcyAccountId,
     userSelectedAccountNumber,


### PR DESCRIPTION
## Description

Improve useLocalStorage hook robustness and improve reliability of tcy stake selector.

I'm not 100% clear on what caused the bug found. But i've basically just changed the logic to be more robust and straight forward and just generally less tricky dicky.

I also noticed that the implementation for `useLocalStorage` was problematic so i've swapped it out for a hook that i've used in production code for a long time that works well. The issue with the old one I spotted was that it's pattern was to set the initial empty state first, then follow up with a useEffect to sync it up with local storage. What this means is that things using the local storage hook will render initially with an empty object, assuming that's coming from local storage.

No risk here of swapping that out as useLocalStorage isn't used by anything except this

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Same as original TCY stake selector change
* Test that once the tcy stake page has seen the account with the highest balance, it should default to that account on TCY page load

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/d925d682-c35e-4e07-a481-b032cce3dcff


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - More reliable default TCY account selection and amount calculation, reducing incorrect or missing defaults.
- Refactor
  - Improved local data persistence for faster initial load and better handling of complex/malformed data.
  - Updates persist instantly; cross‑tab auto‑sync removed for stability (refresh other tabs to see changes).
- Tests
  - Expanded test coverage for local storage behavior, including functional updates and complex objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->