### PR TITLE
fix: more wallet drawer fixes and polish

### DIFF
--- a/src/components/Layout/Header/NavBar/DrawerWalletHeader.tsx
+++ b/src/components/Layout/Header/NavBar/DrawerWalletHeader.tsx
@@ -92,7 +92,7 @@ export const DrawerWalletHeader: FC<DrawerHeaderProps> = memo(
               icon={dotsIcon}
               size='sm'
             />
-            <MenuList zIndex={2}>
+            <MenuList zIndex={'popover'}>
               <MenuGroup title={translate('common.connectedWallet')} color='text.subtle'>
                 <MenuItem icon={walletImageIcon} isDisabled closeOnSelect={false}>
                   <Flex flexDir='row' justifyContent='space-between' alignItems='center'>


### PR DESCRIPTION
## Description

Some small fixes to the wallet drawer.
* Auto close the drawer when our global or wallet modals open. Due to modal stacking shenanigans, certain things break on the modals when the drawer is open
* Increase z-index of kebob menu to prevent network icons from layering over the top of the menu

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Make sure you can interact with the modals that pop up from the wallet drawer
* Make sure kebob menu on wallet drawer behaves normally layering wise

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

Give the modal a second to render before closing the drawer