### PR TITLE
refactor: addressable

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,6 @@
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
     <title>ShapeShift</title>
-    <!-- Addressable Pixel base code -->
-    <script type="module" src="/src/pixels/addressable.ts"></script>
-    <!-- End Addressable Pixel base code -->
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import '@/lib/polyfills'
+import '@/pixels/addressable'
 
 import {
   breadcrumbsIntegration,


### PR DESCRIPTION
## Description

A small refactor in the way that we load the pixel, ensuring it runs before app render - I had it staged when doing https://github.com/shapeshift/web/pull/10424 but forgot to commit it!

## Issue (if applicable)

Relates to https://github.com/shapeshift/web/issues/10383

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Pixel should still work - hard to test without access to the Addressable dashboard. I've pushed this change to juice and confirmed it's still working:

<img width="648" height="539" alt="Screenshot 2025-09-10 at 7 42 48 am" src="https://github.com/user-attachments/assets/ba39f894-5a27-4a60-9eb5-656e28a10748" />


### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Moved tracking pixel initialization from static HTML into the application startup, consolidating loading into the main bundle.
  * Removed the standalone HTML script reference; functionality now loads through the standard import flow.
* **Chores**
  * Aligned startup to rely solely on bundled modules for consistency.
  * No user-facing changes or configuration updates required.
  * Startup behavior and existing functionality are expected to remain consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->