### PR TITLE
fix: evm -> RUNE THOR Txs execution price/Tx introspection

### DIFF
--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -192,7 +192,11 @@ export const selectTxIdsByFilter = createCachedSelector(
       : maybeFilteredByMemo
 
     const maybeFilteredByTxHash = txHash
-      ? maybeFilteredByOriginMemo.filter(txId => txs[txId].txid.startsWith(txHash))
+      ? maybeFilteredByOriginMemo.filter(
+          txId =>
+            txs[txId].txid.toLowerCase().startsWith(txHash.toLowerCase()) ||
+            txs[txId].txid.toLowerCase().startsWith(txHash.toLowerCase().replace(/^0x/, '')),
+        )
       : maybeFilteredByOriginMemo
 
     const maybeUniqueIdsByStatus = txStatusFilter


### PR DESCRIPTION
## Description

https://github.com/shapeshift/web/pull/10427 brought improvements re: RUNE out Txs introspection meaning execution price would now display for *more* RUNE out Txs then before in notification center, however, this doesn't work with EVM -> RUNE Txs 

For any other chain -> RUNE, the in Txid *is* the out Txid, however, for EVM -> RUNE, the out Tx is *almost* the same but has the `0x` prefix stripped, rugging current lookup logic.

Fixed twofolds by: 

- Doing a lookup both with and without 0x prefix (ensuring consumers don't have to manually deal with that) 
- Ensuring we lowercase both the param txHash and the predicate txHash when looking up (i.e for EVM Txs, tx hash we use for `txId` lookup may or may not be checksummed or lowercased, but the OUT: Tx we're after actually is all uppercase)

Note: This doesn't yet fix RUNE -> non-fee, native asset i.e RUJI/TCY

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- contributes to https://github.com/shapeshift/web/pull/10427

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Do an EVM -> RUNE swap and confirm you see execution price
- Do any other chain -> RUNE swap and confirm you see execution price

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

- this diff


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
