### PR TITLE
fix: don't show the name on supported asset avatar

### DIFF
--- a/src/components/Modals/Receive/SupportedNetworks.tsx
+++ b/src/components/Modals/Receive/SupportedNetworks.tsx
@@ -73,7 +73,7 @@ export const SupportedNetworks = ({
           {visibleChains.map((chain, index) => {
             return (
               <Box key={chain.chainId} ml={index === 0 ? 0 : -1.5} zIndex={index}>
-                <LazyLoadAvatar boxSize={5} src={chain.icon} title={chain.name} />
+                <LazyLoadAvatar boxSize={5} src={chain.icon} />
               </Box>
             )
           })}


### PR DESCRIPTION
## Description

This stops the little name label showing up on hover on supported assets. We don't need it as we already have a tooltip.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

No risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Test that supported asset icons on the receive modal still looks good. Hovering doesn't show the name of each icon but shows the tooltip for all supported networks

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/bed28630-8794-407b-b16e-f74251bf1f47
