### PR TITLE
fix: viewing hidden asset page

### DIFF
--- a/src/components/ManageHiddenAssets/ManageHiddenAssetsList.tsx
+++ b/src/components/ManageHiddenAssets/ManageHiddenAssetsList.tsx
@@ -16,11 +16,12 @@ import { isToken } from '@shapeshiftoss/utils'
 import { useCallback, useMemo } from 'react'
 import { TbDots, TbExternalLink, TbEye, TbFileText } from 'react-icons/tb'
 import { useTranslate } from 'react-polyglot'
-import { useNavigate } from 'react-router-dom'
 
 import { Amount } from '@/components/Amount/Amount'
 import { AssetIcon } from '@/components/AssetIcon'
 import { RawText } from '@/components/Text'
+import { useBrowserRouter } from '@/hooks/useBrowserRouter/useBrowserRouter'
+import { useModal } from '@/hooks/useModal/useModal'
 import { isSome } from '@/lib/utils'
 import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
 import {
@@ -42,8 +43,9 @@ type ManageHiddenAssetsListProps = {
 
 export const ManageHiddenAssetsList: React.FC<ManageHiddenAssetsListProps> = ({ onClose }) => {
   const translate = useTranslate()
-  const navigate = useNavigate()
+  const { navigate } = useBrowserRouter()
   const appDispatch = useAppDispatch()
+  const walletDrawer = useModal('walletDrawer')
 
   const spamMarkedAssetIds = useAppSelector(preferences.selectors.selectSpamMarkedAssetIds)
 
@@ -74,8 +76,11 @@ export const ManageHiddenAssetsList: React.FC<ManageHiddenAssetsListProps> = ({ 
     }, [asset, assetId])
 
     const handleViewDetailsClick = useCallback(() => {
-      navigate(`/assets/${assetId}`)
+      if (walletDrawer.isOpen) {
+        walletDrawer.close()
+      }
       onClose?.()
+      navigate(`/assets/${assetId}`)
     }, [assetId])
 
     const handleShowClick = useCallback(() => {


### PR DESCRIPTION
## Description

Fixes navigation from the "View Asset Details" menu item in the Manage Hidden Assets list. Previously, clicking this option would cause the sidebar to transition to an empty route without navigating to the asset details page.

Updated `ManageHiddenAssetsList` to use the `useBrowserRouter()` hook instead of `useNavigate()`. This provides access to the main application's navigation function, even when the component is rendered within a nested router context.

Additionally:
- Added wallet drawer detection and automatic closing before navigation
- Maintained backward compatibility with the `onClose` callback for modal contexts

## Issue (if applicable)

N/A, release blocker: https://discord.com/channels/554694662431178782/1424862617876434996/1424886024684966050

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

From the "Manage hidden assets" menu, click "View Asset Details" and ensure the asset manager draw closes and the browser navigates to that asset's asset page.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

<img width="403" height="277" alt="Screenshot 2025-10-07 at 2 13 41 pm" src="https://github.com/user-attachments/assets/7445c5a1-ccf9-4330-8011-bbbf7025a0ab" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Wallet drawer now closes automatically before navigating to an asset’s details from Manage Hidden Assets, preventing lingering overlays and accidental interactions.

- UX Improvements
  - Smoother, cleaner transition when moving from Manage Hidden Assets to asset details.
  - Consistent behavior when closing the Manage Hidden Assets view and proceeding to details, reducing visual clutter and enhancing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->