### PR TITLE
fix: handle thor.ruji denom and fix action center OUT: Txs parsing

### DIFF
--- a/packages/unchained-client/src/cosmossdk/parser/utils.ts
+++ b/packages/unchained-client/src/cosmossdk/parser/utils.ts
@@ -17,6 +17,7 @@ const assetIdByDenom = new Map<string, AssetId>([
   ['rune', thorchainAssetId],
   ['tcy', tcyAssetId],
   ['x/ruji', rujiAssetId],
+  ['thor.ruji', rujiAssetId],
   ['maya', mayaTokenAssetId],
   ['thor.tcy', tcyAssetId],
   ['cacao', mayachainAssetId],

--- a/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
@@ -1,5 +1,5 @@
 import { usePrevious } from '@chakra-ui/react'
-import { baseChainId, ethChainId, fromAccountId } from '@shapeshiftoss/caip'
+import { baseChainId, ethChainId, fromAccountId, thorchainChainId } from '@shapeshiftoss/caip'
 import type { Swap } from '@shapeshiftoss/swapper'
 import {
   fetchSafeTransactionInfo,
@@ -256,6 +256,10 @@ export const useSwapActionSubscriber = () => {
         const maybeTx = selectTxByFilter(store.getState(), {
           accountId: buyAccountId,
           txHash: buyTxHash,
+          // For THOR chain buys (i.e RUNE, RUJI, TCY and other potential non-fee native AssetIds we add in the future)
+          // we accountId and txHash won't be enough of a discriminator to narrow to one Tx, since both the inbound and outbound Tx will share the same tx Hash *and* the same AccountId
+          // So we use the OUT: memo discriminator to ensure we select the outbound Tx, not the inbound
+          memo: swap?.buyAsset?.chainId === thorchainChainId ? 'OUT:' : undefined,
         })
         return maybeTx
       })()

--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -192,11 +192,11 @@ export const selectTxIdsByFilter = createCachedSelector(
       : maybeFilteredByMemo
 
     const maybeFilteredByTxHash = txHash
-      ? maybeFilteredByOriginMemo.filter(
-          txId =>
-            txs[txId].txid.toLowerCase().startsWith(txHash.toLowerCase()) ||
-            txs[txId].txid.toLowerCase().startsWith(txHash.toLowerCase().replace(/^0x/, '')),
-        )
+      ? maybeFilteredByOriginMemo.filter(txId => {
+          const txIdNormalized = txs[txId].txid.toLowerCase().replace(/^0x/, '')
+          const filterNormalized = txHash.toLowerCase().replace(/^0x/, '')
+          return txIdNormalized.startsWith(filterNormalized)
+        })
       : maybeFilteredByOriginMemo
 
     const maybeUniqueIdsByStatus = txStatusFilter

--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -192,7 +192,11 @@ export const selectTxIdsByFilter = createCachedSelector(
       : maybeFilteredByMemo
 
     const maybeFilteredByTxHash = txHash
-      ? maybeFilteredByOriginMemo.filter(txId => txs[txId].txid.startsWith(txHash))
+      ? maybeFilteredByOriginMemo.filter(
+          txId =>
+            txs[txId].txid.toLowerCase().startsWith(txHash.toLowerCase()) ||
+            txs[txId].txid.toLowerCase().startsWith(txHash.toLowerCase().replace(/^0x/, '')),
+        )
       : maybeFilteredByOriginMemo
 
     const maybeUniqueIdsByStatus = txStatusFilter


### PR DESCRIPTION
## Description

Two birds one stone:

- Adds missing `thor.ruji` in `assetIdByDenom` mapping i.e we currently handle `x/ruji` which works for send, but OUT Txs will actually have a `thor.ruji` transfer
- While this *should* theoretically fix parsing of action center RUJI Txs, resulting in working RUNE <-> RUJI execution, this is not enough. As mentionned in inline comments, a given Thorchain <-> Thorchain swap will have the same AccountId and same txHash on both the inbound and outbound side, so we need an additional discriminator to ensure we select the out Tx.

By ensuring we select the correct out Tx for Thor <-> Thor swaps and by adding the missing `thor.ruji` denom in the mapping, all same-chain Thor swaps will now have their execution price working
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/pull/10427

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low - effectively isolated to action center THORchain buy Txs

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Perform RUNE <-> RUJI swaps on both sides and ensure you see execution price
- Perform any other chain (say EVM) to RUNE/RUJI swap and ensure you see execution price

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

- this diff


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
