### PR TITLE
fix: app crash

### DIFF
--- a/src/components/Layout/Header/ActionCenter/ActionCenterContext.tsx
+++ b/src/components/Layout/Header/ActionCenter/ActionCenterContext.tsx
@@ -1,5 +1,5 @@
 import { useMediaQuery } from '@chakra-ui/react'
-import React, { createContext, useCallback, useContext, useState } from 'react'
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { breakpoints } from '@/theme/theme'
@@ -24,11 +24,16 @@ export const ActionCenterProvider: React.FC<{ children: React.ReactNode }> = ({ 
   }, [isLargerThanMd, navigate])
   const closeDrawer = useCallback(() => setIsDrawerOpen(false), [])
 
-  return (
-    <ActionCenterContext.Provider value={{ isDrawerOpen, openActionCenter, closeDrawer }}>
-      {children}
-    </ActionCenterContext.Provider>
+  const value = useMemo(
+    () => ({
+      isDrawerOpen,
+      openActionCenter,
+      closeDrawer,
+    }),
+    [isDrawerOpen, openActionCenter, closeDrawer],
   )
+
+  return <ActionCenterContext.Provider value={value}>{children}</ActionCenterContext.Provider>
 }
 
 export const useActionCenterContext = () => {

--- a/src/components/Layout/Header/ActionCenter/ActionCenterContext.tsx
+++ b/src/components/Layout/Header/ActionCenter/ActionCenterContext.tsx
@@ -1,5 +1,5 @@
 import { useMediaQuery } from '@chakra-ui/react'
-import React, { createContext, useCallback, useContext, useMemo, useState } from 'react'
+import React, { createContext, useCallback, useContext, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { breakpoints } from '@/theme/theme'
@@ -24,16 +24,11 @@ export const ActionCenterProvider: React.FC<{ children: React.ReactNode }> = ({ 
   }, [isLargerThanMd, navigate])
   const closeDrawer = useCallback(() => setIsDrawerOpen(false), [])
 
-  const value = useMemo(
-    () => ({
-      isDrawerOpen,
-      openActionCenter,
-      closeDrawer,
-    }),
-    [isDrawerOpen, openActionCenter, closeDrawer],
+  return (
+    <ActionCenterContext.Provider value={{ isDrawerOpen, openActionCenter, closeDrawer }}>
+      {children}
+    </ActionCenterContext.Provider>
   )
-
-  return <ActionCenterContext.Provider value={value}>{children}</ActionCenterContext.Provider>
 }
 
 export const useActionCenterContext = () => {

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -159,7 +159,8 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
 
     return portfolioAssetIdsDelta
   }, [
-    findAllQueryData,
+    findAllQueryData.status,
+    findAllQueryData.currentData,
     isConnected,
     isLoadingLocalWallet,
     modal,

--- a/src/hooks/useNotificationToast.tsx
+++ b/src/hooks/useNotificationToast.tsx
@@ -12,8 +12,14 @@ export const useNotificationToast = (options: NotificationToastOptions) => {
     return isLargerThanMd ? 'bottom-right' : 'bottom'
   }, [isLargerThanMd])
 
-  return useToast({
-    position,
-    ...options,
-  })
+  const toastOptions = useMemo(
+    () =>
+      ({
+        position,
+        ...options,
+      }) as const,
+    [position, options],
+  )
+
+  return useToast(toastOptions)
 }

--- a/src/hooks/useNotificationToast.tsx
+++ b/src/hooks/useNotificationToast.tsx
@@ -12,14 +12,8 @@ export const useNotificationToast = (options: NotificationToastOptions) => {
     return isLargerThanMd ? 'bottom-right' : 'bottom'
   }, [isLargerThanMd])
 
