### PR TITLE
fix: dropdown/menu z-index in modal stacks

### DIFF
--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -28,6 +28,7 @@ import { AccountChildOption } from './AccountChildOption'
 import { AccountSegment } from './AccountSegement'
 
 import { InlineCopyButton } from '@/components/InlineCopyButton'
+import { useModalChildZIndex } from '@/context/ModalStackProvider'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { fromBaseUnit } from '@/lib/math'
 import { isValidAccountNumber } from '@/lib/utils/accounts'
@@ -198,6 +199,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
     showLabel = true,
     label,
   }) => {
+    const modalChildZIndex = useModalChildZIndex()
     const filter = useMemo(() => ({ assetId }), [assetId])
     const accountIds = useAppSelector((s: ReduxState) =>
       selectPortfolioAccountIdsByAssetIdFilter(s, filter),
@@ -350,7 +352,12 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
               )}
             </Flex>
           </MenuButton>
-          <MenuList minWidth='fit-content' maxHeight='200px' overflowY='auto' zIndex='modal'>
+          <MenuList
+            minWidth='fit-content'
+            maxHeight='200px'
+            overflowY='auto'
+            zIndex={modalChildZIndex}
+          >
             <MenuOptions
               accountIdsByNumberAndType={accountIdsByNumberAndType}
               asset={asset}

--- a/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
+++ b/src/components/AssetSelection/components/AssetChainDropdown/AssetChainDropdown.tsx
@@ -19,6 +19,7 @@ import { AssetRowLoading } from '../AssetRowLoading'
 import { AssetChainRow } from './AssetChainRow'
 
 import { getStyledMenuButtonProps } from '@/components/AssetSelection/helpers'
+import { useModalChildZIndex } from '@/context/ModalStackProvider'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { assertGetChainAdapter } from '@/lib/utils'
 import { portfolio } from '@/state/slices/portfolioSlice/portfolioSlice'
@@ -64,6 +65,7 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
       state: { wallet },
     } = useWallet()
     const translate = useTranslate()
+    const modalChildZIndex = useModalChildZIndex()
     const chainDisplayName = useAppSelector(state =>
       selectChainDisplayNameByAssetId(state, assetId ?? ''),
     )
