### PR TITLE
feat: speed up the asset page by removing mini graph

### DIFF
--- a/src/components/AssetIcon.tsx
+++ b/src/components/AssetIcon.tsx
@@ -4,7 +4,7 @@ import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import type { JSX } from 'react'
-import { memo, useMemo } from 'react'
+import { memo } from 'react'
 
 import { FoxIcon } from './Icons/FoxIcon'
 import { LazyLoadAvatar } from './LazyLoadAvatar'
@@ -13,6 +13,8 @@ import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSin
 import { PairIcons } from '@/features/defi/components/PairIcons/PairIcons'
 import { selectAssetById, selectFeeAssetById } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
+
+const foxIcon = <FoxIcon boxSize='16px' />
 
 export const defaultClipPath =
   'polygon( 37.122% 12.175%,37.122% 12.175%,36.79% 16.293%,35.828% 20.199%,34.288% 23.841%,32.224% 27.167%,29.687% 30.125%,26.729% 32.662%,23.403% 34.727%,19.761% 36.266%,15.855% 37.228%,11.737% 37.56%,11.737% 37.56%,11.437% 37.558%,11.138% 37.553%,10.84% 37.545%,10.543% 37.533%,10.247% 37.517%,9.952% 37.498%,9.657% 37.476%,9.364% 37.451%,9.071% 37.422%,8.779% 37.39%,8.779% 37.39%,7.696% 37.329%,6.618% 37.397%,5.568% 37.592%,4.566% 37.91%,3.635% 38.35%,2.795% 38.911%,2.067% 39.589%,1.474% 40.383%,1.036% 41.29%,0.775% 42.309%,0.775% 42.309%,0.667% 43.05%,0.57% 43.795%,0.483% 44.543%,0.408% 45.294%,0.345% 46.049%,0.292% 46.806%,0.251% 47.567%,0.222% 48.331%,0.205% 49.098%,0.199% 49.868%,0.199% 49.868%,0.843% 57.853%,2.709% 65.429%,5.694% 72.492%,9.697% 78.943%,14.618% 84.679%,20.354% 89.6%,26.805% 93.604%,33.869% 96.589%,41.444% 98.454%,49.43% 99.099%,49.43% 99.099%,57.415% 98.454%,64.99% 96.589%,72.054% 93.604%,78.505% 89.6%,84.241% 84.679%,89.162% 78.943%,93.165% 72.492%,96.15% 65.429%,98.016% 57.853%,98.66% 49.868%,98.66% 49.868%,98.016% 41.882%,96.15% 34.307%,93.165% 27.243%,89.162% 20.793%,84.241% 15.056%,78.505% 10.136%,72.054% 6.132%,64.99% 3.147%,57.415% 1.281%,49.43% 0.637%,49.43% 0.637%,48.66% 0.643%,47.893% 0.661%,47.129% 0.69%,46.368% 0.731%,45.61% 0.783%,44.856% 0.847%,44.104% 0.922%,43.357% 1.008%,42.612% 1.105%,41.871% 1.214%,41.871% 1.214%,40.852% 1.475%,39.945% 1.912%,39.151% 2.506%,38.473% 3.233%,37.912% 4.073%,37.472% 5.005%,37.153% 6.006%,36.959% 7.057%,36.891% 8.134%,36.951% 9.218%,36.951% 9.218%,36.983% 9.509%,37.012% 9.802%,37.038% 10.095%,37.06% 10.39%,37.079% 10.685%,37.094% 10.982%,37.106% 11.279%,37.115% 11.577%,37.12% 11.876%,37.122% 12.175% );'
@@ -116,15 +118,10 @@ export const AssetIcon = memo(
     )
     const assetId = _assetId ?? asset?.assetId
     const assetIconBg = useColorModeValue('gray.200', 'gray.700')
-    const assetIconColor = useColorModeValue('text.subtle', 'text.subtle')
 
     const chainAdapterManager = getChainAdapterManager()
     const chainId = assetId && fromAssetId(assetId).chainId
     const nativeAssetId = chainAdapterManager.get(chainId ?? '')?.getFeeAssetId()
-    const foxIcon = useMemo(
-      () => <FoxIcon boxSize='16px' color={assetIconColor} />,
-      [assetIconColor],
-    )
     const feeAsset = useAppSelector(state => selectFeeAssetById(state, nativeAssetId ?? ''))
 
     if (!asset) return <LazyLoadAvatar src={src} bg={assetIconBg} icon={foxIcon} {...rest} />

--- a/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
+++ b/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
@@ -11,7 +11,6 @@ import { WatchAssetButton } from '../AssetHeader/WatchAssetButton'
 import { AssetCell } from './AssetCell'
 import { ChangeCell } from './ChangeCell'
 import { PriceCell } from './PriceCell'
-import { SparkLineCell } from './SparkLineCell'
 import { TradeButtonCell } from './TradeButtonCell'
 import { VolumeCell } from './VolumeCell'
 
@@ -67,16 +66,6 @@ export const MarketsTableVirtualized: React.FC<MarketsTableVirtualizedProps> = m
             <AssetCell assetId={row.original.assetId} symbol={row.original.symbol} />
           ),
         },
-        ...(isLargerThanMd
-          ? [
-              {
-                id: 'sparkline',
-                Cell: ({ row }: { row: Row<Asset> }) => (
-                  <SparkLineCell assetId={row.original.assetId} themeColor={row.original.color} />
-                ),
-              },
-            ]
-          : []),
         {
           id: 'price',
           Header: () => <Text ml='auto' translation='dashboard.portfolio.price' />,

--- a/src/components/Table/Table.theme.ts
+++ b/src/components/Table/Table.theme.ts
@@ -9,16 +9,16 @@ export const TableStyle = {
       thead: {
         tr: {
           th: {
-            paddingLeft: 4,
-            paddingRight: 4,
+            paddingLeft: 6,
+            paddingRight: 6,
           },
         },
       },
       tbody: {
         tr: {
           td: {
-            paddingLeft: 4,
-            paddingRight: 4,
+            paddingLeft: 6,
+            paddingRight: 6,
           },
         },
       },


### PR DESCRIPTION
## Description

Some small tweaks to optimise the assets page. Primarily just a removal of the tiny graph as per [this convo](https://discord.com/channels/554694662431178782/1425718155300311091). It's currently what's killing the performance the most on the assets explore page. 

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10756 

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

 * Test that the assets page still works as expected

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/58074855-e2ee-4328-9953-a0bbe96d678a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Increased horizontal padding in table header and body cells for improved readability on medium screens.
- Refactor
  - Simplified asset fallback icon to a static fox icon; appearance is now consistent and independent of color.
  - Streamlined Markets table by removing the Sparkline column for a cleaner layout.
- Documentation
  - No user-facing documentation changes.
- Tests
  - No test changes.
- Chores
  - Internal implementation cleanups with no impact on public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->