### PR TITLE
fix: don't always send max

### DIFF
--- a/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
+++ b/src/components/Modals/Send/hooks/useSendDetails/useSendDetails.tsx
@@ -4,7 +4,7 @@ import type { FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { ChainAdapterError, solana } from '@shapeshiftoss/chain-adapters'
 import { contractAddressOrUndefined } from '@shapeshiftoss/utils'
 import { useQuery } from '@tanstack/react-query'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useFormContext, useWatch } from 'react-hook-form'
 import { useTranslate } from 'react-polyglot'
 


### PR DESCRIPTION
## Description

In the new send flow, if "Send max" is clicked, and then some other smaller amount entered, we send the max amount anyway.

I learned this the hard way.

This change unconditionally clears the send max flag in `handleInputChange` whenever the user manually changes the input amount.

## Issue (if applicable)

N/A, found when testing current release: https://discord.com/channels/554694662431178782/1429766121925513366/1430051803399196723

## Risk

Low - simple change, fixes bad bug.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Send flows.

## Testing

In the new send flow, click "Send max", then enter a smaller amount and proceed with the send.
That smaller amount should be sent, not the max amount.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Send Max now reliably clears whenever you manually edit the amount field, preventing unintended max amounts from remaining set.
  * Amount edits and subsequent transactions are now more predictable, reducing risk of accidental overpayments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->