### PR TITLE
fix: avoid reloading the app on fiat ramp submit

### DIFF
--- a/src/components/MultiHopTrade/components/FiatRamps/FiatRampTrade.tsx
+++ b/src/components/MultiHopTrade/components/FiatRamps/FiatRampTrade.tsx
@@ -3,6 +3,7 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { AnimatePresence } from 'framer-motion'
+import type { FormEvent } from 'react'
 import { memo, useCallback, useEffect, useMemo, useRef } from 'react'
 import { FormProvider, useForm } from 'react-hook-form'
 import { Route, Routes, useLocation, useNavigate } from 'react-router-dom'
@@ -239,53 +240,58 @@ const RampRoutes = memo(({ onChangeTab, direction }: RampRoutesProps) => {
     }
   }, [sortedQuotes, selectedQuote, dispatch, isFetchingQuotes, pathname])
 
-  const handleSubmit = useCallback(async () => {
-    if (!selectedQuote?.provider) return
-    if (!isConnected) return
+  const handleSubmit = useCallback(
+    async (e: FormEvent<unknown>) => {
+      e.preventDefault()
+      if (!selectedQuote?.provider) return
+      if (!isConnected) return
 
-    const ramp = supportedFiatRamps[selectedQuote.provider]
-    const mpData = {
-      action: direction,
-      assetId: getMaybeCompositeAssetSymbol(
-        direction === FiatRampAction.Buy ? buyAsset?.assetId ?? '' : sellAsset?.assetId ?? '',
-        assets,
-      ),
-      ramp: ramp.id,
-    }
-    getMixPanel()?.track(MixPanelEvent.FiatRamp, mpData)
-    const url = await ramp.onSubmit({
-      action: direction,
-      assetId:
-        direction === FiatRampAction.Buy ? buyAsset?.assetId ?? '' : sellAsset?.assetId ?? '',
-      address: manualReceiveAddress ?? walletReceiveAddress ?? '',
-      fiatCurrency: direction === FiatRampAction.Buy ? sellFiatCurrency.code : buyFiatCurrency.code,
-      fiatAmount: direction === FiatRampAction.Buy ? sellFiatAmount : undefined,
-      amountCryptoPrecision:
-        direction === FiatRampAction.Sell ? sellAmountCryptoPrecision : undefined,
-      options: {
-        language: selectedLocale,
-        mode: colorMode,
-        currentUrl: window.location.href,
-      },
-    })
-    if (url) popup.open({ url, title: direction === FiatRampAction.Buy ? 'Buy' : 'Sell' })
-  }, [
-    assets,
-    buyAsset?.assetId,
-    buyFiatCurrency,
-    colorMode,
-    popup,
-    selectedLocale,
-    sellAsset?.assetId,
-    sellFiatCurrency,
-    direction,
-    manualReceiveAddress,
-    walletReceiveAddress,
-    selectedQuote?.provider,
-    sellAmountCryptoPrecision,
-    sellFiatAmount,
-    isConnected,
-  ])
+      const ramp = supportedFiatRamps[selectedQuote.provider]
+      const mpData = {
+        action: direction,
+        assetId: getMaybeCompositeAssetSymbol(
+          direction === FiatRampAction.Buy ? buyAsset?.assetId ?? '' : sellAsset?.assetId ?? '',
+          assets,
+        ),
+        ramp: ramp.id,
+      }
+      getMixPanel()?.track(MixPanelEvent.FiatRamp, mpData)
+      const url = await ramp.onSubmit({
+        action: direction,
+        assetId:
+          direction === FiatRampAction.Buy ? buyAsset?.assetId ?? '' : sellAsset?.assetId ?? '',
+        address: manualReceiveAddress ?? walletReceiveAddress ?? '',
+        fiatCurrency:
+          direction === FiatRampAction.Buy ? sellFiatCurrency.code : buyFiatCurrency.code,
+        fiatAmount: direction === FiatRampAction.Buy ? sellFiatAmount : undefined,
+        amountCryptoPrecision:
+          direction === FiatRampAction.Sell ? sellAmountCryptoPrecision : undefined,
+        options: {
+          language: selectedLocale,
+          mode: colorMode,
+          currentUrl: window.location.href,
+        },
+      })
+      if (url) popup.open({ url, title: direction === FiatRampAction.Buy ? 'Buy' : 'Sell' })
+    },
+    [
+      assets,
+      buyAsset?.assetId,
+      buyFiatCurrency,
+      colorMode,
+      popup,
+      selectedLocale,
+      sellAsset?.assetId,
+      sellFiatCurrency,
+      direction,
+      manualReceiveAddress,
+      walletReceiveAddress,
+      selectedQuote?.provider,
+      sellAmountCryptoPrecision,
+      sellFiatAmount,
+      isConnected,
+    ],
+  )
 
   const bodyContent = useMemo(
     () => (


### PR DESCRIPTION
## Description

Again a weird mistake! We (I) were not preventing default on form submit in the fiat ramp form, causing a reload with a `?` at the beginning of the URL at first submit!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://discord.com/channels/554694662431178782/1422901804131418112/1423146609235202058

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Load the app from mobile or desktop 
- Submit a fiat ramp (open the popup by clicking "Preview Trade")
- The app shouldn't reload and the popup should open
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/7040e618-4d77-44fe-9f93-b71c69e8200e