### PR TITLE
fix: make sure continue doesn't show up before you confirm all phrases in backup

### DIFF
--- a/src/components/MobileWalletDialog/routes/CreateWallet/CreateBackupConfirm.tsx
+++ b/src/components/MobileWalletDialog/routes/CreateWallet/CreateBackupConfirm.tsx
@@ -62,7 +62,7 @@ export const CreateBackupConfirm = () => {
   }
 
   const hasChosenWords = useMemo(() => {
-    return selections.length >= TEST_COUNT_REQUIRED
+    return selections.filter(Boolean).length === TEST_COUNT_REQUIRED
   }, [selections])
 
   const handleSubmit = useCallback(() => {

--- a/src/context/WalletProvider/NativeWallet/components/NativeTestPhrase.tsx
+++ b/src/context/WalletProvider/NativeWallet/components/NativeTestPhrase.tsx
@@ -97,7 +97,7 @@ export const NativeTestPhrase = () => {
   })
 
   const hasChosenWords = useMemo(() => {
-    return testState?.selectedWords.length === TEST_COUNT_REQUIRED
+    return testState?.selectedWords.filter(Boolean).length === TEST_COUNT_REQUIRED
   }, [testState])
 
   const handleSubmit = useCallback(() => {


### PR DESCRIPTION

## Description

Ensures we don't activate the continue button before the user has selected all phrase confirmations

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10463 

## Risk

Low risk, this is a simple change

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Create a new wallet in mobile and try confirming the seed phrase in different orders. Continue should only show up when you've selected all 3

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

![69a8062e-32f5-45c6-af6f-924b49ba76f4](https://github.com/user-attachments/assets/8be926e8-c638-4b35-9fae-eacf8d861199)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup confirmation validation: users must select all required words before continuing, preventing accidental progression with incomplete or empty selections.
  * Strengthened test phrase checks to require explicit choices for each slot, eliminating cases where sparse selections could incorrectly pass.
  * Ensures a more reliable and clear flow during wallet backup and test phrase verification, reducing user confusion and enhancing security by enforcing complete input before submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->