@@ -209,7 +211,7 @@ export const AssetChainDropdown: React.FC<AssetChainDropdownProps> = memo(
           </MenuButton>
         </Tooltip>
         <Portal>
-          <MenuList zIndex='modal'>
+          <MenuList zIndex={modalChildZIndex}>
             <MenuOptionGroup type='radio' value={assetId} onChange={handleChangeAsset}>
               {renderedChains}
             </MenuOptionGroup>

--- a/src/components/ChainDropdown/ChainDropdown.tsx
+++ b/src/components/ChainDropdown/ChainDropdown.tsx
@@ -20,6 +20,7 @@ import { ChainRow } from './ChainRow'
 import { Amount } from '@/components/Amount/Amount'
 import { IconCircle } from '@/components/IconCircle'
 import { GridIcon } from '@/components/Icons/GridIcon'
+import { useModalChildZIndex } from '@/context/ModalStackProvider'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
 import { selectPortfolioTotalBalanceByChainIdIncludeStaking } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
@@ -46,6 +47,7 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
   buttonProps,
   ...menuProps
 }) => {
+  const modalChildZIndex = useModalChildZIndex()
   const fiatBalanceByChainId = useAppSelector(selectPortfolioTotalBalanceByChainIdIncludeStaking)
 
   const translate = useTranslate()
@@ -85,7 +87,7 @@ export const ChainDropdown: React.FC<ChainDropdownProps> = ({
         {chainId ? <ChainRow chainId={chainId} /> : translate('common.allChains')}
       </MenuButton>
       <Portal>
-        <MenuList zIndex='popover'>
+        <MenuList zIndex={modalChildZIndex}>
           <MenuOptionGroup type='radio' value={chainId} onChange={onChange}>
             {showAll && (
               <MenuItemOption value=''>

--- a/src/components/ChainMenu.tsx
+++ b/src/components/ChainMenu.tsx
@@ -18,6 +18,7 @@ import { useTranslate } from 'react-polyglot'
 
 import { AssetIcon } from '@/components/AssetIcon'
 import { CircleIcon } from '@/components/Icons/Circle'
+import { useModalChildZIndex } from '@/context/ModalStackProvider'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 
 export type ChainMenuProps<T extends ChainId | 'All'> = {
@@ -130,6 +131,7 @@ const GenericChainMenu = <T extends ChainId | 'All'>({
   buttonProps,
 }: ChainMenuProps<T>) => {
   const translate = useTranslate()
+  const modalChildZIndex = useModalChildZIndex()
 
   return (
     <Menu autoSelect={false}>
@@ -149,7 +151,7 @@ const GenericChainMenu = <T extends ChainId | 'All'>({
         </MenuButton>
       </Tooltip>
 
-      <MenuList p={2} maxHeight='350px' overflowY='auto' zIndex='dropdown'>
+      <MenuList p={2} maxHeight='350px' overflowY='auto' zIndex={modalChildZIndex}>
         <MenuGroup title={translate('common.selectNetwork')} ml={3} color='text.subtle'>
           {chainIds.map(chainId => (
             <ChainMenuItem<T>

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderFooter.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderFooter.tsx
@@ -11,6 +11,7 @@ import { useCallback, useMemo } from 'react'
 
 import { Row } from '@/components/Row/Row'
 import { Text } from '@/components/Text'
+import { useModalChildZIndex } from '@/context/ModalStackProvider'
 import { useActions } from '@/hooks/useActions'
 import { assertUnreachable } from '@/lib/utils'
 import { ExpiryOption } from '@/state/slices/limitOrderInputSlice/constants'
@@ -56,6 +57,7 @@ const getExpiryOptionTranslation = (expiryOption: ExpiryOption) => {
 }
 
 export const LimitOrderFooter = () => {
+  const modalChildZIndex = useModalChildZIndex()
   const expiry = useAppSelector(selectExpiry)
   const { setExpiry } = useActions(limitOrderInput.actions)
 
@@ -100,7 +102,7 @@ export const LimitOrderFooter = () => {
           >
             <Text translation={expiryOptionTranslation} />
           </MenuButton>
-          <MenuList zIndex='modal'>
+          <MenuList zIndex={modalChildZIndex}>
             <MenuOptionGroup type='radio' value={expiry} onChange={handleChangeExpiryOption}>
               {expiryOptions}
             </MenuOptionGroup>

--- a/src/context/ModalStackProvider/constants.ts
+++ b/src/context/ModalStackProvider/constants.ts
@@ -1,0 +1,5 @@
+/**
+ * Z-index buffer for modal stack management
+ * Provides spacing between base modal z-index and stacked modals
+ */
+export const ZINDEX_BUFFER = 10

--- a/src/context/ModalStackProvider/index.ts
+++ b/src/context/ModalStackProvider/index.ts
@@ -1,4 +1,6 @@
+export { ZINDEX_BUFFER } from './constants'
 export { ModalStackProvider, useModalStack } from './ModalStackProvider'
 export type { ModalStackContextType, ModalStackItem } from './types'
+export { useModalChildZIndex } from './useModalChildZIndex'
 export { useModalRegistration } from './useModalRegistration'
 export type { UseModalRegistrationProps } from './useModalRegistration'

--- a/src/context/ModalStackProvider/useModalChildZIndex.ts
+++ b/src/context/ModalStackProvider/useModalChildZIndex.ts
@@ -1,0 +1,30 @@
+import { useMemo } from 'react'
+
+import { ZINDEX_BUFFER } from './constants'
+import { useModalStack } from './ModalStackProvider'
+
+/**
+ * Hook for child components (like dropdowns, menus, popovers) that need to render
+ * above the current modal in the stack. This is useful for components that use Portal
+ * and need to be aware of the modal stack to render at the correct z-index level.
+ *
+ * @returns A z-index value to use for portaled content, or 'modal' if not in a modal stack
+ */
+export const useModalChildZIndex = () => {
+  const { getHighestModal, getZIndex } = useModalStack()
+
+  const zIndexValue = useMemo(() => {
+    const highestModal = getHighestModal()
+    if (!highestModal) return 'modal'
+
+    const zIndex = getZIndex(highestModal.id)
+    if (zIndex === undefined) return 'modal'
+
+    // Child content should be above the modal content
+    // Modal content is at: calc(var(--chakra-zIndices-modal) + ${zIndex + ZINDEX_BUFFER})
+    // So we add 1 more to be above it
+    return `calc(var(--chakra-zIndices-modal) + ${zIndex + ZINDEX_BUFFER + 1})`
+  }, [getHighestModal, getZIndex])
+
+  return zIndexValue
+}

--- a/src/context/ModalStackProvider/useModalRegistration.ts
+++ b/src/context/ModalStackProvider/useModalRegistration.ts
@@ -1,13 +1,13 @@
 import { useEffect, useMemo, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 
+import { ZINDEX_BUFFER } from './constants'
 import { useModalStack } from './ModalStackProvider'
 
 export type UseModalRegistrationProps = {
   isOpen: boolean
   onClose: () => void
 }
-const ZINDEX_BUFFER = 10
 
 export const useModalRegistration = ({ isOpen, onClose }: UseModalRegistrationProps) => {
   const { registerModal, unregisterModal, getIsHighestModal, getZIndex } = useModalStack()


### PR DESCRIPTION
## Description

Fix modal stacking regression where child components (dropdowns, menus, popovers) rendered inside modals were appearing behind their parent modal instead of in front. This occurred because these components used hardcoded z-index values that didn't respect the new modal stack management system introduced in https://github.com/shapeshift/web/pull/10783.

## Issue (if applicable)

Regression from https://github.com/shapeshift/web/pull/10783 where clicking the chain selector in the RFOX stake modal caused the dropdown to render behind the stake modal instead of in front.

Unblocks https://github.com/shapeshift/web/pull/10848

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

1. Navigate to fox-ecosystem route (RFOX staking page)
2. Open the RFOX stake modal
3. Click the chain selector dropdown
4. Expected: Dropdown should appear in front of the modal (not behind it)
5. Click account selector dropdown
6. Expected: Dropdown should appear in front of the modal

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="516" height="469" alt="Screenshot 2025-10-20 at 1 17 18 pm" src="https://github.com/user-attachments/assets/83c44c27-faff-485d-8504-3b505e373623" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal and dropdown layering to ensure correct visual stacking when multiple modals or dropdowns are open simultaneously.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->