### PR TITLE
fix: rfox staking section

### DIFF
--- a/src/pages/Fox/components/RFOXSimulator.tsx
+++ b/src/pages/Fox/components/RFOXSimulator.tsx
@@ -11,7 +11,7 @@ import { Amount } from '@/components/Amount/Amount'
 import { Text } from '@/components/Text'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
-import { getStakingContract, selectLastEpoch } from '@/pages/RFOX/helpers'
+import { getStakingContract, selectLatestEpoch } from '@/pages/RFOX/helpers'
 import { useEpochHistoryQuery } from '@/pages/RFOX/hooks/useEpochHistoryQuery'
 import { useTotalStakedQuery } from '@/pages/RFOX/hooks/useGetTotalStaked'
 import { selectAssetById, selectUsdRateByAssetId } from '@/state/slices/selectors'
@@ -59,34 +59,35 @@ export const RFOXSimulator = ({ stakingAssetId }: RFOXSimulatorProps) => {
       .toFixed(4)
   }, [totalStakedCryptoResult.data, depositAmount])
 
-  const { data: lastEpoch } = useEpochHistoryQuery({ select: selectLastEpoch })
+  const { data: latestEpoch } = useEpochHistoryQuery({ select: selectLatestEpoch })
 
   const estimatedFoxBurn = useMemo(() => {
-    if (!lastEpoch) return
+    if (!latestEpoch) return
     if (!stakingAsset) return
     if (!stakingAssetUsdPrice) return
 
     return bnOrZero(shapeShiftRevenue)
-      .times(lastEpoch.burnRate)
+      .times(latestEpoch.burnRate)
       .div(stakingAssetUsdPrice)
       .toFixed(0)
-  }, [lastEpoch, shapeShiftRevenue, stakingAssetUsdPrice, stakingAsset])
+  }, [latestEpoch, shapeShiftRevenue, stakingAssetUsdPrice, stakingAsset])
 
   const estimatedRewards = useMemo(() => {
-    if (!lastEpoch) return
+    if (!latestEpoch) return
     if (!poolShare) return
     if (!runeUsdPrice) return
 
     // @TODO: we might not need this optional chain here if the data exists
     const distributionRate =
-      lastEpoch.detailsByStakingContract[getStakingContract(stakingAssetId)]?.distributionRate ?? 0
+      latestEpoch.detailsByStakingContract[getStakingContract(stakingAssetId)]?.distributionRate ??
+      0
 
     return bnOrZero(shapeShiftRevenue)
       .times(distributionRate)
       .times(poolShare)
       .div(runeUsdPrice)
       .toFixed(2)
-  }, [lastEpoch, shapeShiftRevenue, runeUsdPrice, stakingAssetId, poolShare])
+  }, [latestEpoch, shapeShiftRevenue, runeUsdPrice, stakingAssetId, poolShare])
 
   if (!(runeAsset && stakingAsset)) return null
 

