### PR TITLE
fix: grouped assets market data

### DIFF
--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -925,6 +925,8 @@ export const selectGroupedAssetsWithBalances = createCachedSelector(
   ): GroupedAssetBalance | null => {
     const spamAssetIdsSet = new Set(spamMarkedAssetIds)
     const primaryAsset = assetsById[primaryAssetId]
+    // Normalize to use the relatedAssetKey if it exists, since market data is only stored on primary assets
+    const normalizedPrimaryAssetId = primaryAsset?.relatedAssetKey ?? primaryAssetId
     const primaryRow = accountRows.find(row => row.assetId === primaryAssetId) ?? {
       assetId: primaryAssetId,
       name: primaryAsset?.name ?? '',
@@ -933,14 +935,14 @@ export const selectGroupedAssetsWithBalances = createCachedSelector(
       fiatAmount: '0',
       cryptoAmount: '0',
       allocation: 0,
-      price: marketData[primaryAssetId]?.price ?? '0',
-      priceChange: marketData[primaryAssetId]?.changePercent24Hr ?? 0,
+      price: marketData[normalizedPrimaryAssetId]?.price ?? '0',
+      priceChange: marketData[normalizedPrimaryAssetId]?.changePercent24Hr ?? 0,
       relatedAssetKey: assetsById[primaryAssetId]?.relatedAssetKey ?? null,
       isChainSpecific: primaryAsset?.isChainSpecific ?? false,
       isPrimary: primaryAsset?.isPrimary ?? false,
     }
 
-    const allRelatedAssetIds = relatedAssetIdsByAssetId[primaryAssetId] || []
+    const allRelatedAssetIds = relatedAssetIdsByAssetId[normalizedPrimaryAssetId] || []
     const relatedAssets = allRelatedAssetIds
       .map(assetId => {
         if (spamAssetIdsSet.has(assetId)) return null


### PR DESCRIPTION
## Description

Fixes market data for grouped assets shown under the swapper in mobile.

`develop`:

<img width="472" height="512" alt="Screenshot 2025-10-07 at 4 00 06 pm" src="https://github.com/user-attachments/assets/09f9effc-96d4-438b-aa73-865c96ace0bd" />

This branch:

<img width="478" height="567" alt="Screenshot 2025-10-07 at 4 00 26 pm" src="https://github.com/user-attachments/assets/4972bb88-0dd1-4117-a5fd-22ed209a199f" />

## Issue (if applicable)

N/A, blocking current release: https://discord.com/channels/554694662431178782/1424862617876434996/1424886024684966050

## Risk

Small

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

- On the swapper page on mobile, ensure that the grouped assets in the asset list show the token's market value for the top-level asset
- Confirm all other grouped asset lists render as expected throughout the app.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See description.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrects primary asset price and price change displays when assets use related keys, preventing mismatches.
  - Ensures related assets are consistently discovered and shown alongside their primary asset.
  - Resolves missing or incorrect market data for related assets in the portfolio view.
  - Aligns asset relations and market data lookups to provide consistent, accurate information across primary and related asset rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->