### PR TITLE
fix: small ui polish tweaks to hidden assets

### DIFF
--- a/src/components/Layout/Header/NavBar/DrawerWallet.tsx
+++ b/src/components/Layout/Header/NavBar/DrawerWallet.tsx
@@ -125,8 +125,6 @@ const AccountTableSkeleton: FC = memo(() => (
   </Stack>
 ))
 
-const manageHiddenAssetsElement = <ManageHiddenAssetsContent />
-
 const DrawerWalletInner: FC = memo(() => {
   const translate = useTranslate()
   const send = useModal('send')
@@ -208,6 +206,8 @@ const DrawerWalletInner: FC = memo(() => {
     () => <DrawerSettings onBack={handleBackToMain} onClose={onClose} />,
     [handleBackToMain, onClose],
   )
+
+  const manageHiddenAssetsElement = useMemo(() => <ManageHiddenAssetsContent />, [])
 
   return (
     <Drawer isOpen={isOpen} placement='right' onClose={onClose} size='sm'>

--- a/src/components/ManageHiddenAssets/ManageHiddenAssetsList.tsx
+++ b/src/components/ManageHiddenAssets/ManageHiddenAssetsList.tsx
@@ -4,6 +4,7 @@ import {
   IconButton,
   Menu,
   MenuButton,
+  MenuGroup,
   MenuItem,
   MenuList,
   Stack,
@@ -13,8 +14,8 @@ import {
 import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId, isNft } from '@shapeshiftoss/caip'
 import { isToken } from '@shapeshiftoss/utils'
-import { useCallback, useMemo } from 'react'
-import { TbDots, TbExternalLink, TbEye, TbFileText } from 'react-icons/tb'
+import { memo, useCallback, useMemo } from 'react'
+import { TbDots, TbExternalLink, TbEye } from 'react-icons/tb'
 import { useTranslate } from 'react-polyglot'
 
 import { Amount } from '@/components/Amount/Amount'
@@ -22,8 +23,8 @@ import { AssetIcon } from '@/components/AssetIcon'
 import { RawText } from '@/components/Text'
 import { useBrowserRouter } from '@/hooks/useBrowserRouter/useBrowserRouter'
 import { useModal } from '@/hooks/useModal/useModal'
-import { isSome } from '@/lib/utils'
 import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
+import { selectHiddenAssets } from '@/state/slices/preferencesSlice/selectors'
 import {
   selectAssetById,
   selectPortfolioCryptoPrecisionBalanceByFilter,
@@ -33,99 +34,97 @@ import { useAppDispatch, useAppSelector } from '@/state/store'
 const dotsIcon = <TbDots />
 const eyeIcon = <TbEye />
 const externalLinkIcon = <TbExternalLink />
-const fileTextIcon = <TbFileText />
 
 const hoverStylesSx = { _hover: { bg: 'gray.50', _dark: { bg: 'gray.700' } } }
 
-type ManageHiddenAssetsListProps = {
+type AssetRowProps = {
+  assetId: AssetId
   onClose?: () => void
+  onToggleSpam: (assetId: AssetId) => void
+  onNavigate: (assetId: AssetId) => void
 }
 
-export const ManageHiddenAssetsList: React.FC<ManageHiddenAssetsListProps> = ({ onClose }) => {
+const AssetRow = memo<AssetRowProps>(({ assetId, onClose, onToggleSpam, onNavigate }) => {
   const translate = useTranslate()
-  const { navigate } = useBrowserRouter()
-  const appDispatch = useAppDispatch()
-  const walletDrawer = useModal('walletDrawer')
-
-  const spamMarkedAssetIds = useAppSelector(preferences.selectors.selectSpamMarkedAssetIds)
-
-  const hiddenAssets = useAppSelector(state =>
-    spamMarkedAssetIds.map(assetId => selectAssetById(state, assetId)).filter(isSome),
+  const asset = useAppSelector(state => selectAssetById(state, assetId))
+  const assetBalanceFilter = useMemo(() => ({ assetId }), [assetId])
+  const cryptoBalance = useAppSelector(state =>
+    selectPortfolioCryptoPrecisionBalanceByFilter(state, assetBalanceFilter),
   )
 
-  const AssetRow: React.FC<{ assetId: AssetId }> = ({ assetId }) => {
-    const asset = useAppSelector(state => selectAssetById(state, assetId))
-    const assetBalanceFilter = useMemo(() => ({ assetId }), [assetId])
-    const cryptoBalance = useAppSelector(state =>
-      selectPortfolioCryptoPrecisionBalanceByFilter(state, assetBalanceFilter),
-    )
+  const explorerHref = useMemo(() => {
+    if (!asset) return
 
-    const explorerHref = useMemo(() => {
-      if (!asset) return
+    const { assetReference } = fromAssetId(assetId)
 
-      const { assetReference } = fromAssetId(assetId)
+    if (isNft(assetId)) {
+      const [token] = assetReference.split('/')
+      return `${asset.explorer}/token/${token}?a=${asset.id}`
+    }
 
-      if (isNft(assetId)) {
-        const [token] = assetReference.split('/')
-        return `${asset.explorer}/token/${token}?a=${asset.id}`
-      }
+    if (isToken(assetId)) return `${asset?.explorerAddressLink}${assetReference}`
 
-      if (isToken(assetId)) return `${asset?.explorerAddressLink}${assetReference}`
+    return asset.explorer
+  }, [asset, assetId])
 
-      return asset.explorer
-    }, [asset, assetId])
+  const handleViewDetailsClick = useCallback(() => {
+    onClose?.()
+    onNavigate(assetId)
+  }, [assetId, onClose, onNavigate])
 
-    const handleViewDetailsClick = useCallback(() => {
-      if (walletDrawer.isOpen) {
-        walletDrawer.close()
-      }
-      onClose?.()
-      navigate(`/assets/${assetId}`)
-    }, [assetId])
+  const handleShowClick = useCallback(() => {
+    onToggleSpam(assetId)
+  }, [assetId, onToggleSpam])
 
-    const handleShowClick = useCallback(() => {
-      appDispatch(preferences.actions.toggleSpamMarkedAssetId(assetId))
-    }, [assetId])
+  const handleStopPropagation = useCallback((e: React.MouseEvent) => {
+    e.stopPropagation()
+  }, [])
 
-    if (!asset) return null
+  if (!asset) return null
 
-    return (
-      <Flex align='center' justify='space-between' p={4} borderRadius='md' sx={hoverStylesSx}>
-        <Flex align='center' gap={3} flex={1}>
-          <AssetIcon assetId={assetId} size='sm' />
-          <Box>
-            <RawText fontSize='md' fontWeight='medium'>
-              {asset.name}
-            </RawText>
-            <Text fontSize='sm' color='text.subtle'>
-              {asset.symbol}
-            </Text>
-          </Box>
-        </Flex>
-        <Flex align='center' gap={3}>
-          <Stack spacing={0} fontWeight='medium' textAlign='right'>
-            <Amount.Crypto
-              fontWeight='semibold'
-              lineHeight='shorter'
-              height='20px'
-              value={cryptoBalance}
-              symbol={asset.symbol}
-              truncateLargeNumbers={true}
-            />
-          </Stack>
-          <Menu>
-            <MenuButton
-              as={IconButton}
-              aria-label={translate('common.moreOptions')}
-              icon={dotsIcon}
-              variant='ghost'
-              size='sm'
-              isRound
-            />
-            <MenuList>
-              <MenuItem icon={fileTextIcon} onClick={handleViewDetailsClick}>
-                {translate('common.viewAssetDetails')}
-              </MenuItem>
+  return (
+    <Flex
+      align='center'
+      justify='space-between'
+      p={4}
+      borderRadius='md'
+      sx={hoverStylesSx}
+      cursor='pointer'
+      onClick={handleViewDetailsClick}
+    >
+      <Flex align='center' gap={3} flex={1}>
+        <AssetIcon assetId={assetId} size='sm' />
+        <Box>
+          <RawText fontSize='md' fontWeight='medium'>
+            {asset.name}
+          </RawText>
+          <Text fontSize='sm' color='text.subtle'>
+            {asset.symbol}
+          </Text>
+        </Box>
+      </Flex>
+      <Flex align='center' gap={3} onClick={handleStopPropagation}>
+        <Stack spacing={0} fontWeight='medium' textAlign='right'>
+          <Amount.Crypto
+            fontWeight='semibold'
+            lineHeight='shorter'
+            height='20px'
+            value={cryptoBalance}
+            symbol={asset.symbol}
+            truncateLargeNumbers={true}
+          />
+        </Stack>
+        <Menu>
+          <MenuButton
+            as={IconButton}
+            aria-label={translate('common.moreOptions')}
+            icon={dotsIcon}
+            variant='ghost'
+            size='sm'
+            isRound
+          />
+          <MenuList>
+            <MenuGroup>
               {explorerHref && (
                 <MenuItem
                   icon={externalLinkIcon}
@@ -140,12 +139,42 @@ export const ManageHiddenAssetsList: React.FC<ManageHiddenAssetsListProps> = ({ 
               <MenuItem icon={eyeIcon} onClick={handleShowClick} color='red.500'>
                 {translate('assets.showAsset')}
               </MenuItem>
-            </MenuList>
-          </Menu>
-        </Flex>
+            </MenuGroup>
+          </MenuList>
+        </Menu>
       </Flex>
-    )
-  }
+    </Flex>
+  )
+})
+
+type ManageHiddenAssetsListProps = {
+  onClose?: () => void
+}
+
+export const ManageHiddenAssetsList: React.FC<ManageHiddenAssetsListProps> = ({ onClose }) => {
+  const translate = useTranslate()
+  const { navigate } = useBrowserRouter()
+  const appDispatch = useAppDispatch()
+  const walletDrawer = useModal('walletDrawer')
+
+  const hiddenAssets = useAppSelector(selectHiddenAssets)
+
+  const handleNavigate = useCallback(
+    (assetId: AssetId) => {
+      if (walletDrawer.isOpen) {
+        walletDrawer.close()
+      }
+      navigate(`/assets/${assetId}`)
+    },
+    [navigate, walletDrawer],
+  )
+
+  const handleToggleSpam = useCallback(
+    (assetId: AssetId) => {
+      appDispatch(preferences.actions.toggleSpamMarkedAssetId(assetId))
+    },
+    [appDispatch],
+  )
 
   if (hiddenAssets.length === 0) {
     return (
@@ -163,7 +192,13 @@ export const ManageHiddenAssetsList: React.FC<ManageHiddenAssetsListProps> = ({ 
   return (
     <Stack spacing={1}>
       {hiddenAssets.map(asset => (
-        <AssetRow key={asset.assetId} assetId={asset.assetId} />
+        <AssetRow
+          key={asset.assetId}
+          assetId={asset.assetId}
+          onClose={onClose}
+          onToggleSpam={handleToggleSpam}
+          onNavigate={handleNavigate}
+        />
       ))}
     </Stack>
   )

--- a/src/state/slices/preferencesSlice/selectors.ts
+++ b/src/state/slices/preferencesSlice/selectors.ts
@@ -1,10 +1,13 @@
+import { createSelector } from '@reduxjs/toolkit'
 import type { AssetId } from '@shapeshiftoss/caip'
 import createCachedSelector from 're-reselect'
 
 import type { Flag } from './preferencesSlice'
 import { preferences } from './preferencesSlice'
 
+import { isSome } from '@/lib/utils'
 import type { ReduxState } from '@/state/reducer'
+import { selectAssetById } from '@/state/slices/assetsSlice/selectors'
 
 export const selectFeatureFlag = createCachedSelector(
   preferences.selectors.selectFeatureFlags,
@@ -23,3 +26,10 @@ export const selectIsSpamMarkedByAssetId = createCachedSelector(
   (_state: ReduxState, assetId: AssetId) => assetId,
   (spamMarkedAssetIds, assetId): boolean => spamMarkedAssetIds.includes(assetId),
 )((_state: ReduxState, assetId: AssetId): AssetId => assetId ?? 'assetId')
+
+export const selectHiddenAssets = createSelector(
+  preferences.selectors.selectSpamMarkedAssetIds,
+  (state: ReduxState) => state,
+  (spamMarkedAssetIds, state) =>
+    spamMarkedAssetIds.map(assetId => selectAssetById(state, assetId)).filter(isSome),
+)


### PR DESCRIPTION
## Description

A few polishy fixes to the hidden assets UI
* Fixed incosistent menu item with on the dots menu
* Fixed flashing asset icons
* Made the rows clickable to go through to assets page (feels more natural with the row highlight)
* Made it much quicker to navigate to the manage hidden assets page. Previously it seemed to take a couple of seconds to navigate there

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #

## Risk

Low risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Go to hidden assets page 
<img width="607" height="763" alt="image" src="https://github.com/user-attachments/assets/a2b111e0-15b0-485b-b4c3-1d2fe1407215" />

* Make sure menu functions properly
* Asset icons shouldn't flicker

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="607" height="763" alt="image" src="https://github.com/user-attachments/assets/353f6fd1-94cd-4ab5-8b36-78661c321833" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manage Hidden Assets: row click opens details; per-row quick-action menu with View Details, Open in Explorer, and Show Asset.
  * Per-asset balances displayed; explorer links tailored by asset type.
  * New selector exposes hidden assets for list rendering.

* **Refactor**
  * List rendering optimized with memoized per-asset rows for smoother performance.
  * Wallet drawer simplified and manage-assets view memoized.

* **Bug Fixes**
  * Action menu interactions no longer trigger row navigation.
  * Wallet drawer no longer auto-closes based on other modal state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->