### PR TITLE
fix: fox 404 when clicking rFox on asset page

### DIFF
--- a/src/components/StakingVaults/EarnOpportunities.tsx
+++ b/src/components/StakingVaults/EarnOpportunities.tsx
@@ -11,6 +11,7 @@ import { Text } from '@/components/Text'
 import { FoxEthProvider, useFoxEth } from '@/context/FoxEthProvider/FoxEthProvider'
 import { WalletActions } from '@/context/WalletProvider/actions'
 import { useBrowserRouter } from '@/hooks/useBrowserRouter/useBrowserRouter'
+import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import type { EarnOpportunityType } from '@/state/slices/opportunitiesSlice/types'
 import { DefiProvider } from '@/state/slices/opportunitiesSlice/types'
@@ -37,6 +38,7 @@ export const EarnOpportunitiesContent = ({ assetId, accountId }: EarnOpportuniti
     dispatch,
   } = useWallet()
   const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const isRfoxFoxEcosystemPageEnabled = useFeatureFlag('RfoxFoxEcosystemPage')
 
   const stakingOpportunities = useAppSelector(
     selectAggregatedEarnUserStakingOpportunitiesIncludeEmpty,
@@ -83,7 +85,7 @@ export const EarnOpportunitiesContent = ({ assetId, accountId }: EarnOpportuniti
       }
 
       if (provider === DefiProvider.rFOX) {
-        return navigate('/rfox')
+        return navigate(isRfoxFoxEcosystemPageEnabled ? '/fox-ecosystem' : '/rfox')
       }
 
       // @ts-ignore that's incorrect according to types but is absolutely valid
@@ -104,7 +106,7 @@ export const EarnOpportunitiesContent = ({ assetId, accountId }: EarnOpportuniti
         state: { background: location },
       })
     },
-    [dispatch, isConnected, location, navigate],
+    [dispatch, isConnected, isRfoxFoxEcosystemPageEnabled, location, navigate],
   )
 
   if (!asset) return null


### PR DESCRIPTION
## Description

Currently when you're on the fox asset page and click on the fox defi opportunity, it tries to redirect to /rFox even if you have fox-ecosystem activated. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10726

## Risk

Low risk, straight forward change

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that clicking the rFox defi opportunity on fox asset page takes you to fox ecosystem

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

I wasn't able to get defi section to show up on local )ut this change is very straight forward. So hopefully we're ok to just sanity check this in develop
