### PR TITLE
fix: remove back button on native rename/delete routes

### DIFF
--- a/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
+++ b/src/context/WalletProvider/NewWalletViews/NewWalletViewsSwitch.tsx
@@ -293,7 +293,7 @@ export const NewWalletViewsSwitch = () => {
 
     return (
       <Box flex={1} bg={bodyBgColor} p={6} position={isLargerThanMd ? 'relative' : 'initial'}>
-        {!isRootRoute || !isLargerThanMd ? (
+        {!isRootRoute ? (
           <Box
             position='absolute'
             left={3}


### PR DESCRIPTION
### Description

Adds native rename and delete routes to the root route check to prevent displaying the back button on said screens

### Risks

Low

### Testing

- Navigate to the native wallet rename route on desktop/mobile web and verify no back button is displayed
- Navigate to the native wallet delete route on desktop/mobile web and verify no back button is displayed
- On mobile, confirm that the wallet "modal" (full-width modal) does perform as before and still has back routes everywhere

### Issue

closes https://github.com/shapeshift/web/pull/10854

### Screenshots

- develop:

<img width="970" height="871" alt="Screenshot 2025-10-20 at 15 54 23" src="https://github.com/user-attachments/assets/a21a332f-ee68-4623-be0a-80c0730d7202" />
<img width="959" height="868" alt="Screenshot 2025-10-20 at 15 54 15" src="https://github.com/user-attachments/assets/938c567d-ef17-4ad8-a048-2de851ba6e37" />

- This diff:

<img width="948" height="836" alt="Screenshot 2025-10-20 at 15 54 43" src="https://github.com/user-attachments/assets/a3fc9d11-2fc7-4b16-94f3-346aa8bb1170" />
<img width="985" height="844" alt="Screenshot 2025-10-20 at 15 54 34" src="https://github.com/user-attachments/assets/6e1773fe-89df-4a60-977d-f67a4c5a1e9d" />

- Mobile regression test 

https://jam.dev/c/a35aa704-6326-4a1b-b9a9-d8d3e6390bbb


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI/UX**
  * Back button is now hidden on wallet rename and delete screens and other root-level routes.
  * Back-button visibility logic simplified — controlled consistently by route detection.
  * Connect-route behavior and navigation remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->