### PR TITLE
fix: switch settings modal to dialog

### DIFF
--- a/src/components/Modals/Settings/ClearCache.tsx
+++ b/src/components/Modals/Settings/ClearCache.tsx
@@ -1,15 +1,5 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
-import {
-  Box,
-  Button,
-  Flex,
-  Icon,
-  IconButton,
-  ModalBody,
-  ModalHeader,
-  Stack,
-  Tooltip,
-} from '@chakra-ui/react'
+import { Box, Button, Flex, Icon, IconButton, Stack, Tooltip } from '@chakra-ui/react'
 import { useCallback, useMemo } from 'react'
 import { FaInfoCircle } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
@@ -17,6 +7,12 @@ import { useNavigate } from 'react-router-dom'
 
 import type { MaybeDrawerProps } from './SettingsCommon'
 
+import { DialogBody } from '@/components/Modal/components/DialogBody'
+import {
+  DialogHeader,
+  DialogHeaderLeft,
+  DialogHeaderMiddle,
+} from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
 import { RawText } from '@/components/Text'
 import { reloadWebview } from '@/context/WalletProvider/MobileWallet/mobileMessageHandlers'
@@ -125,21 +121,25 @@ export const ClearCache = ({ isDrawer = false }: MaybeDrawerProps) => {
 
   return (
     <SlideTransition>
-      <IconButton
-        variant='ghost'
-        icon={arrowBackIcon}
-        aria-label={translate('common.back')}
-        position='absolute'
-        top={2}
-        left={3}
-        fontSize='xl'
-        size='sm'
-        isRound
-        onClick={goBack}
-      />
-      <ModalHeader textAlign='center'>{translate('modals.settings.clearCache')}</ModalHeader>
+      <DialogHeader textAlign='center'>
+        <DialogHeaderLeft>
+          <IconButton
+            variant='ghost'
+            icon={arrowBackIcon}
+            aria-label={translate('common.back')}
+            position='absolute'
+            top={2}
+            left={3}
+            fontSize='xl'
+            size='sm'
+            isRound
+            onClick={goBack}
+          />
+        </DialogHeaderLeft>
+        <DialogHeaderMiddle>{translate('modals.settings.clearCache')}</DialogHeaderMiddle>
+      </DialogHeader>
       <>
-        <ModalBody
+        <DialogBody
           alignItems='center'
           justifyContent='center'
           textAlign='center'
@@ -148,7 +148,7 @@ export const ClearCache = ({ isDrawer = false }: MaybeDrawerProps) => {
           overflowX='hidden'
         >
           {clearButtons}
-        </ModalBody>
+        </DialogBody>
       </>
     </SlideTransition>
   )

--- a/src/components/Modals/Settings/CurrencyFormat.tsx
+++ b/src/components/Modals/Settings/CurrencyFormat.tsx
@@ -1,5 +1,5 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
-import { Button, Flex, Icon, IconButton, ModalBody, ModalHeader, Stack } from '@chakra-ui/react'
+import { Button, Flex, Icon, IconButton, Stack } from '@chakra-ui/react'
 import sortBy from 'lodash/sortBy'
 import { useCallback, useMemo } from 'react'
 import { FaCheck } from 'react-icons/fa'
@@ -9,6 +9,12 @@ import { useNavigate } from 'react-router-dom'
 import type { MaybeDrawerProps } from './SettingsCommon'
 import { currencyFormatsRepresenter } from './SettingsCommon'
 
+import { DialogBody } from '@/components/Modal/components/DialogBody'
+import {
+  DialogHeader,
+  DialogHeaderLeft,
+  DialogHeaderMiddle,
+} from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
 import { RawText } from '@/components/Text'
 import { CurrencyFormats, preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
@@ -75,21 +81,25 @@ export const CurrencyFormat = ({ isDrawer = false }: MaybeDrawerProps) => {
 
   return (
     <SlideTransition>
-      <IconButton
-        variant='ghost'
-        icon={arrowBackIcon}
-        aria-label={translate('common.back')}
-        position='absolute'
-        top={2}
-        left={3}
-        fontSize='xl'
-        size='sm'
-        isRound
-        onClick={handleGoBack}
-      />
-      <ModalHeader textAlign='center'>{translate('modals.settings.currencyFormat')}</ModalHeader>
+      <DialogHeader textAlign='center'>
+        <DialogHeaderLeft>
+          <IconButton
+            variant='ghost'
+            icon={arrowBackIcon}
+            aria-label={translate('common.back')}
+            position='absolute'
+            top={2}
+            left={3}
+            fontSize='xl'
+            size='sm'
+            isRound
+            onClick={handleGoBack}
+          />
+        </DialogHeaderLeft>
+        <DialogHeaderMiddle>{translate('modals.settings.currencyFormat')}</DialogHeaderMiddle>
+      </DialogHeader>
       <>
-        <ModalBody
+        <DialogBody
           alignItems='center'
           justifyContent='center'
           textAlign='center'
@@ -98,7 +108,7 @@ export const CurrencyFormat = ({ isDrawer = false }: MaybeDrawerProps) => {
           overflowX='hidden'
         >
           {formatButtons}
-        </ModalBody>
+        </DialogBody>
       </>
     </SlideTransition>
   )

--- a/src/components/Modals/Settings/FiatCurrencies.tsx
+++ b/src/components/Modals/Settings/FiatCurrencies.tsx
@@ -1,5 +1,5 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
-import { Button, Flex, Icon, IconButton, ModalBody, ModalHeader, Stack } from '@chakra-ui/react'
+import { Button, Flex, Icon, IconButton, Stack } from '@chakra-ui/react'
 import identity from 'lodash/identity'
 import sortBy from 'lodash/sortBy'
 import { useCallback, useMemo } from 'react'
@@ -9,6 +9,12 @@ import { useNavigate } from 'react-router-dom'
 
 import type { MaybeDrawerProps } from './SettingsCommon'
 
+import { DialogBody } from '@/components/Modal/components/DialogBody'
+import {
+  DialogHeader,
+  DialogHeaderLeft,
+  DialogHeaderMiddle,
+} from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
 import { RawText, Text } from '@/components/Text'
 import type { SupportedFiatCurrencies } from '@/lib/market-service'
@@ -80,21 +86,25 @@ export const FiatCurrencies = ({ isDrawer = false }: MaybeDrawerProps) => {
 
   return (
     <SlideTransition>
-      <IconButton
-        variant='ghost'
-        icon={arrowBackIcon}
-        aria-label={translate('common.back')}
-        position='absolute'
-        top={2}
-        left={3}
-        fontSize='xl'
-        size='sm'
-        isRound
-        onClick={handleGoBack}
-      />
-      <ModalHeader textAlign='center'>{translate('modals.settings.currency')}</ModalHeader>
+      <DialogHeader textAlign='center'>
+        <DialogHeaderLeft>
+          <IconButton
+            variant='ghost'
+            icon={arrowBackIcon}
+            aria-label={translate('common.back')}
+            position='absolute'
+            top={2}
+            left={3}
+            fontSize='xl'
+            size='sm'
+            isRound
+            onClick={handleGoBack}
+          />
+        </DialogHeaderLeft>
+        <DialogHeaderMiddle>{translate('modals.settings.currency')}</DialogHeaderMiddle>
+      </DialogHeader>
       <>
-        <ModalBody
+        <DialogBody
           alignItems='center'
           justifyContent='center'
           textAlign='center'
@@ -103,7 +113,7 @@ export const FiatCurrencies = ({ isDrawer = false }: MaybeDrawerProps) => {
           overflowX='hidden'
         >
           {currencyButtons}
-        </ModalBody>
+        </DialogBody>
       </>
     </SlideTransition>
   )

--- a/src/components/Modals/Settings/Languages.tsx
+++ b/src/components/Modals/Settings/Languages.tsx
@@ -1,5 +1,5 @@
 import { ArrowBackIcon } from '@chakra-ui/icons'
-import { Button, Flex, Icon, IconButton, ModalBody, ModalHeader, Stack } from '@chakra-ui/react'
+import { Button, Flex, Icon, IconButton, Stack } from '@chakra-ui/react'
 import { useCallback, useMemo } from 'react'
 import { FaCheck } from 'react-icons/fa'
 import { useTranslate } from 'react-polyglot'
@@ -9,6 +9,12 @@ import type { MaybeDrawerProps } from './SettingsCommon'
 
 import { locales } from '@/assets/translations/constants'
 import { getLocaleLabel } from '@/assets/translations/utils'
+import { DialogBody } from '@/components/Modal/components/DialogBody'
+import {
+  DialogHeader,
+  DialogHeaderLeft,
+  DialogHeaderMiddle,
+} from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
 import { RawText } from '@/components/Text'
 import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
@@ -78,24 +84,28 @@ export const Languages = ({ isDrawer = false }: MaybeDrawerProps) => {
 
   return (
     <SlideTransition>
-      <IconButton
-        variant='ghost'
-        icon={arrowBackIcon}
-        aria-label={translate('common.back')}
-        position='absolute'
-        top={2}
-        left={3}
-        fontSize='xl'
-        size='sm'
-        isRound
-        onClick={handleGoBack}
-      />
-      <ModalHeader textAlign='center'>{translate('modals.settings.language')}</ModalHeader>
+      <DialogHeader textAlign='center'>
+        <DialogHeaderLeft>
+          <IconButton
+            variant='ghost'
+            icon={arrowBackIcon}
+            aria-label={translate('common.back')}
+            position='absolute'
+            top={2}
+            left={3}
+            fontSize='xl'
+            size='sm'
+            isRound
+            onClick={handleGoBack}
+          />
+        </DialogHeaderLeft>
+        <DialogHeaderMiddle>{translate('modals.settings.language')}</DialogHeaderMiddle>
+      </DialogHeader>
       <>
-        <ModalBody alignItems='center' justifyContent='center' textAlign='center'>
+        <DialogBody alignItems='center' justifyContent='center' textAlign='center'>
           {selectedLocaleButton}
           {otherLocaleButtons}
-        </ModalBody>
+        </DialogBody>
       </>
     </SlideTransition>
   )

--- a/src/components/Modals/Settings/Settings.tsx
+++ b/src/components/Modals/Settings/Settings.tsx
@@ -1,10 +1,10 @@
-import { Modal, ModalContent, ModalOverlay } from '@chakra-ui/react'
 import { useEffect } from 'react'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 
 import { SettingsRoutes } from './SettingsCommon'
 import { SettingsRouter } from './SettingsRouter'
 
+import { Dialog } from '@/components/Modal/components/Dialog'
 import { useModal } from '@/hooks/useModal/useModal'
 import type { MobileMessageEvent } from '@/plugins/mobile'
 
@@ -42,14 +42,11 @@ const Settings = () => {
   }, [appHistory, close, isOpen])
 
   return (
-    <Modal isOpen={isOpen} onClose={close} isCentered size='md'>
-      <ModalOverlay />
-      <ModalContent>
-        <MemoryRouter initialEntries={entries} initialIndex={0}>
-          <SettingsRouter />
-        </MemoryRouter>
-      </ModalContent>
-    </Modal>
+    <Dialog isOpen={isOpen} onClose={close}>
+      <MemoryRouter initialEntries={entries} initialIndex={0}>
+        <SettingsRouter />
+      </MemoryRouter>
+    </Dialog>
   )
 }
 

--- a/src/components/Modals/Settings/SettingsList.tsx
+++ b/src/components/Modals/Settings/SettingsList.tsx
@@ -1,10 +1,16 @@
-import { ModalBody, ModalCloseButton, ModalHeader } from '@chakra-ui/react'
 import type { FC } from 'react'
 import { useCallback, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
 
 import { SettingsContent } from './SettingsContent'
 
+import { DialogBody } from '@/components/Modal/components/DialogBody'
+import { DialogCloseButton } from '@/components/Modal/components/DialogCloseButton'
+import {
+  DialogHeader,
+  DialogHeaderMiddle,
+  DialogHeaderRight,
+} from '@/components/Modal/components/DialogHeader'
 import { SlideTransition } from '@/components/SlideTransition'
 import { useBrowserRouter } from '@/hooks/useBrowserRouter/useBrowserRouter'
 import { useModal } from '@/hooks/useModal/useModal'
@@ -31,13 +37,15 @@ export const SettingsList: FC = () => {
 
   return (
     <SlideTransition>
-      <ModalHeader textAlign='center' userSelect='none' onClick={handleHeaderClick}>
-        {translate('modals.settings.settings')}
-      </ModalHeader>
-      <ModalCloseButton />
-      <ModalBody alignItems='center' justifyContent='center' textAlign='center' pt={0} px={0}>
+      <DialogHeader textAlign='center' userSelect='none' onClick={handleHeaderClick}>
+        <DialogHeaderMiddle> {translate('modals.settings.settings')} </DialogHeaderMiddle>
+        <DialogHeaderRight>
+          <DialogCloseButton />
+        </DialogHeaderRight>
+      </DialogHeader>
+      <DialogBody alignItems='center' justifyContent='center' textAlign='center' pt={0} px={0}>
         <SettingsContent />
-      </ModalBody>
+      </DialogBody>
     </SlideTransition>
   )
 }


### PR DESCRIPTION
## Description

Our settings modal isn't sexy at all and doesn't feel native on mobile, let's update it to use our dialog component

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted while using the mobile app

## Risk
Low, usage should be as before
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to open the settings modal on desktop, should be the same thing as before
- Try to open the settings modal on mobile, it should use a sexy dialog that you can close by swiping down
- Try every routes of this modal to ensure everything works as before!

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/9fb446ff-b111-4632-8bc2-a5403246a009