### PR TITLE
fix: wallet nav buttons hitbox

### DIFF
--- a/src/pages/Dashboard/components/DashboardTab.tsx
+++ b/src/pages/Dashboard/components/DashboardTab.tsx
@@ -5,7 +5,9 @@ import { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 import { matchPath, useLocation, useNavigate } from 'react-router-dom'
 
-const tabPaddingY = { base: 4, md: 6 }
+const tabPaddingBottom = { base: 4, md: 6 }
+const tabPaddingTop = { base: 4, md: 0 }
+const tabMarginTop = { base: 0, md: 6 }
 
 type DashboardTabProps = {
   label: string
@@ -45,7 +47,9 @@ export const DashboardTab = forwardRef<DashboardTabProps, 'button'>(
         variant='tab'
         ref={ref}
         flexShrink={0}
-        py={tabPaddingY}
+        pt={tabPaddingTop}
+        pb={tabPaddingBottom}
+        mt={tabMarginTop}
         onClick={handleClick}
         isActive={isActive}
         borderBottomWidth={4}


### PR DESCRIPTION
## Description

Noticed the nav items in wallet page are clickable for a few pxs on top of 'em - fixed by moving from py to explicit top/bottom and use margin instead of padding

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted whilst in the house

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure wallet page nav buttons are *not* clickable on top of their text 
- Ensure app layout in wallet page is exactly the same as develop

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- Layout (left: this diff)

<img width="1728" height="989" alt="image" src="https://github.com/user-attachments/assets/97b8d26c-7e6c-450f-a80b-03b82393f07d" />
<img width="1294" height="914" alt="image" src="https://github.com/user-attachments/assets/33fb5028-45c1-4be4-92e0-ef0bacb6ff4e" />

- develop

<img width="386" height="185" alt="Screenshot 2025-09-04 at 15 36 32" src="https://github.com/user-attachments/assets/7c0af822-e519-4b55-86ed-fc81434bfa3d" />

https://jam.dev/c/96fada70-3217-4db9-8aa6-9c91d826babe

- this diff

<img width="354" height="160" alt="Screenshot 2025-09-04 at 15 47 21" src="https://github.com/user-attachments/assets/00d4b392-36aa-4ade-a93a-1dcc768f7271" />

https://jam.dev/c/29f06a7f-ca47-42e7-81b8-b2e89b16be77

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Style
  * Updated Dashboard tab button spacing for better responsiveness and readability. On small screens, tabs keep balanced top/bottom padding; on medium and larger screens, top padding is reduced, bottom padding increased, and a top margin is added. This improves visual alignment, separation from surrounding content, and click targets without altering navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->