### PR TITLE
feat: bring back flags routing as 5 clicks for new nav

### DIFF
--- a/src/components/Layout/Header/NavBar/DrawerSettings.tsx
+++ b/src/components/Layout/Header/NavBar/DrawerSettings.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react'
 import type { FC } from 'react'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom'
 
 import { DialogBackButton } from '@/components/Modal/components/DialogBackButton'
@@ -12,6 +12,7 @@ import { Languages } from '@/components/Modals/Settings/Languages'
 import { SettingsRoutes, SettingsRoutesRelative } from '@/components/Modals/Settings/SettingsCommon'
 import { SettingsContent } from '@/components/Modals/Settings/SettingsContent'
 import { Text } from '@/components/Text'
+import { useBrowserRouter } from '@/hooks/useBrowserRouter/useBrowserRouter'
 
 type DrawerSettingsProps = {
   onBack: () => void
@@ -26,6 +27,8 @@ const clearCacheElement = <ClearCache isDrawer />
 export const DrawerSettings: FC<DrawerSettingsProps> = ({ onBack, onClose }) => {
   const location = useLocation()
   const navigate = useNavigate()
+  const { navigate: browserNavigate } = useBrowserRouter()
+  const [clickCount, setClickCount] = useState<number>(0)
 
   // Ensure that we back out of memory routing back to main route when on main settings route and clicking back
   const handleBackClick = useCallback(() => {
@@ -36,11 +39,25 @@ export const DrawerSettings: FC<DrawerSettingsProps> = ({ onBack, onClose }) => 
     }
   }, [location.pathname, navigate, onBack])
 
+  /**
+   * clicking 5 times on the settings header will close this modal and take you to the flags page
+   * useful for QA team and unlikely to be triggered by a regular user
+   */
+  const handleHeaderClick = useCallback(() => {
+    if (clickCount === 4) {
+      setClickCount(0)
+      onClose?.()
+      browserNavigate('/flags')
+    } else {
+      setClickCount(clickCount + 1)
+    }
+  }, [clickCount, setClickCount, onClose, browserNavigate])
+
   const settingsContentElement = useMemo(() => <SettingsContent onClose={onClose} />, [onClose])
 
   return (
     <Box display='flex' flexDirection='column' height='100%'>
-      <DialogHeader>
+      <DialogHeader onClick={handleHeaderClick}>
         <DialogHeader.Left>
           <DialogBackButton onClick={handleBackClick} />
         </DialogHeader.Left>


### PR DESCRIPTION
## Description

What this says on the box, it does. Makes flags UI accessible again with new nav.
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/10725

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Flags route is still accessible on 5 taps on settings drawer header on mobile
- Flags route is now accessible on 5 taps on settings view header on desktop

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

https://jam.dev/c/dd8d3f45-81b4-4602-b80f-5bfc029aa995


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->
