### PR TITLE
fix: highlighted tokens don't display grouping when active chainId is selected

### DIFF
--- a/src/components/MultiHopTrade/components/TradeInput/components/HighlightedTokens.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/HighlightedTokens.tsx
@@ -262,7 +262,7 @@ export const HighlightedTokens = () => {
           disableUnsupported={false}
           height='100vh'
           showPrice
-          showRelatedAssets
+          showRelatedAssets={selectedChainId === 'all'}
         />
       </Flex>
     )
@@ -276,6 +276,7 @@ export const HighlightedTokens = () => {
     handleRowClick,
     handleRowLongPress,
     portalsAssets,
+    selectedChainId,
   ])
 
   const title = useMemo(() => {


### PR DESCRIPTION
## Description

Does what it says on the box - spotted by large @neomaking in https://github.com/shapeshift/web/pull/10442#issuecomment-3266979658

Note, there is another bug with *some* assets which is already present in develop (see screenshots) which will be fixed in a follow-up

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low/None

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to highlighted tokens on mobile 
- Select an active chain and notice assets aren't grouped

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- This diff (left) vs. develop (right)
<img width="1716" height="990" alt="Screenshot 2025-09-08 at 18 15 06" src="https://github.com/user-attachments/assets/3088c433-7420-41ff-89af-b4fb24cb1750" />
<img width="1728" height="993" alt="Screenshot 2025-09-08 at 18 15 24" src="https://github.com/user-attachments/assets/46cb5dd8-a5f3-4488-b9f4-a06ef7222e91" />



<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Related assets now appear only when the chain filter is set to “All,” preventing unintended visibility on specific chains and improving relevance of the asset list.
  * Highlighted tokens refresh correctly when switching the chain filter, ensuring the display stays in sync with the selected network and reducing stale or misleading results during navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->