### PR TITLE
fix: select best quote on fiat ramp

### DIFF
--- a/src/components/MultiHopTrade/components/FiatRamps/FiatRampTrade.tsx
+++ b/src/components/MultiHopTrade/components/FiatRamps/FiatRampTrade.tsx
@@ -225,6 +225,8 @@ const RampRoutes = memo(({ onChangeTab, direction }: RampRoutesProps) => {
   // Auto-select the best quote when quotes are available and no quote is selected
   // This only happens on first load or when amount changes (not on refetch)
   useEffect(() => {
+    // Wait for all quotes to be fetched to select the best quote
+    if (isFetchingQuotes) return
     if (pathname.includes('quotes')) return
 
     if (sortedQuotes.length > 0) {


### PR DESCRIPTION
## Description

I applied a review but didn't notice it was creating a bug: best quote select should wait for all quotes to be fetched before selecting the best quote, or the selected quote could not be the best!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted while using fiat ramps

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Type any amount in the fiat ramp as a swapper
- See the selected quote by default is effectively the best
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
<img width="1019" height="640" alt="image" src="https://github.com/user-attachments/assets/464f5e0d-0955-4a9c-b3a5-1246d8c7f9a9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of the fiat on/off-ramp trade flow by waiting for all quotes to load before auto-selecting the best option.
  * Prevents premature or incorrect auto-selection and reduces UI flicker, especially on slower networks or during high latency.
  * Existing behavior on quote list views remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->