### PR TITLE
fix: redirect to buy/sell page instead of modal on asset page

### DIFF
--- a/src/Routes/RoutesCommon.tsx
+++ b/src/Routes/RoutesCommon.tsx
@@ -260,20 +260,6 @@ export const routes: Route[] = [
         main: Ramp,
         hide: true,
       },
-      ...assetIdPaths.flatMap(assetIdPath => [
-        {
-          path: `/ramp/buy${assetIdPath}`,
-          label: 'fiatRamps.buy',
-          main: Ramp,
-          hide: true,
-        },
-        {
-          path: `/ramp/sell${assetIdPath}`,
-          label: 'fiatRamps.sell',
-          main: Ramp,
-          hide: true,
-        },
-      ]),
     ],
   },
   {

--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -9,7 +9,6 @@ import { useTranslate } from 'react-polyglot'
 import { useNavigate } from 'react-router-dom'
 
 import { SwapIcon } from '@/components/Icons/SwapIcon'
-import { FiatRampAction } from '@/components/Modals/FiatRamps/FiatRampsCommon'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { WalletActions } from '@/context/WalletProvider/actions'
 import { useModal } from '@/hooks/useModal/useModal'
@@ -67,7 +66,6 @@ export const AssetActions: React.FC<AssetActionProps> = ({
   const chainAdapterManager = getChainAdapterManager()
   const send = useModal('send')
   const receive = useModal('receive')
-  const fiatRamps = useModal('fiatRamps')
   const assetActionsDrawer = useModal('assetActionsDrawer')
   const translate = useTranslate()
   const mixpanel = getMixPanel()
@@ -107,12 +105,9 @@ export const AssetActions: React.FC<AssetActionProps> = ({
 
   const handleBuySellClick = useCallback(() => {
     vibrate('heavy')
-    fiatRamps.open({
-      assetId: assetSupportsBuy ? assetId : ethAssetId,
-      fiatRampAction: FiatRampAction.Buy,
-      accountId,
-    })
-  }, [accountId, assetId, assetSupportsBuy, fiatRamps])
+    const targetAssetId = assetSupportsBuy ? assetId : ethAssetId
+    navigate(`/ramp/buy?defaultAsset=${encodeURIComponent(targetAssetId)}`)
+  }, [assetId, assetSupportsBuy, navigate])
 
   const handleTradeClick = useCallback(() => {
     vibrate('heavy')

--- a/src/components/Modals/FiatRamps/views/FiatForm.tsx
+++ b/src/components/Modals/FiatRamps/views/FiatForm.tsx
@@ -40,7 +40,7 @@ export const FiatForm: React.FC<FiatFormProps> = ({
   const sortedAssets = useSelector(selectAssetsSortedByMarketCapUserCurrencyBalanceAndName)
   const [accountId, setAccountId] = useState<AccountId | undefined>(selectedAccountId)
   const [addressByAccountId, setAddressByAccountId] = useState<AddressesByAccountId>()
-  const [selectedAssetId, setSelectedAssetId] = useState<AssetId>()
+  const [selectedAssetId, setSelectedAssetId] = useState<AssetId | undefined>()
 
   const defaultAsset = useAppSelector(selectHighestMarketCapFeeAsset)
 

--- a/src/pages/Ramp/Ramp.tsx
+++ b/src/pages/Ramp/Ramp.tsx
@@ -1,8 +1,8 @@
 import { Box, Card, Flex } from '@chakra-ui/react'
 import type { AssetId } from '@shapeshiftoss/caip'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom'
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom'
 
 import { PageContainer } from '../Buy/components/PageContainer'
 import { TopAssets } from '../Buy/TopAssets'
@@ -14,12 +14,12 @@ import { FiatForm } from '@/components/Modals/FiatRamps/views/FiatForm'
 import { cardstyles } from '@/components/MultiHopTrade/const'
 import { RawText, Text } from '@/components/Text'
 import type { TextPropTypes } from '@/components/Text/Text'
+import { useQuery } from '@/hooks/useQuery/useQuery'
 import { RampTab } from '@/pages/Trade/tabs/RampTab'
 import { useGetFiatRampsQuery } from '@/state/apis/fiatRamps/fiatRamps'
 
-type MatchParams = {
-  chainId?: string
-  assetSubId?: string
+type QueryParams = {
+  defaultAsset?: string
 }
 
 const layoutMainStyle = { paddingInlineStart: 0, paddingInlineEnd: 0 }
@@ -32,8 +32,8 @@ const RampContent: React.FC = () => {
   useGetFiatRampsQuery()
 
   const location = useLocation()
-  const { chainId, assetSubId } = useParams<MatchParams>()
-  const [selectedAssetId, setSelectedAssetId] = useState<AssetId | undefined>()
+  const query = useQuery<QueryParams>()
+  const defaultAssetId = query.defaultAsset as AssetId | undefined
 
   const isSellRoute = location.pathname.startsWith('/ramp/sell')
   const titleKey = isSellRoute ? 'rampPage.sellTitle' : 'rampPage.buyTitle'
@@ -42,13 +42,6 @@ const RampContent: React.FC = () => {
   const translate = useTranslate()
 
   const action = location.pathname.includes('/sell') ? FiatRampAction.Sell : FiatRampAction.Buy
-
-  useEffect(() => {
-    // Auto select asset when passed in via params
-    if (chainId && assetSubId) {
-      setSelectedAssetId(`${chainId}/${assetSubId}`)
-    }
-  }, [assetSubId, chainId])
 
   const titleTransaltionsComponents: TextPropTypes['components'] = useMemo(
     () => ({
@@ -94,7 +87,7 @@ const RampContent: React.FC = () => {
             </Flex>
             <Box flexBasis='400px' textAlign='left'>
               <Card mx={cardMxOffsetBase} {...cardstyles}>
-                <FiatForm assetId={selectedAssetId} fiatRampAction={action} />
+                <FiatForm assetId={defaultAssetId} fiatRampAction={action} />
               </Card>
             </Box>
           </Flex>


### PR DESCRIPTION
## Description

This modifies the buy/sell button on the asset page to instead redirect to the actual buy/sell page with the asset prefilled instead of pop open a modal. The modal was causing issues when you tried to select an asset as it caused a double modal which screws with our focus and scrolling.

### Dev notes

The existing routing system like `/buy/:assetId` didn't seem to be working properly. For example in prod you'd expect this to take you to ethereum selected https://app.shapeshift.com/#/ramp/buy/eip155:1/slip44:60.

Seems to be due to some route matching weirdness so i've just pivoted it to a simple encoded param

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10640 

## Risk

Low risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that selecting an asset on the buy/sell page works normally
* Test that clicking buy/sell on an asset page redirects to buy/sell page instead of opening a modal

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/c1ef796d-25d5-4401-aad4-6bee65606b53
