### PR TITLE
fix: prevent unecessary calc and rerender on empty upsert asset calls

### DIFF
--- a/src/state/slices/assetsSlice/assetsSlice.ts
+++ b/src/state/slices/assetsSlice/assetsSlice.ts
@@ -50,6 +50,11 @@ export const assets = createSlice({
   reducers: create => ({
     clear: create.reducer(() => initialState),
     upsertAssets: create.reducer((state, action: PayloadAction<UpsertAssetsPayload>) => {
+      // Ignore empty upserts - don't create new references for no reason
+      if (action.payload.ids.length === 0 && Object.keys(action.payload.byId).length === 0) {
+        return
+      }
+
       state.byId = Object.assign({}, state.byId, action.payload.byId) // upsert
       // Note this preserves the original sorting while removing duplicates.
       state.ids = Array.from(new Set(state.ids.concat(action.payload.ids)))


### PR DESCRIPTION
## Description

Small optimisation to prevent rerenders and unnecessary expensive calcs when we call upset assets with an empty array (which we seem to do quite a bit).

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10510 

## Risk

No risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Explore page might feel a tad more snappy

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Reduces unnecessary updates when no asset changes occur, preventing redundant re-renders and improving UI responsiveness, especially in asset-heavy views.
  * Users may notice smoother scrolling, quicker interactions, and reduced CPU usage when assets remain unchanged.
  * No changes to user workflows or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->