### PR TITLE
fix: stop inline copy tooltip from sticking forever on mobile

### DIFF
--- a/src/components/InlineCopyButton.tsx
+++ b/src/components/InlineCopyButton.tsx
@@ -1,8 +1,8 @@
 import { CheckIcon, CopyIcon } from '@chakra-ui/icons'
 import type { FlexProps } from '@chakra-ui/react'
-import { Box, Flex, IconButton, Tooltip } from '@chakra-ui/react'
+import { Flex, IconButton, Tooltip } from '@chakra-ui/react'
 import type { MouseEvent, PropsWithChildren } from 'react'
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
 
 import { useCopyToClipboard } from '@/hooks/useCopyToClipboard'
@@ -23,12 +23,7 @@ export const InlineCopyButton: React.FC<InlineCopyButtonProps> = ({
   flexProps,
 }) => {
   const translate = useTranslate()
-  const { isCopied, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
-  const [isTooltipOpen, setIsTooltipOpen] = useState(false)
-
-  const handleMouseEnter = useCallback(() => setIsTooltipOpen(true), [])
-  const handleMouseLeave = useCallback(() => setIsTooltipOpen(false), [])
-  const handleClick = useCallback(() => setIsTooltipOpen(true), [])
+  const { isCopied, isCopying, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
 
   const handleCopyClick = useCallback(
     (e: MouseEvent) => {
@@ -58,17 +53,8 @@ export const InlineCopyButton: React.FC<InlineCopyButtonProps> = ({
     <Flex gap={2} alignItems='center' {...flexProps}>
       {children}
       {translate ? (
-        <Tooltip
-          isOpen={isTooltipOpen}
-          label={translate(isCopied ? 'common.copied' : 'common.copy')}
-        >
-          <Box
-            onMouseEnter={handleMouseEnter}
-            onMouseLeave={handleMouseLeave}
-            onClick={handleClick}
-          >
-            <IconButton {...buttonProps} />
-          </Box>
+        <Tooltip isOpen={isCopying} label={translate('common.copied')}>
+          <IconButton {...buttonProps} />
         </Tooltip>
       ) : (
         <IconButton {...buttonProps} />

--- a/src/hooks/useCopyToClipboard.tsx
+++ b/src/hooks/useCopyToClipboard.tsx
@@ -32,5 +32,5 @@ export function useCopyToClipboard({ timeout = 2000 }: useCopyToClipboardProps) 
     }, timeout)
   }
 
-  return { isCopied, copyToClipboard }
+  return { isCopied, isCopying, copyToClipboard }
 }


### PR DESCRIPTION
## Description

The current issue is that on mobile our "inline copy" button opens a tooltip and never closes. This changes the tooltip behaviour to show the copied feedback for 2 seconds before disappearing. We lose the "copy" tooltip on hover but I think the icon is fairly self explanatory. And this makes the logic a lot more reliable.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10027

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test some inline copy buttons on both desktop and mobile. Good example is the claim modals on fox eco page 

<img width="579" height="503" alt="image" src="https://github.com/user-attachments/assets/2806b1eb-8ecb-492f-b814-ea21e93d08ea" />

* Make sure when you click it you get some feedback that you copied and the tooltip doesn't stick forever


<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/34e1b41d-94f6-4aaa-b57b-de08e0b3155d