-  const toastOptions = useMemo(
-    () =>
-      ({
-        position,
-        ...options,
-      }) as const,
-    [position, options],
-  )
-
-  return useToast(toastOptions)
+  return useToast({
+    position,
+    ...options,
+  })
 }

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -13,35 +13,10 @@ import { useLifetimeRewardDistributionsQuery } from './useLifetimeRewardDistribu
 import { RewardDistributionNotification } from '@/components/Layout/Header/ActionCenter/components/Notifications/RewardDistributionNotification'
 
 export const useRfoxRewardDistributionActionSubscriber = () => {
-  console.log('🔴 REPRO DEBUG: useRfoxRewardDistributionActionSubscriber hook called')
-
   const stakingAssetAccountIds = useAppSelector(state =>
     selectAccountIdsByChainIdFilter(state, { chainId: arbitrumChainId }),
   )
   const dispatch = useAppDispatch()
-
-  useEffect(() => {
-    dispatch(
-      actionSlice.actions.upsertAction({
-        id: 'reward-distribution-13-0xaC2a4fD70BCD8Bab0662960455c363735f0e2b56-thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
-        type: ActionType.RewardDistribution,
-        status: ActionStatus.Initiated, // NOT Complete - this triggers the loop
-        createdAt: Date.now(),
-        updatedAt: Date.now(),
-        rewardDistributionMetadata: {
-          distribution: {
-            epoch: 13,
-            stakingContract: '0xaC2a4fD70BCD8Bab0662960455c363735f0e2b56',
-            rewardAddress: 'thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
-            status: 'complete',
-            txId: '0xfake123',
-          },
-          txHash: '0xfake123',
-        },
-      }),
-    )
-  }, [dispatch])
-
   const { isDrawerOpen, openActionCenter } = useActionCenterContext()
   const toast = useNotificationToast({ duration: isDrawerOpen ? 5000 : null })
   const actions = useAppSelector(actionSlice.selectors.selectActionsById)
@@ -118,30 +93,15 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
 
   useEffect(() => {
-    console.log('🔴 REPRO DEBUG: COMPLETE useEffect triggered')
-    console.log(
-      '🔴 REPRO DEBUG: rewardDistributionsByTxId keys:',
-      Object.keys(rewardDistributionsByTxId),
-    )
-    console.log('🔴 REPRO DEBUG: Current actions in store:', Object.keys(actions).length, 'actions')
-
     const now = Date.now()
 
-    Object.entries(rewardDistributionsByTxId).forEach(([txId, distribution]) => {
+    Object.entries(rewardDistributionsByTxId).forEach(([_, distribution]) => {
       if (!distribution) return
 
       if (distribution.status === 'complete' && distribution.txId) {
         const actionId = `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`
 
-        console.log(`🔴 REPRO DEBUG: Processing COMPLETE distribution ${actionId}`)
-        console.log(`🔴 REPRO DEBUG: Action exists in store:`, !!actions[actionId])
-
-        if (!actions[actionId]) {
-          console.log(`🔴 REPRO DEBUG: COMPLETE action ${actionId} doesn't exist, skipping`)
-          return
-        }
-
-        console.log(`🔴 REPRO DEBUG: Dispatching COMPLETE action ${actionId}`)
+        if (!actions[actionId]) return
         dispatch(
           actionSlice.actions.upsertAction({
             id: actionId,

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -111,6 +111,9 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
 
         if (!actions[actionId]) return
 
+        if (existingAction.status === ActionStatus.Complete) {
+          return
+        }
         dispatch(
           actionSlice.actions.upsertAction({
             id: actionId,

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -18,7 +18,15 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   )
   const dispatch = useAppDispatch()
   const { isDrawerOpen, openActionCenter } = useActionCenterContext()
-  const toast = useNotificationToast({ duration: isDrawerOpen ? 5000 : null })
+
+  const toastOptions = useMemo(
+    () => ({
+      duration: isDrawerOpen ? 5000 : null,
+    }),
+    [isDrawerOpen],
+  )
+  const toast = useNotificationToast(toastOptions)
+
   const actions = useAppSelector(actionSlice.selectors.selectActionsById)
   const stakingAssetAccountAddresses = useMemo(
     () => stakingAssetAccountIds.map(accountId => fromAccountId(accountId).account),
@@ -38,7 +46,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
       acc[rewardDistribution.txId || rewardDistribution.stakingContract] = rewardDistribution
       return acc
     }, {})
-  }, [lifetimeRewardDistributionsQuery])
+  }, [lifetimeRewardDistributionsQuery.data])
 
   useEffect(() => {
     const now = Date.now()
@@ -90,7 +98,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         }
       }
     })
-  }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
+  }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
 
   useEffect(() => {
     const now = Date.now()
@@ -101,7 +109,12 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
       if (distribution.status === 'complete' && distribution.txId) {
         const actionId = `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`
 
-        if (!actions[actionId]) return
+        const existingAction = actions[actionId]
+        if (!existingAction) return
+
+        if (existingAction.status === ActionStatus.Complete) {
+          return
+        }
         dispatch(
           actionSlice.actions.upsertAction({
             id: actionId,
@@ -141,5 +154,5 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         }
       }
     })
-  }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
+  }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
 }

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -18,15 +18,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   )
   const dispatch = useAppDispatch()
   const { isDrawerOpen, openActionCenter } = useActionCenterContext()
-
-  const toastOptions = useMemo(
-    () => ({
-      duration: isDrawerOpen ? 5000 : null,
-    }),
-    [isDrawerOpen],
-  )
-  const toast = useNotificationToast(toastOptions)
-
+  const toast = useNotificationToast({ duration: isDrawerOpen ? 5000 : null })
   const actions = useAppSelector(actionSlice.selectors.selectActionsById)
   const stakingAssetAccountAddresses = useMemo(
     () => stakingAssetAccountIds.map(accountId => fromAccountId(accountId).account),
@@ -46,7 +38,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
       acc[rewardDistribution.txId || rewardDistribution.stakingContract] = rewardDistribution
       return acc
     }, {})
-  }, [lifetimeRewardDistributionsQuery.data])
+  }, [lifetimeRewardDistributionsQuery])
 
   useEffect(() => {
     const now = Date.now()
@@ -98,7 +90,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         }
       }
     })
