### PR TITLE
fix: better handle send errors in send flow

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -33,7 +33,7 @@
     "claimable": "Claimable",
     "comingSoon": "Coming Soon ...",
     "approve": "Approve",
-    "approveToken": "Approve Token", 
+    "approveToken": "Approve Token",
     "approveAmount": "Approve Amount",
     "approveTo": "Approve To",
     "reset": "Reset",

--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -338,9 +338,11 @@ export const useSendDetails = (): UseSendDetailsReturnType => {
     // openapi-generator error-handling https://github.com/OpenAPITools/openapi-generator/blob/8357cc313be5a099f994c4ffaf56146f40dba911/samples/client/petstore/typescript-fetch/builds/enum/runtime.ts#L221
     if (
       estimatedFeesError?.message ===
-      'The request failed and the interceptors did not return an alternative response'
+        'The request failed and the interceptors did not return an alternative response' ||
+      estimatedFeesError?.message?.includes('body stream already read')
     )
       return setValue(SendFormFields.AmountFieldError, 'modals.send.getFeesError')
+
     if (estimatedFeesError?.message) {
       setValue(SendFormFields.AmountFieldError, estimatedFeesError.message)
     }

--- a/src/components/Modals/Send/views/Details.tsx
+++ b/src/components/Modals/Send/views/Details.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertIcon,
   Box,
   Button,
   Flex,
@@ -336,6 +338,12 @@ export const Details = () => {
       </DialogBody>
       <DialogFooter>
         <Stack flex={1}>
+          {amountFieldError && (
+            <Alert status='error' borderRadius='lg' mb={3}>
+              <AlertIcon />
+              <Text translation={amountFieldError} fontSize='sm' />
+            </Alert>
+          )}
           <Button
             width='full'
             isDisabled={
@@ -344,13 +352,13 @@ export const Details = () => {
               isLoading ||
               Boolean(memoFieldError)
             }
-            colorScheme={amountFieldError ? 'red' : 'blue'}
+            colorScheme='blue'
             size='lg'
             onClick={handleNextClick}
             isLoading={isLoading}
             data-test='send-modal-next-button'
           >
-            <Text translation={amountFieldError || 'common.next'} />
+            <Text translation='common.next' />
           </Button>
           <Button width='full' variant='ghost' size='lg' mr={3} onClick={handleClose}>
             <Text translation='common.cancel' />


### PR DESCRIPTION
## Description

Small design fixes to error state on send flow. 

I wasn't able to replicate this issue where you enter a USD amount and get an infinite loader on the fee calculation part of the flow. So i've just fixed the design aspects.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #9563 

## Risk

Low risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Attempt to replicate the issue outlined in this ticket here https://linear.app/shapeshift-dao/issue/SS-4487/error-messaging-for-sends-of-tokens-on-unsupported-contracts-needs. The error banner should look nicer and have a more helpful error message

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

I was only able to replicate this for design adjustments with a monkey patch 
[send-error-handling.txt](https://github.com/user-attachments/files/22653118/send-error-handling.txt)


<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/d6e513fb-2fdd-4293-9415-9bc1cb5e503d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Display an inline error alert in Send > Details when the amount is invalid, showing a translated message.
* **Bug Fixes**
  * Improved fee estimation error handling to gracefully handle additional error cases (e.g., “body stream already read”) and present a clear user-facing message.
* **Style**
  * Standardized the Next button color to blue.
* **Chores**
  * Minor translation file formatting cleanup (no user-visible changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->