### PR TITLE
fix: wc dApps capabilities advertisement

### DIFF
--- a/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
+++ b/src/plugins/walletConnectToDapps/WalletConnectModalManager.tsx
@@ -194,16 +194,7 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
           />
         )
       case WalletConnectModal.SignEIP155TransactionConfirmation:
-        if (!topic) return null
-        return (
-          <EIP155TransactionConfirmation
-            onConfirm={handleConfirmEIP155Request}
-            onReject={handleRejectRequestAndClose}
-            state={state as Required<WalletConnectState<EthSignTransactionCallRequest>>}
-            topic={topic}
-          />
-        )
-      case WalletConnectModal.SendEIP155TransactionConfirmation:
+      case WalletConnectModal.SendEIP155TransactionConfirmation: {
         if (!topic) return null
 
         const requestParams = state.modalData?.requestEvent?.params.request.params
@@ -231,6 +222,7 @@ export const WalletConnectModalManager: FC<WalletConnectModalManagerProps> = ({
             topic={topic}
           />
         )
+      }
       case WalletConnectModal.SendCosmosTransactionConfirmation:
         if (!topic) return null
         return (

--- a/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/SessionProposal.tsx
@@ -19,7 +19,7 @@ import { DAppInfo } from '@/plugins/walletConnectToDapps/components/DAppInfo'
 import { ModalSection } from '@/plugins/walletConnectToDapps/components/modals/ModalSection'
 import { Permissions } from '@/plugins/walletConnectToDapps/components/Permissions'
 import type { SessionProposalRef } from '@/plugins/walletConnectToDapps/types'
-import { WalletConnectActionType } from '@/plugins/walletConnectToDapps/types'
+import { EIP155_SigningMethod, WalletConnectActionType } from '@/plugins/walletConnectToDapps/types'
 import type { WalletConnectSessionModalProps } from '@/plugins/walletConnectToDapps/WalletConnectModalManager'
 import { selectAccountIdsByChainId, selectWalletAccountIds } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -51,9 +51,20 @@ const _createApprovalNamespaces = (
         const { chainNamespace } = fromAccountId(accountId)
         return chainNamespace === key
       })
+
+      // That condition seems useless at runtime since we *currently* only handle eip155
+      // but technically, we *do* support Cosmos SDK
+      const methods =
+        key === 'eip155'
+          ? Object.values(EIP155_SigningMethod).filter(
+              // Not required, and will currently will fail in wc land
+              method => method !== EIP155_SigningMethod.GET_CAPABILITIES,
+            )
+          : proposalNamespace.methods
+
       namespaces[key] = {
         accounts: selectedAccountsForKey,
-        methods: proposalNamespace.methods,
+        methods,
         events: proposalNamespace.events,
       }
       return namespaces


### PR DESCRIPTION
## Description

Two birds one stone:

1. advertises all capabilities, noticed when testing app vs. MM, MM did avertise a *lot* more than us:
  <img width="419" height="827" alt="image" src="https://github.com/user-attachments/assets/c4fc6445-224c-4a27-894f-a4ef1cbeafac" />
  <img width="497" height="676" alt="image" src="https://github.com/user-attachments/assets/6a5a17fb-c859-4465-8c08-ad31f111d0fc" />
2. progresses towards https://github.com/shapeshift/web/issues/10391 preparing for new connect flow, which doesn't display proposed namespace capabilities (which we now won't honour with this fix either way, we will now always try to provide as many capabilities as possible, similar to wc demo)

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

- progresses towards https://github.com/shapeshift/web/issues/10391

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Go to https://react-app.walletconnect.com/ and ensure you see all capabilities like in screenshot 
- Confirm all methods in the dapp above are happy
- Also test one of each in other dApps: 
  - Structured signing (e.g, permit or approval on 1inch)  - not required to test explicitly since the demo dApp below provides it, but nice to test as a paranoia
  - Actual non-`0x` data (e.g swap on relay) transaction signing. This one is required to be tested explicitly, not on the WC demo above, which will produce a send modal, as it doesn't have any contract call data. 

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

  <img width="497" height="676" alt="image" src="https://github.com/user-attachments/assets/6a5a17fb-c859-4465-8c08-ad31f111d0fc" />

- this diff

<img width="286" height="589" alt="image" src="https://github.com/user-attachments/assets/66fe51cc-c861-409c-978c-ad5f0b313b21" />
<img width="550" height="471" alt="Screenshot 2025-09-12 at 13 18 53" src="https://github.com/user-attachments/assets/f77cd889-22b3-4a69-9f7e-50b0786b472f" />
<img width="562" height="576" alt="Screenshot 2025-09-12 at 13 24 11" src="https://github.com/user-attachments/assets/067b6bc0-04df-41b6-8355-8fc7829a56c5" />
<img width="551" height="769" alt="Screenshot 2025-09-12 at 13 24 37" src="https://github.com/user-attachments/assets/f1808516-9062-4f27-880c-496f8a608f9b" />
<img width="560" height="575" alt="Screenshot 2025-09-12 at 13 24 48" src="https://github.com/user-attachments/assets/06b187ad-d70f-4b2a-ae55-c3b1f89814f0" />
<img width="534" height="951" alt="Screenshot 2025-09-12 at 13 28 46" src="https://github.com/user-attachments/assets/560ce9c4-4e4d-4185-a21c-5b6e4285dce7" />
<img width="563" height="930" alt="Screenshot 2025-09-12 at 13 41 16" src="https://github.com/user-attachments/assets/ac2a61ec-26e1-4be0-b93b-4ce03db38181" />
<img width="551" height="722" alt="Screenshot 2025-09-12 at 13 41 32" src="https://github.com/user-attachments/assets/16219beb-549d-47e2-8077-30f01c8d645d" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
