### PR TITLE
fix: always upsert past rfox distributions

### DIFF
--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -110,11 +110,11 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
         const actionId = `reward-distribution-${distribution.epoch}-${distribution.stakingContract}-${distribution.rewardAddress}`
 
         const existingAction = actions[actionId]
-        if (!existingAction) return
 
-        if (existingAction.status === ActionStatus.Complete) {
+        if (existingAction?.status === ActionStatus.Complete) {
           return
         }
+
         dispatch(
           actionSlice.actions.upsertAction({
             id: actionId,
@@ -129,7 +129,7 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
           }),
         )
 
-        if (!toast.isActive(actionId)) {
+        if (!toast.isActive(actionId) && existingAction) {
           toast({
             id: actionId,
             status: 'success',


### PR DESCRIPTION
## Description

We should upsert complete distribution even if the user doesn't have any pending distibution yet, as we don't show them anywhere else than in the action center now

And we shouldn't send notifications (toast) for past distributions if there isn't a linked pending action in the store to ensure we don't spam everyone at first load with a bunch of notification

Note that this is best effort and we don't have the exact time of the distribution so the action date will be like RFOX claims, dated when it's upserted in the store (do we have any other way to do that as we don't have the TX in the history?)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10664

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Clear your cache
- Reload, ensure you see all the distribution in the action center
- Reload, ensure we don't upsert anything else again (no doublon)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="419" height="1022" alt="image" src="https://github.com/user-attachments/assets/60ef6b8a-f61c-491b-8247-92bb1c3e60be" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents incorrect toast notifications when no related reward action exists.
  * Improves stability by safely handling missing action data, reducing potential errors or crashes during reward distribution updates.

* **Refactor**
  * Enhanced null-safety in conditional checks to ensure more reliable behavior without changing the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->