-  }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
+  }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
 
   useEffect(() => {
     const now = Date.now()
@@ -109,12 +101,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
       if (distribution.status === 'complete' && distribution.txId) {
         const actionId = `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`
 
-        const existingAction = actions[actionId]
-        if (!existingAction) return
-
-        if (existingAction.status === ActionStatus.Complete) {
-          return
-        }
+        if (!actions[actionId]) return
         dispatch(
           actionSlice.actions.upsertAction({
             id: actionId,
@@ -154,5 +141,5 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         }
       }
     })
-  }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
+  }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
 }

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -13,10 +13,35 @@ import { useLifetimeRewardDistributionsQuery } from './useLifetimeRewardDistribu
 import { RewardDistributionNotification } from '@/components/Layout/Header/ActionCenter/components/Notifications/RewardDistributionNotification'
 
 export const useRfoxRewardDistributionActionSubscriber = () => {
+  console.log('🔴 REPRO DEBUG: useRfoxRewardDistributionActionSubscriber hook called')
+
   const stakingAssetAccountIds = useAppSelector(state =>
     selectAccountIdsByChainIdFilter(state, { chainId: arbitrumChainId }),
   )
   const dispatch = useAppDispatch()
+
+  useEffect(() => {
+    dispatch(
+      actionSlice.actions.upsertAction({
+        id: 'reward-distribution-13-0xaC2a4fD70BCD8Bab0662960455c363735f0e2b56-thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
+        type: ActionType.RewardDistribution,
+        status: ActionStatus.Initiated, // NOT Complete - this triggers the loop
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+        rewardDistributionMetadata: {
+          distribution: {
+            epoch: 13,
+            stakingContract: '0xaC2a4fD70BCD8Bab0662960455c363735f0e2b56',
+            rewardAddress: 'thor125dwsa39yeylqc7pn59l079dur502nsleyrgup',
+            status: 'complete',
+            txId: '0xfake123',
+          },
+          txHash: '0xfake123',
+        },
+      }),
+    )
+  }, [dispatch])
+
   const { isDrawerOpen, openActionCenter } = useActionCenterContext()
   const toast = useNotificationToast({ duration: isDrawerOpen ? 5000 : null })
   const actions = useAppSelector(actionSlice.selectors.selectActionsById)
@@ -93,15 +118,30 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
 
   useEffect(() => {
+    console.log('🔴 REPRO DEBUG: COMPLETE useEffect triggered')
+    console.log(
+      '🔴 REPRO DEBUG: rewardDistributionsByTxId keys:',
+      Object.keys(rewardDistributionsByTxId),
+    )
+    console.log('🔴 REPRO DEBUG: Current actions in store:', Object.keys(actions).length, 'actions')
+
     const now = Date.now()
 
-    Object.entries(rewardDistributionsByTxId).forEach(([_, distribution]) => {
+    Object.entries(rewardDistributionsByTxId).forEach(([txId, distribution]) => {
       if (!distribution) return
 
       if (distribution.status === 'complete' && distribution.txId) {
         const actionId = `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`
 
-        if (!actions[actionId]) return
+        console.log(`🔴 REPRO DEBUG: Processing COMPLETE distribution ${actionId}`)
+        console.log(`🔴 REPRO DEBUG: Action exists in store:`, !!actions[actionId])
+
+        if (!actions[actionId]) {
+          console.log(`🔴 REPRO DEBUG: COMPLETE action ${actionId} doesn't exist, skipping`)
+          return
+        }
+
+        console.log(`🔴 REPRO DEBUG: Dispatching COMPLETE action ${actionId}`)
         dispatch(
           actionSlice.actions.upsertAction({
             id: actionId,

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -109,7 +109,8 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
       if (distribution.status === 'complete' && distribution.txId) {
         const actionId = `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`
 
-        if (!actions[actionId]) return
+        const existingAction = actions[actionId]
+        if (!existingAction) return
 
         if (existingAction.status === ActionStatus.Complete) {
           return

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -18,7 +18,15 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   )
   const dispatch = useAppDispatch()
   const { isDrawerOpen, openActionCenter } = useActionCenterContext()
-  const toast = useNotificationToast({ duration: isDrawerOpen ? 5000 : null })
+
+  const toastOptions = useMemo(
+    () => ({
+      duration: isDrawerOpen ? 5000 : null,
+    }),
+    [isDrawerOpen],
+  )
+  const toast = useNotificationToast(toastOptions)
+
   const actions = useAppSelector(actionSlice.selectors.selectActionsById)
   const stakingAssetAccountAddresses = useMemo(
     () => stakingAssetAccountIds.map(accountId => fromAccountId(accountId).account),

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -98,7 +98,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         }
       }
     })
-  }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
+  }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
 
   useEffect(() => {
     const now = Date.now()
@@ -150,5 +150,5 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         }
       }
     })
-  }, [rewardDistributionsByTxId, dispatch, toast, isDrawerOpen, openActionCenter, actions])
+  }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
 }

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -46,7 +46,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
       acc[rewardDistribution.txId || rewardDistribution.stakingContract] = rewardDistribution
       return acc
     }, {})