--- a/src/pages/RFOX/helpers.ts
+++ b/src/pages/RFOX/helpers.ts
@@ -36,7 +36,7 @@ export const selectStakingBalance = (abiStakingInfo: AbiStakingInfo) => {
 }
 
 export const selectLastEpoch = (data: EpochWithIpfsHash[]): EpochWithIpfsHash | undefined => {
-  return data[data.length - 1]
+  return data[0]
 }
 
 const stakingContractByAssetId = {

--- a/src/pages/RFOX/helpers.ts
+++ b/src/pages/RFOX/helpers.ts
@@ -35,7 +35,7 @@ export const selectStakingBalance = (abiStakingInfo: AbiStakingInfo) => {
   return selectFromStakingInfo('stakingBalance', abiStakingInfo)
 }
 
-export const selectLastEpoch = (data: EpochWithIpfsHash[]): EpochWithIpfsHash | undefined => {
+export const selectLatestEpoch = (data: EpochWithIpfsHash[]): EpochWithIpfsHash | undefined => {
   return data[0]
 }
 

--- a/src/pages/RFOX/hooks/useCurrentApyQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentApyQuery.ts
@@ -48,6 +48,7 @@ export const useCurrentApyQuery = ({ stakingAssetId }: useCurrentApyQueryProps) 
       if (!runeAsset) return
       if (!stakingAsset) return
       if (!totalStakedCryptoCurrencyQuery?.data) return
+      if (!epochs.length) return
 
       const latestEpoch = epochs[0]
 

--- a/src/pages/RFOX/hooks/useCurrentApyQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentApyQuery.ts
@@ -49,9 +49,7 @@ export const useCurrentApyQuery = ({ stakingAssetId }: useCurrentApyQueryProps) 
       if (!stakingAsset) return
       if (!totalStakedCryptoCurrencyQuery?.data) return
 
-      const latestEpoch = epochs.reduce((prev, current) => {
-        return current.number > prev.number ? current : prev
-      })
+      const latestEpoch = epochs[0]
 
       const distributionRate =
         latestEpoch.detailsByStakingContract[getStakingContract(stakingAsset.assetId)]

--- a/src/pages/RFOX/hooks/useCurrentEpochRewardsQuery.ts
+++ b/src/pages/RFOX/hooks/useCurrentEpochRewardsQuery.ts
@@ -51,22 +51,17 @@ export const useCurrentEpochRewardsQuery = ({
         if (!epochHistory || !currentEpochRewardUnits || !affiliateRevenue || !currentEpochMetadata)
           return 0n
 
-        const orderedEpochHistory = epochHistory.sort((a, b) => b.number - a.number)
+        const previousEpochRewardUnits = epochHistory.reduce((lastKnownEpochRewardUnits, epoch) => {
+          if (lastKnownEpochRewardUnits !== 0n) return lastKnownEpochRewardUnits
 
-        const previousEpochRewardUnits = orderedEpochHistory.reduce(
-          (lastKnownEpochRewardUnits, epoch) => {
-            if (lastKnownEpochRewardUnits !== 0n) return lastKnownEpochRewardUnits
+          const distribution =
+            epoch.detailsByStakingContract[getStakingContract(stakingAssetId)]
+              ?.distributionsByStakingAddress[
+              getAddress(fromAccountId(stakingAssetAccountId).account)
+            ]?.totalRewardUnits
 
-            const distribution =
-              epoch.detailsByStakingContract[getStakingContract(stakingAssetId)]
-                ?.distributionsByStakingAddress[
-                getAddress(fromAccountId(stakingAssetAccountId).account)
-              ]?.totalRewardUnits
-
-            return distribution ? BigInt(distribution) : 0n
-          },
-          0n,
-        )
+          return distribution ? BigInt(distribution) : 0n
+        }, 0n)
 
         const rewardUnits = currentEpochRewardUnits - previousEpochRewardUnits
 

--- a/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
+++ b/src/pages/RFOX/hooks/useEpochHistoryQuery.ts
@@ -30,12 +30,14 @@ export const fetchEpochHistory = async (): Promise<EpochWithIpfsHash[]> => {
     queryFn: fetchCurrentEpochMetadata,
   })
 
-  return Promise.all(
+  const epochs = await Promise.all(
     Object.values(currentEpochMetadata.ipfsHashByEpoch).map(async hash => {
       const { data } = await axios.get<Epoch>(`${IPFS_GATEWAY}/${hash}`)
       return { ...data, ipfsHash: hash }
     }),
   )
+
+  return epochs.sort((a, b) => b.number - a.number)
 }
 
 export const useEpochHistoryQuery = <SelectData = EpochWithIpfsHash[]>({

--- a/src/pages/RFOX/hooks/useLifetimeRewardDistributionsQuery.ts
+++ b/src/pages/RFOX/hooks/useLifetimeRewardDistributionsQuery.ts
@@ -29,7 +29,6 @@ export const useLifetimeRewardDistributionsQuery = ({
     (data: EpochWithIpfsHash[]): RewardDistributionWithMetadata[] => {
       if (!stakingAssetAccountAddresses) return []
       return data
-        .sort((a, b) => b.number - a.number)
         .flatMap(epoch =>
           stakingAssetAccountAddresses.flatMap(stakingAssetAccountAddress => {
             const stakingAddress = getAddress(stakingAssetAccountAddress)


### PR DESCRIPTION
## Description

- Remove incorrect `Total {ASSET} Burn` field
- Add fiat value
- Fix simulator (weth/fox estimated rewards), by using correct latest epoch
- Sort epochs query level for accuracy and consistency.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10662

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure rfox simulator is showing accurate values for both fox and weth/fox
- Verify `Total {ASSET} Burn` value has been removed and fiat values are displayed for `Staking Balance` `Lifetime Rewards` and `Pending Rewards Balance`

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)

<img width="1201" height="544" alt="image" src="https://github.com/user-attachments/assets/660adf45-f0af-4d66-a34b-d5a137ce714c" />

<img width="1210" height="556" alt="image" src="https://github.com/user-attachments/assets/ba650fbc-aed2-4a7b-9fa2-0d25a3410f19" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows fiat values (user-currency) for staking balance, current epoch rewards, and lifetime rewards using per-asset market prices.
* **Bug Fixes**
  * Ensures epoch history is consistently newest-first and improves latest-epoch selection.
  * Improves accuracy of current/previous reward calculations and refines loading indicators.
* **Refactor**
  * Simplifies data flows and removes affiliate-related and emissions/pool UI segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->