### PR TITLE
wip: ledger read-only full wire-up

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -550,6 +550,8 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
 
       if (input.pubKey) return input.pubKey
 
+      if (!wallet) throw new Error('wallet is required')
+
       this.assertSupportsChain(wallet)
       await verifyLedgerAppOpen(this.chainId, wallet)
 

--- a/packages/chain-adapters/src/types.ts
+++ b/packages/chain-adapters/src/types.ts
@@ -267,7 +267,7 @@ export interface TxHistoryInput {
 }
 
 export type GetAddressInputBase = {
-  wallet: HDWallet
+  wallet: HDWallet | null
   accountNumber: number
   isChange?: boolean
   addressIndex?: number

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1780,7 +1780,8 @@
         "pairExistingDeviceBody": "Connecting a different Ledger device? Click 'Pair new device' to start fresh."
       },
       "failure": {
-        "body": "Unable to connect Ledger wallet"
+        "header": "Can't connect to Ledger",
+        "body": "We were not able to detect your ledger, but you can connect in read only mode."
       },
       "readOnly": {
         "button": "Connect as Read Only"

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -12,6 +12,8 @@ import { SwapIcon } from '@/components/Icons/SwapIcon'
 import { FiatRampAction } from '@/components/Modals/FiatRamps/FiatRampsCommon'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from '@/context/WalletProvider/actions'
+import { KeyManager } from '@/context/WalletProvider/KeyManager'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from '@/hooks/useModal/useModal'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
@@ -19,6 +21,7 @@ import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from '@/lib/mixpanel/types'
 import { vibrate } from '@/lib/vibrate'
 import { selectSupportsFiatRampByAssetId } from '@/state/apis/fiatRamps/selectors'
+import { selectWalletType } from '@/state/slices/localWalletSlice/selectors'
 import { selectAssetById } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -79,6 +82,9 @@ export const AssetActions: React.FC<AssetActionProps> = ({
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
   const filter = useMemo(() => ({ assetId }), [assetId])
   const assetSupportsBuy = useAppSelector(s => selectSupportsFiatRampByAssetId(s, filter))
+  const isLedgerReadOnlyEnabled = useFeatureFlag('LedgerReadOnly')
+  const walletType = useAppSelector(selectWalletType)
+  const isLedgerReadOnly = isLedgerReadOnlyEnabled && walletType === KeyManager.Ledger
 
   useEffect(() => {
     const isValid = chainAdapterManager.has(asset.chainId)
@@ -237,14 +243,14 @@ export const AssetActions: React.FC<AssetActionProps> = ({
           onClick={handleSendClick}
           leftIcon={arrowUpIcon}
           width={buttonWidthProps}
-          isDisabled={!hasValidBalance || !isValidChainId || isNft(assetId)}
+          isDisabled={!hasValidBalance || !isValidChainId || isNft(assetId) || (!isConnected && !isLedgerReadOnly)}
           data-test='asset-action-send'
           flex={buttonFlexProps}
         >
           {translate('common.send')}
         </Button>
         <Button
-          disabled={!isValidChainId}
+          disabled={!isValidChainId || (!isConnected && !isLedgerReadOnly)}
           onClick={handleReceiveClick}
           leftIcon={arrowDownIcon}
           width={buttonWidthProps}

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -12,8 +12,6 @@ import { SwapIcon } from '@/components/Icons/SwapIcon'
 import { FiatRampAction } from '@/components/Modals/FiatRamps/FiatRampsCommon'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from '@/context/WalletProvider/actions'
-import { KeyManager } from '@/context/WalletProvider/KeyManager'
-import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from '@/hooks/useModal/useModal'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
@@ -21,7 +19,6 @@ import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from '@/lib/mixpanel/types'
 import { vibrate } from '@/lib/vibrate'
 import { selectSupportsFiatRampByAssetId } from '@/state/apis/fiatRamps/selectors'
-import { selectWalletType } from '@/state/slices/localWalletSlice/selectors'
 import { selectAssetById } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -82,9 +79,6 @@ export const AssetActions: React.FC<AssetActionProps> = ({
   if (!asset) throw new Error(`Asset not found for AssetId ${assetId}`)
   const filter = useMemo(() => ({ assetId }), [assetId])
   const assetSupportsBuy = useAppSelector(s => selectSupportsFiatRampByAssetId(s, filter))
-  const isLedgerReadOnlyEnabled = useFeatureFlag('LedgerReadOnly')
-  const walletType = useAppSelector(selectWalletType)
-  const isLedgerReadOnly = isLedgerReadOnlyEnabled && walletType === KeyManager.Ledger
 
   useEffect(() => {
     const isValid = chainAdapterManager.has(asset.chainId)
@@ -243,14 +237,14 @@ export const AssetActions: React.FC<AssetActionProps> = ({
           onClick={handleSendClick}
           leftIcon={arrowUpIcon}
           width={buttonWidthProps}
-          isDisabled={!hasValidBalance || !isValidChainId || isNft(assetId) || (!isConnected && !isLedgerReadOnly)}
+          isDisabled={!hasValidBalance || !isValidChainId || isNft(assetId)}
           data-test='asset-action-send'
           flex={buttonFlexProps}
         >
           {translate('common.send')}
         </Button>
         <Button
-          disabled={!isValidChainId || (!isConnected && !isLedgerReadOnly)}
+          disabled={!isValidChainId}
           onClick={handleReceiveClick}
           leftIcon={arrowDownIcon}
           width={buttonWidthProps}

--- a/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/hooks/useReceiveAddress.tsx
@@ -21,7 +21,9 @@ export const getReceiveAddress = async ({
   const { chainId } = fromAssetId(asset.assetId)
   const { accountType, bip44Params } = accountMetadata
   const chainAdapter = getChainAdapterManager().get(chainId)
-  if (!(chainAdapter && wallet)) return
+  if (!chainAdapter) return
+  if (!(wallet || pubKey)) return
+
   const { accountNumber } = bip44Params
   const address = await chainAdapter.getAddress({ wallet, accountNumber, accountType, pubKey })
   return address

--- a/src/components/MultiHopTrade/types.ts
+++ b/src/components/MultiHopTrade/types.ts
@@ -10,7 +10,7 @@ export enum TradeRoutePaths {
 
 export type GetReceiveAddressArgs = {
   asset: Asset
-  wallet: HDWallet
+  wallet: HDWallet | null
   deviceId: string
   accountMetadata: AccountMetadata
   pubKey?: string

--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -16,6 +16,7 @@ import { LanguageTypeEnum } from '@/constants/LanguageTypeEnum'
 import { usePlugins } from '@/context/PluginProvider/PluginProvider'
 import { useActionCenterSubscribers } from '@/hooks/useActionCenterSubscribers/useActionCenterSubscribers'
 import { useIsSnapInstalled } from '@/hooks/useIsSnapInstalled/useIsSnapInstalled'
+import { useLedgerDisconnectionHandler } from '@/hooks/useLedgerDisconnectionHandler'
 import { useMixpanelPortfolioTracking } from '@/hooks/useMixpanelPortfolioTracking/useMixpanelPortfolioTracking'
 import { useModal } from '@/hooks/useModal/useModal'
 import { useRouteAssetId } from '@/hooks/useRouteAssetId/useRouteAssetId'
@@ -69,6 +70,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   useTransactionsSubscriber()
   useActionCenterSubscribers()
   useSnapStatusHandler()
+  useLedgerDisconnectionHandler()
 
   useEffect(() => {
     const handleLedgerOpenApp = ({ chainId, reject }: LedgerOpenAppEventArgs) => {

--- a/src/context/WalletProvider/NewWalletViews/components/LedgerFailureBody.tsx
+++ b/src/context/WalletProvider/NewWalletViews/components/LedgerFailureBody.tsx
@@ -1,0 +1,31 @@
+import { Button, Flex } from '@chakra-ui/react'
+import type { ReactNode } from 'react'
+
+import { Text } from '@/components/Text'
+
+type LedgerFailureBodyProps = {
+  icon: ReactNode
+  onConnectReadOnly: () => void
+}
+
+export const LedgerFailureBody = ({ icon, onConnectReadOnly }: LedgerFailureBodyProps) => {
+  return (
+    <Flex direction='column' alignItems='center' justifyContent='center' height='full' gap={6}>
+      {icon}
+      <Text fontSize='xl' translation='walletProvider.ledger.failure.header' />
+      <Text 
+        color='gray.500' 
+        translation='walletProvider.ledger.failure.body' 
+        textAlign='center' 
+      />
+      <Button
+        maxW='200px'
+        width='100%'
+        colorScheme='blue'
+        onClick={onConnectReadOnly}
+      >
+        <Text translation='walletProvider.ledger.readOnly.button' />
+      </Button>
+    </Flex>
+  )
+}

--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -34,7 +34,6 @@ import { getWallet } from '@/context/WalletProvider/MobileWallet/mobileMessageHa
 import { KeepKeyRoutes } from '@/context/WalletProvider/routes'
 import { useWalletConnectV2EventHandler } from '@/context/WalletProvider/WalletConnectV2/useWalletConnectV2EventHandler'
 import { METAMASK_RDNS, useMipdProviders } from '@/lib/mipd'
-import { sleep } from '@/lib/poll/poll'
 import { localWalletSlice } from '@/state/slices/localWalletSlice/localWalletSlice'
 
 // Global lock to prevent concurrent Ledger USB operations

--- a/src/hooks/useLedgerDisconnectionHandler/index.ts
+++ b/src/hooks/useLedgerDisconnectionHandler/index.ts
@@ -1,0 +1,1 @@
+export { useLedgerDisconnectionHandler } from './useLedgerDisconnectionHandler'

--- a/src/hooks/useLedgerDisconnectionHandler/useLedgerDisconnectionHandler.ts
+++ b/src/hooks/useLedgerDisconnectionHandler/useLedgerDisconnectionHandler.ts
@@ -1,0 +1,46 @@
+import { useEffect } from 'react'
+
+import { WalletActions } from '@/context/WalletProvider/actions'
+import { KeyManager } from '@/context/WalletProvider/KeyManager'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
+import { useUSBDeviceTracking } from '@/hooks/useUSBDeviceTracking'
+import { useWallet } from '@/hooks/useWallet/useWallet'
+
+export const useLedgerDisconnectionHandler = () => {
+  const { dispatch, state } = useWallet()
+  const isLedgerReadOnlyEnabled = useFeatureFlag('LedgerReadOnly')
+  
+  // Track USB device connections
+  const { isDisconnected: isUSBDisconnected } = useUSBDeviceTracking(isLedgerReadOnlyEnabled)
+  
+  // Handle Ledger disconnection
+  useEffect(() => {
+    if (!isLedgerReadOnlyEnabled) return
+    
+    // Check if current wallet is a Ledger and USB device was disconnected
+    const isCurrentWalletLedger = state.connectedType === KeyManager.Ledger
+    const isWalletConnected = state.isConnected
+    const hasWallet = !!state.wallet
+    
+    console.log('LedgerDisconnectionHandler: State change', {
+      isCurrentWalletLedger,
+      isWalletConnected,
+      hasWallet,
+      isUSBDisconnected,
+      connectedType: state.connectedType
+    })
+    
+    // Only disconnect wallet if:
+    // 1. Current wallet is Ledger
+    // 2. Wallet is currently connected
+    // 3. We have a wallet instance
+    // 4. USB device was disconnected
+    if (isCurrentWalletLedger && isWalletConnected && hasWallet && isUSBDisconnected) {
+      console.log('LedgerDisconnectionHandler: Ledger USB device disconnected, setting wallet as disconnected')
+      dispatch({
+        type: WalletActions.SET_IS_CONNECTED,
+        payload: false,
+      })
+    }
+  }, [isUSBDisconnected, state.connectedType, state.isConnected, state.wallet, dispatch, isLedgerReadOnlyEnabled])
+}

--- a/src/hooks/useUSBDeviceTracking/index.ts
+++ b/src/hooks/useUSBDeviceTracking/index.ts
@@ -1,0 +1,1 @@
+export { useUSBDeviceTracking } from './useUSBDeviceTracking'

--- a/src/hooks/useUSBDeviceTracking/useUSBDeviceTracking.ts
+++ b/src/hooks/useUSBDeviceTracking/useUSBDeviceTracking.ts
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+
+const LEDGER_VENDOR_ID = 0x2c97
+
+type USBDeviceState = 'connected' | 'disconnected' | 'unknown'
+
+export const useUSBDeviceTracking = (enabled: boolean = true) => {
+  const [deviceState, setDeviceState] = useState<USBDeviceState>('unknown')
+
+  useEffect(() => {
+    if (!enabled || !navigator.usb) return
+
+    const handleConnect = (event: USBConnectionEvent) => {
+      if (event.device.vendorId === LEDGER_VENDOR_ID) {
+        console.log('USB: Ledger device connected', {
+          vendorId: event.device.vendorId,
+          productId: event.device.productId,
+          productName: event.device.productName,
+          manufacturerName: event.device.manufacturerName
+        })
+        setDeviceState('connected')
+      }
+    }
+
+    const handleDisconnect = (event: USBConnectionEvent) => {
+      if (event.device.vendorId === LEDGER_VENDOR_ID) {
+        console.log('USB: Ledger device disconnected', {
+          vendorId: event.device.vendorId,
+          productId: event.device.productId,
+          productName: event.device.productName,
+          manufacturerName: event.device.manufacturerName
+        })
+        setDeviceState('disconnected')
+      }
+    }
+
+    // Add event listeners
+    navigator.usb.addEventListener('connect', handleConnect)
+    navigator.usb.addEventListener('disconnect', handleDisconnect)
+
+    // Check initial state
+    const checkInitialState = async () => {
+      try {
+        const devices = await navigator.usb.getDevices()
+        const ledgerDevices = devices.filter(device => device.vendorId === LEDGER_VENDOR_ID)
+        const hasLedger = ledgerDevices.length > 0
+        
+        console.log('USB: Initial device check', {
+          totalDevices: devices.length,
+          ledgerDevicesCount: ledgerDevices.length,
+          hasLedger,
+          ledgerDevices: ledgerDevices.map(d => ({
+            vendorId: d.vendorId,
+            productId: d.productId,
+            productName: d.productName,
+            manufacturerName: d.manufacturerName
+          }))
+        })
+        
+        setDeviceState(hasLedger ? 'connected' : 'disconnected')
+      } catch (error) {
+        // getDevices() may fail if no permissions granted
+        console.log('USB: Initial device check failed', error)
+        setDeviceState('unknown')
+      }
+    }
+
+    checkInitialState()
+
+    // Cleanup
+    return () => {
+      navigator.usb.removeEventListener('connect', handleConnect)
+      navigator.usb.removeEventListener('disconnect', handleDisconnect)
+    }
+  }, [enabled])
+
+  return {
+    deviceState,
+    isConnected: deviceState === 'connected',
+    isDisconnected: deviceState === 'disconnected',
+    isUnknown: deviceState === 'unknown',
+  }
+}

--- a/src/pages/Dashboard/Dashboard.tsx
+++ b/src/pages/Dashboard/Dashboard.tsx
@@ -14,7 +14,11 @@ import { Main } from '@/components/Layout/Main'
 import { SEO } from '@/components/Layout/Seo'
 import { RawText } from '@/components/Text'
 import { WalletActions } from '@/context/WalletProvider/actions'
+import { KeyManager } from '@/context/WalletProvider/KeyManager'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from '@/hooks/useWallet/useWallet'
+import { selectWalletType } from '@/state/slices/localWalletSlice/selectors'
+import { useAppSelector } from '@/state/store'
 import { Accounts } from '@/pages/Accounts/Accounts'
 import { TransactionHistory } from '@/pages/TransactionHistory/TransactionHistory'
 
@@ -118,13 +122,16 @@ export const Dashboard = memo(() => {
     dispatch: walletDispatch,
     state: { isLoadingLocalWallet, isConnected },
   } = useWallet()
+  const isLedgerReadOnlyEnabled = useFeatureFlag('LedgerReadOnly')
+  const walletType = useAppSelector(selectWalletType)
 
   useEffect(() => {
     if (isLoadingLocalWallet) return
     if (isConnected) return
+    if (isLedgerReadOnlyEnabled && walletType === KeyManager.Ledger) return
 
     walletDispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })
-  }, [isLoadingLocalWallet, isConnected, walletDispatch])
+  }, [isLoadingLocalWallet, isConnected, isLedgerReadOnlyEnabled, walletType, walletDispatch])
 
   const mobileHome = useMemo(() => <MobileHome />, [])
   const mobileEarn = useMemo(() => <ScrollView>{earnDashboard}</ScrollView>, [])

--- a/src/pages/Dashboard/components/DashboardHeader/DashboardHeaderTop.tsx
+++ b/src/pages/Dashboard/components/DashboardHeader/DashboardHeaderTop.tsx
@@ -17,12 +17,15 @@ import { SwapIcon } from '@/components/Icons/SwapIcon'
 import { FiatRampAction } from '@/components/Modals/FiatRamps/FiatRampsCommon'
 import { TradeRoutePaths } from '@/components/MultiHopTrade/types'
 import { WalletBalanceChange } from '@/components/WalletBalanceChange/WalletBalanceChange'
+import { KeyManager } from '@/context/WalletProvider/KeyManager'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from '@/hooks/useModal/useModal'
 import { useRouteAccountId } from '@/hooks/useRouteAccountId/useRouteAccountId'
 import { useRouteAssetId } from '@/hooks/useRouteAssetId/useRouteAssetId'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { getMixPanel } from '@/lib/mixpanel/mixPanelSingleton'
 import { MixPanelEvent } from '@/lib/mixpanel/types'
+import { selectWalletType } from '@/state/slices/localWalletSlice/selectors'
 import { selectAssetById } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -110,6 +113,9 @@ export const DashboardHeaderTop = memo(() => {
   const assetId = useRouteAssetId()
   const accountId = useRouteAccountId()
   const asset = useAppSelector(state => selectAssetById(state, assetId ?? ''))
+  const isLedgerReadOnlyEnabled = useFeatureFlag('LedgerReadOnly')
+  const walletType = useAppSelector(selectWalletType)
+  const isLedgerReadOnly = isLedgerReadOnlyEnabled && walletType === KeyManager.Ledger
 
   const navigate = useNavigate()
   const send = useModal('send')
@@ -163,23 +169,23 @@ export const DashboardHeaderTop = memo(() => {
           icon={buyIcon}
           label={translate('fiatRamps.buy')}
           onClick={handleBuyClick}
-          isDisabled={!isConnected}
+          isDisabled={!isConnected && !isLedgerReadOnly}
         />
         <MobileActionButton
           icon={sendIcon}
           label={translate('common.send')}
           onClick={handleSendClick}
-          isDisabled={!isConnected}
+          isDisabled={!isConnected && !isLedgerReadOnly}
         />
         <MobileActionButton
           icon={receiveIcon}
           label={translate('common.receive')}
           onClick={handleReceiveClick}
-          isDisabled={!isConnected}
+          isDisabled={!isConnected && !isLedgerReadOnly}
         />
       </Flex>
     ),
-    [handleTradeClick, handleBuyClick, handleSendClick, handleReceiveClick, isConnected, translate],
+    [handleTradeClick, handleBuyClick, handleSendClick, handleReceiveClick, isConnected, isLedgerReadOnly, translate],
   )
 
   const desktopButtons = useMemo(
@@ -191,13 +197,13 @@ export const DashboardHeaderTop = memo(() => {
         justifyContent={'center'}
         display={desktopButtonGroupDisplay}
       >
-        <Button isDisabled={!isConnected} onClick={handleQrCodeClick} leftIcon={qrCodeIcon}>
+        <Button isDisabled={!isConnected && !isLedgerReadOnly} onClick={handleQrCodeClick} leftIcon={qrCodeIcon}>
           {translate('modals.send.qrCode')}
         </Button>
-        <Button isDisabled={!isConnected} onClick={handleSendClick} leftIcon={arrowUpIcon}>
+        <Button isDisabled={!isConnected && !isLedgerReadOnly} onClick={handleSendClick} leftIcon={arrowUpIcon}>
           {translate('common.send')}
         </Button>
-        <Button isDisabled={!isConnected} onClick={handleReceiveClick} leftIcon={arrowDownIcon}>
+        <Button isDisabled={!isConnected && !isLedgerReadOnly} onClick={handleReceiveClick} leftIcon={arrowDownIcon}>
           {translate('common.receive')}
         </Button>
         <Button onClick={handleTradeClick} leftIcon={ioSwapVerticalSharpIcon}>
@@ -211,6 +217,7 @@ export const DashboardHeaderTop = memo(() => {
       handleReceiveClick,
       handleTradeClick,
       isConnected,
+      isLedgerReadOnly,
       translate,
     ],
   )


### PR DESCRIPTION
## Description

TODO:

- [ ] vibe 
- [ ] handle WebUSB race conditions 
- [ ] handle Ledger disconnections in WalletManager 
- [ ] handle Ledger disconnections groundwork in app (i.e SET_IS_CONNECTED false)
- [ ] handle every single place where disconnected state isn't properly handled 
  - [ ] top buttons in wallet page on desktop
  - [ ] don't hide asset page buttons
  - [ ] swapper: should we keep "Connect Wallet" at quote time or let users progress further in the flow? 
  - [ ] wat do with verify in receive info? disable it with tooltip? should we add a message somewhere to tell users this address is *not* verified and they probably should connect their wallet?
  - [ ] should we let users progress further than "No Wallet connected", remove this condition, and prompt for connection on sends? 
  - [ ] should we let users pick accounts in fiat ramps vs. "Connect Wallet" atm?
  - [ ] should we let users progress further in /fox-ecosystem and don't just open the "Connect Wallet" modal but block them further? 
  - [ ] should we let users progress further in TCY page? 
  - [ ] should we let users progress further in pools page?
  - [ ] should we let users progress further in lending page?

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/9017

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

High fosho.

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

TODO

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
