### PR TITLE
fix(mobile): remove double bottom offset from asset list

### DIFF
--- a/src/pages/Dashboard/components/AccountList/AccountTable.tsx
+++ b/src/pages/Dashboard/components/AccountList/AccountTable.tsx
@@ -261,7 +261,7 @@ export const AccountTable = memo(({ forceCompactView = false, onRowClick }: Acco
         assets={accountsAssets}
         handleClick={handleAssetClick}
         handleLongPress={handleAssetLongPress}
-        height='calc(100vh - var(--mobile-header-offset) - var(--safe-area-inset-bottom) - var(--safe-area-inset-top) - env(safe-area-inset-bottom) - env(safe-area-inset-top) - env(safe-area-inset-top) - var(--mobile-nav-offset) - 54px)'
+        height='calc(100vh - var(--mobile-header-offset) - env(safe-area-inset-top) - var(--safe-area-inset-top) - 54px)'
         showRelatedAssets
       />
     )


### PR DESCRIPTION
## Description

- Fixes a mobile regression in https://github.com/shapeshift/web/pull/10380 that caused a large gap below the asset list in “My Crypto”.

The mobile `AssetList` height subtracted both bottom safe-area and `--mobile-nav-offset` while parent containers already applied bottom padding, resulting in a reduced scrollable area and visible gap.

## Issue (if applicable)

N/A - fixes blocker in current release, https://github.com/shapeshift/web/pull/10450

## Risk

Low. Change is isolated to mobile height calculation; grouped assets functionality intact.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

On mobile, confirm that there is no gap between the bottom of the asset list and the bottom nav bar.

`develop`:

<img src="https://github.com/user-attachments/assets/8cd33b06-5626-4b08-8d2c-3dd2200cc618" alt="IMG_A708E0FD1E40-1" width="300">

This branch:

<img src="https://github.com/user-attachments/assets/ec78189d-7712-4a6d-a66e-d56b052e39e9" alt="IMG_C723E883F9A6-1" width="300">

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See testing section above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected mobile layout height calculation for the account list, ensuring proper respect for safe areas.
  * Prevents content being cut off at the bottom and reduces extra whitespace.
  * Improves scrolling behavior and visual consistency across devices with notches and dynamic safe areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->