-  }, [lifetimeRewardDistributionsQuery])
+  }, [lifetimeRewardDistributionsQuery.data])
 
   useEffect(() => {
     const now = Date.now()


### PR DESCRIPTION
## Description

Fixes current app crash caused by `useRfoxRewardDistributionActionSubscriber()`.
The reason why this bug happened right around rewards distribution is precisely that, the fact that rewards distribution fixed it.
Nuking your state would fix it, as you would start from a complete rewards distribution state, vs. having a previous state with initiated, but not complete distributions being a rug. 

This PR reads like a recipe. While there is not many lines changed here, please make sure to read each commit separately.

- https://github.com/shapeshift/web/pull/10556/commits/6bbf3c27c9f3227f94d18da2deef8fe9e44f2cc2: as the title says, paranoia doesn't hurt. Ensures action center context value is memoized, as well as the value we pass to `useToast()` in our `useNotificationToast()` wrapper. Memo all the things baby!
- https://github.com/shapeshift/web/pull/10556/commits/2d2a879905d860045fc0df464c23aa8a872602aa: this one may or may not be an issue, but it can definitely cause some, depending on what we're doing/reacting on, and doesn't hurt to have, unless we explicitly need to react on the whole query object (including timestamp etc). Rationale being, we only need `status` and `currentData` so let's just use that as deps.
- https://github.com/shapeshift/web/pull/10556/commits/b009d44f200f8b29539c3b26aa9a77fb8564f1b4: more "memo all the things" paranoia. Ensures we pass a memoized object to `useNotificationToast()` in offending subscriber hook
- https://github.com/shapeshift/web/pull/10556/commits/2c0f6ab9cdcd3b7fa9baa7ea88417ce2e53ec2cd: same exact rationale as not reacting on more than we need
- https://github.com/shapeshift/web/pull/10556/commits/dccd7733e99f5e183357614e8ad31454cb2fb431: ensure we don't pass more deps than necessary - should've been caught by `exhaustive-deps` lint rule but wasn't 
- note, all until now didn't fix anything, but lead to this. https://github.com/shapeshift/web/pull/10556/commits/297c5730336a4ee344d787aacf515c7276cb7505 is the actual fix. We were having an infinite loop of react on action -> dispatch -> react on dispatched action since `actions` value changed referentially. The fix was actually super simple once you got to it: if an action is already complete, it's still complete and is not going to be complete-er. Early bail, and fix the infinite loop 🎉 
- https://github.com/shapeshift/web/pull/10556/commits/189a3fba66d768791a447186c941971cfb9d9a8a: disregard this one, just a rug in picking hunks 
- https://github.com/shapeshift/web/pull/10556/commits/45ff21b47f222297fe1439a5ccb6adaaa540b0fa reverts all changes preparing for monkey-patch 
- https://github.com/shapeshift/web/pull/10556/commits/16b902cbdda2495fab941e30b03cdf18f532dbb9 introduces a monkey-patch that will introduce this state whether you're in a buggy state atm or not 
- https://github.com/shapeshift/web/pull/10556/commits/73b9202153494593a70f3ab9ce7f5f6d2e76ff58 reverts said monkey patches
- https://github.com/shapeshift/web/pull/10556/commits/97a9fa7c23b8715b4492fac8c85ca775289c5c2e reverts fixes back

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10557

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Test this PR as-is. Notice no crash (which, if your state is "sane", should be the same as develop for you)
- checkout https://github.com/shapeshift/web/commit/16b902cbdda2495fab941e30b03cdf18f532dbb9 - notice you're now seeing this bug.  ⚠️ note: you may or may not have to tweak that monkey patch to match your own (`rewardsAddress`, namely, as well as the `distribution.rewardAddress` part of the `reward-distribution-13-0xaC2a4fD70BCD8Bab0662960455c363735f0e2b56-thor125dwsa39yeylqc7pn59l079dur502nsleyrgup`  mock consisting of `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`) 
- not explicitly required, but you most likely will also see this bug if you checkout develop *after* trying the monkey-patch of bad state above 
- revert back to the latest commit of this PR (97a9fa7c23b8715b4492fac8c85ca775289c5c2e) or 189a3fba66d768791a447186c941971cfb9d9a8a before reverts, same thing - notice how the bug is now gone again

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

Tested on 3000 (rugged state) and 3001 (initially not rugged state, but becoming rugged after the monkey-patch).

- this PR 

https://jam.dev/c/66e3e5f6-36f7-404f-9ebc-bacb804c0eea

- monkey patch bad state

https://jam.dev/c/c5c8c524-5d7c-492c-a2bc-d1f110f91847

- develop (now encountering it in both, since I got bad state in both)

https://jam.dev/c/15429f19-11fe-4166-9a08-81c8040ec363

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing features added.

- Bug Fixes
  - Improved reliability of reward distribution updates to prevent duplicate or missed actions and toasts.
  - Prevented unnecessary effect triggers when opening/closing the drawer.

- Performance
  - Reduced unnecessary re-renders by memoizing context values and toast options.
  - Optimized computations by refining memo dependencies to react only to relevant data changes.

- Refactor
  - Streamlined action handling logic for pending and completed states for clearer, more predictable behavior.
  - Standardized toast configuration for consistent notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->