### PR TITLE
feat: better icon transitions between quotes

### DIFF
--- a/src/components/MultiHopTrade/components/SwapperIcons.tsx
+++ b/src/components/MultiHopTrade/components/SwapperIcons.tsx
@@ -16,23 +16,35 @@ type SwapperIconsProps = {
   swapperName: SwapperName | undefined
 }
 
+const animationTransition = {
+  duration: 0.2,
+  ease: [0.43, 0.13, 0.23, 0.96] as [number, number, number, number],
+}
+const widthWillChangeStyle = { willChange: 'width' } as const
+const opacityTransformWillChangeStyle = { willChange: 'opacity, transform' } as const
+const swapperInitial = { opacity: 0, scale: 0.9 }
+const swapperAnimate = { opacity: 1, scale: 1, transition: animationTransition }
+const swapperExit = { opacity: 0, scale: 1.05, transition: animationTransition }
+const overlayStyle = {
+  position: 'absolute',
+  inset: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+} as const
+
 export const SwapperIcons = ({ swapSource, swapperName }: SwapperIconsProps) => {
   const isStreaming =
     swapSource === THORCHAIN_STREAM_SWAP_SOURCE ||
     swapSource === THORCHAIN_LONGTAIL_STREAMING_SWAP_SOURCE ||
     swapSource === MAYACHAIN_STREAM_SWAP_SOURCE
 
-  const animationTransition = useMemo(
-    () => ({ duration: 0.2, ease: [0.43, 0.13, 0.23, 0.96] as [number, number, number, number] }),
-    [],
-  )
-
   const widthAnimate = useMemo(
     () =>
       isStreaming
         ? { width: 24, transition: animationTransition }
         : { width: 0, transition: animationTransition },
-    [animationTransition, isStreaming],
+    [isStreaming],
   )
 
   const streamingAnimate = useMemo(
@@ -40,34 +52,7 @@ export const SwapperIcons = ({ swapSource, swapperName }: SwapperIconsProps) => 
       isStreaming
         ? { opacity: 1, scale: 1, transition: animationTransition }
         : { opacity: 0, scale: 0.85, transition: animationTransition },
-    [animationTransition, isStreaming],
-  )
-
-  const swapperInitial = useMemo(() => ({ opacity: 0, scale: 0.9 }), [])
-  const swapperAnimate = useMemo(
-    () => ({ opacity: 1, scale: 1, transition: animationTransition }),
-    [animationTransition],
-  )
-  const swapperExit = useMemo(
-    () => ({ opacity: 0, scale: 1.05, transition: animationTransition }),
-    [animationTransition],
-  )
-  const overlayStyle = useMemo(
-    () =>
-      ({
-        position: 'absolute',
-        inset: 0,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-      }) as const,
-    [],
-  )
-
-  const widthWillChangeStyle = useMemo(() => ({ willChange: 'width' }) as const, [])
-  const opacityTransformWillChangeStyle = useMemo(
-    () => ({ willChange: 'opacity, transform' }) as const,
-    [],
+    [isStreaming],
   )
 
   return (


### PR DESCRIPTION
## Description

The icon changes when changing between quotes, especially when going to/from a streaming swap, looks kinda jank.

This PR makes the icon transitions buttery smooth.

## Issue (if applicable)

N/A, it just annoyed me.

## Risk

> High Risk PRs Require 2 approvals

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Change between quotes and notice that the swapper and streaming icons transition in a smooth way.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

Production:

https://github.com/user-attachments/assets/914aab95-d030-47c5-bc0f-85def6be5bb3

This PR:

https://github.com/user-attachments/assets/6920ae19-b41c-44d8-b2cf-fd0037afa616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced layout shifting and flicker when swapper names/icons change by stabilizing layout during transitions.
  * Streaming indicator now appears/disappears smoothly via animated width and opacity to avoid jarring jumps.

* **Style**
  * Smoother, more polished icon and indicator animations with improved visual consistency.

* **Refactor**
  * Reworked animation and rendering approach to use a unified motion-driven layout and overlay transitions while preserving public behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->