### PR TITLE
fix: only display asset icon on chain specific icon

### DIFF
--- a/src/components/StakingVaults/Cells.tsx
+++ b/src/components/StakingVaults/Cells.tsx
@@ -41,6 +41,7 @@ type AssetCellProps = {
   opportunityName?: string
   isExternal?: boolean
   version?: string
+  isChainSpecific?: boolean
 } & StackProps
 
 const rowTitleBoxAfter = {
@@ -78,6 +79,7 @@ export const AssetCell = ({
   opportunityName,
   isExternal,
   version,
+  isChainSpecific,
   ...rest
 }: AssetCellProps) => {
   const translate = useTranslate()
@@ -113,7 +115,7 @@ export const AssetCell = ({
           {icons && icons.length > 1 ? (
             <PairIcons icons={icons} iconSize='sm' bg='none' />
           ) : (
-            <AssetIcon assetId={asset.assetId} size='md' />
+            <AssetIcon assetId={asset.assetId} size='md' showNetworkIcon={isChainSpecific} />
           )}
         </SkeletonCircle>
         <SkeletonText noOfLines={2} isLoaded={!!asset} flex={1} width='50%'>

--- a/src/pages/Dashboard/components/AccountList/AccountTable.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
@@ -81,6 +81,7 @@ export const AccountTable = memo(({ forceCompactView = false, onRowClick }: Acco
         disableSortBy: true,
         Cell: ({ row }: { row: AccountRowProps }) => (
           <AssetCell
+            isChainSpecific={row.original.isChainSpecific}
             assetId={row.original.assetId}
             subText={truncate(row.original.symbol, { length: 6 })}
           />


### PR DESCRIPTION
## Description

... and in children rows of expanded primary asset row

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes N/A, spotted by @neomaing in https://github.com/shapeshift/web/pull/10442#issuecomment-3266979658

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to wallet 
- Ensure primary asset *token* rows (e.g those without related assets/ nesting) have a network icon (native assets still shouldn't have it
- Ensure parent row of related assets does not have a network icon
- Ensure expanded asset with related assets has network icon in its children

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
