### PR TITLE
fix: modal not resizing properly to keyboard mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="apple-touch-icon" sizes="512x512" href="/icon-512x512.png" integrity="%VITE_SRI_ICON_512X512_PNG%" crossorigin="anonymous" />
     <link rel="icon" type="image/png" href="/favicon.png" integrity="%VITE_SRI_FAVICON_PNG%" crossorigin="anonymous" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" integrity="%VITE_SRI_FAVICON_SVG%" crossorigin="anonymous" />
-    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no,viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta property="og:title" content="ShapeShift DAO">
     <meta property="og:image" content="/ss-thumb.jpg">
     <meta property="og:type" content="website" />

--- a/src/components/Modal/components/Dialog.tsx
+++ b/src/components/Modal/components/Dialog.tsx
@@ -2,7 +2,7 @@ import type { ModalProps } from '@chakra-ui/react'
 import { Modal, ModalContent, ModalOverlay, useMediaQuery } from '@chakra-ui/react'
 import styled from '@emotion/styled'
 import type { PropsWithChildren } from 'react'
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useState } from 'react'
+import React, { useCallback, useEffect, useLayoutEffect, useMemo } from 'react'
 import { Drawer } from 'vaul'
 
 import {
@@ -26,7 +26,7 @@ const CustomDrawerContent = styled(Drawer.Content)`
   flex-direction: column;
   border-radius: 24px 24px 0 0;
   position: fixed;
-  max-height: 95%;
+  max-height: calc(95dvh - env(safe-area-inset-top) - var(--safe-area-inset-top));
   bottom: 0;
   left: 0;
   right: 0;
@@ -44,8 +44,6 @@ const CustomDrawerOverlay = styled(Drawer.Overlay)`
   -webkit-touch-callout: none;
 `
 
-const snapPoint = 0.5
-
 const DialogWindow: React.FC<DialogProps> = ({
   isOpen,
   onClose,
@@ -57,26 +55,15 @@ const DialogWindow: React.FC<DialogProps> = ({
   const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
   const { setIsOpen, isOpen: isDialogOpen } = useDialog()
 
-  const [viewportHeight, setViewportHeight] = useState(window.visualViewport?.height)
-
-  useEffect(() => {
-    function updateViewportHeight() {
-      setViewportHeight(window.visualViewport?.height || 0)
-    }
-
-    window.visualViewport?.addEventListener('resize', updateViewportHeight)
-    return () => window.visualViewport?.removeEventListener('resize', updateViewportHeight)
-  }, [])
-
   const contentStyle = useMemo(() => {
     return {
+      height: isFullScreen ? '100dvh' : height || 'auto',
       maxHeight: isFullScreen
-        ? '100vh'
-        : 'calc(100% - env(safe-area-inset-top) - var(--safe-area-inset-top))',
-      height: isFullScreen ? viewportHeight : height || '80vh',
+        ? '100dvh'
+        : 'calc(95dvh - env(safe-area-inset-top) - var(--safe-area-inset-top))',
       paddingTop: isFullScreen ? 'calc(env(safe-area-inset-top) + var(--safe-area-inset-top))' : 0,
     }
-  }, [height, isFullScreen, viewportHeight])
+  }, [height, isFullScreen])
 
   useEffect(() => {
     setIsOpen(isOpen)
@@ -106,13 +93,7 @@ const DialogWindow: React.FC<DialogProps> = ({
 
   if (isMobile || !isLargerThanMd) {
     return (
-      <Drawer.Root
-        repositionInputs={isFullScreen ? true : false}
-        open={isDialogOpen}
-        onClose={onClose}
-        activeSnapPoint={snapPoint}
-        modal
-      >
+      <Drawer.Root repositionInputs={false} open={isDialogOpen} onClose={onClose} modal>
         <Drawer.Portal>
           <CustomDrawerOverlay onClick={handleClose} />
           <CustomDrawerContent style={contentStyle}>{children}</CustomDrawerContent>

--- a/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
+++ b/src/plugins/walletConnectToDapps/components/modals/connect/ConnectContent.tsx
@@ -146,7 +146,7 @@ export const ConnectContent: React.FC<ConnectContentProps> = ({
                   placeholder={translate(
                     'plugins.walletConnectToDapps.modal.connect.linkPlaceholder',
                   )}
-                  autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+                  autoFocus={!window.matchMedia('(pointer: coarse)').matches}
                   variant='filled'
                   onPaste={handleInputPaste}
                 />


### PR DESCRIPTION
## Description

Previously when on mobile, we had some full screen modals where if you opened, then closed the keyboard, you'd end up in a weird state where the modal sits awkwardly on the bottom half of the screen. This PR attempts to fix that.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10573 

## Risk

Medium risk, could break some important modals on mobile.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that opening the "connect to dApp" modal on mobile, opening and closing the keyboard doesn't result in awkward half modal.
* Test other modals with inputs in them like trade asset search on the swapper (when you click an asset selection)
* Test same modals on desktop to verify no regression

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)


https://github.com/user-attachments/assets/7fe3784f-900a-40a3-91e8-0bea6a7e2f7b



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Full-screen modals now fill the viewport; non-full-screen modals use a stable max height to prevent layout issues.
  - Mobile drawer snapping and input repositioning simplified/disabled to avoid layout glitches.
  - Input autofocus now disabled on touch devices and enabled on pointer devices to prevent unwanted keyboards.
  - Viewport meta updated for more consistent mobile resizing behavior.

- Refactor
  - Simplified modal/drawer height and snap-point logic and removed unused imports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->