### PR TITLE
fix: tx history when no filter passed

### DIFF
--- a/src/state/slices/txHistorySlice/selectors.ts
+++ b/src/state/slices/txHistorySlice/selectors.ts
@@ -162,20 +162,6 @@ export const selectTxIdsByFilter = createCachedSelector(
     originMemoFilter,
     txHashFilter,
   ): TxId[] => {
-    // Ensure that we do not end up selecting all Txids in store in case no filters are passed
-    if (
-      !(
-        accountIdFilter ||
-        assetIdFilter ||
-        txStatusFilter ||
-        parserFilter ||
-        memoFilter ||
-        originMemoFilter ||
-        txHashFilter
-      )
-    )
-      return []
-
     const maybeFilteredByAccountId = accountIdFilter
       ? pickBy(data, (_, accountId) => {
           return accountId === accountIdFilter


### PR DESCRIPTION
## Description

Fixes TX history not showing when no filters are passed into the `selectTxIdsByFilter` selector.

## Issue (if applicable)

Unblocks release from regression introduced in https://github.com/shapeshift/web/pull/10456

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

- Ensure the AC of https://github.com/shapeshift/web/pull/10456 still holds.
- Ensure transaction history now shows in the "Activity" and "Recent Transactions" sections of the app

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Transaction history now shows all transactions when no filters are applied, instead of appearing empty.
  - Preserves the existing transaction order and applies filters only when specified.
  - No changes to visible controls or filtering options; behavior is now consistent and predictable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->