### PR TITLE
chore: update rfox ipfs hash

### DIFF
--- a/src/pages/RFOX/constants.ts
+++ b/src/pages/RFOX/constants.ts
@@ -11,7 +11,7 @@ export const unstakeEvent = getAbiItem({ abi: RFOX_ABI, name: 'Unstake' })
 
 export const IPFS_GATEWAY = 'https://gateway.pinata.cloud/ipfs'
 
-export const CURRENT_EPOCH_IPFS_HASH = 'bafkreigehwjmpbjslvxtbovqf2owee2ahis5gfces4h5diran742mxnfye'
+export const CURRENT_EPOCH_IPFS_HASH = 'bafkreic5txrt6qngyqvmpglslaw6xlcec565xf3h3nmp7znuyfkfwo6d3e'
 
 export const RFOX_STAKING_ASSET_IDS = [foxOnArbitrumOneAssetId, uniV2EthFoxArbitrumAssetId]
 

--- a/src/pages/RFOX/hooks/useLifetimeRewardDistributionsQuery.ts
+++ b/src/pages/RFOX/hooks/useLifetimeRewardDistributionsQuery.ts
@@ -12,6 +12,7 @@ type UseLifetimeRewardDistributionsQueryProps = {
 
 export type RewardDistributionWithMetadata = RewardDistribution & {
   epoch: number
+  distributionTimestamp: number
   status: Epoch['distributionStatus']
   stakingAddress: string
   stakingContract: string
@@ -46,6 +47,7 @@ export const useLifetimeRewardDistributionsQuery = ({
 
               return {
                 epoch: epoch.number,
+                distributionTimestamp: epoch.distributionTimestamp,
                 status: epoch.distributionStatus,
                 stakingAddress,
                 stakingContract,

--- a/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
+++ b/src/pages/RFOX/hooks/useRfoxRewardDistributionActionSubscriber.tsx
@@ -49,8 +49,6 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   }, [lifetimeRewardDistributionsQuery.data])
 
   useEffect(() => {
-    const now = Date.now()
-
     Object.entries(rewardDistributionsByTxId).forEach(([_, distribution]) => {
       if (!distribution) return
 
@@ -64,8 +62,8 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
             id: actionId,
             type: ActionType.RewardDistribution,
             status: ActionStatus.Initiated,
-            createdAt: now,
-            updatedAt: now,
+            createdAt: distribution.distributionTimestamp,
+            updatedAt: distribution.distributionTimestamp,
             rewardDistributionMetadata: {
               distribution,
               txHash: distribution.txId || undefined,
@@ -101,8 +99,6 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
   }, [rewardDistributionsByTxId, dispatch, toast, openActionCenter, actions])
 
   useEffect(() => {
-    const now = Date.now()
-
     Object.entries(rewardDistributionsByTxId).forEach(([_, distribution]) => {
       if (!distribution) return
 
@@ -120,8 +116,8 @@ export const useRfoxRewardDistributionActionSubscriber = () => {
             id: actionId,
             type: ActionType.RewardDistribution,
             status: ActionStatus.Complete,
-            createdAt: now,
-            updatedAt: now,
+            createdAt: distribution.distributionTimestamp,
+            updatedAt: distribution.distributionTimestamp,
             rewardDistributionMetadata: {
               distribution,
               txHash: distribution.txId,

--- a/src/pages/RFOX/types.ts
+++ b/src/pages/RFOX/types.ts
@@ -44,6 +44,8 @@ export type Epoch = {
   startTimestamp: number
   /** The end timestamp for this epoch */
   endTimestamp: number
+  /** The timestamp of the pending or complete reward distribution */
+  distributionTimestamp: number
   /** The start block for this epoch */
   startBlock: number
   /** The end block for this epoch */


### PR DESCRIPTION
## Description

- Update rfox ipfs hash to reflect current pending reward distribution
- Update to use new `distributionTimestamp` variable for activity notifications

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

N/A

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Ensure pending rewards distributions are displayed
- Ensure accurate notification timestamps for rfox activity after cache clear

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up:

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up: 

## Screenshots (if applicable)

<img width="342" height="616" alt="image" src="https://github.com/user-attachments/assets/c8f3e336-a3a2-49b0-974d-0828494b0e77" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Reward distribution entries now include and display the official distribution timestamp.
- Bug Fixes
  - Fixed reward distribution timelines to use the actual distribution time instead of the current time, improving historical accuracy.
- Chores
  - Updated app to reference the latest epoch data source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->