### PR TITLE
fix: account id selection in new send flow

### DIFF
--- a/src/components/AccountSelector/AccountSelector.tsx
+++ b/src/components/AccountSelector/AccountSelector.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Flex, HStack, Icon, Text, useDisclosure, VStack } from '@c
 import type { AccountId, AssetId } from '@shapeshiftoss/caip'
 import { fromAccountId } from '@shapeshiftoss/caip'
 import type { FC } from 'react'
-import { memo, useCallback, useEffect, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 import { RiExpandUpDownLine } from 'react-icons/ri'
 import { useTranslate } from 'react-polyglot'
 
@@ -66,12 +66,6 @@ export const AccountSelector: FC<AccountSelectorProps> = memo(
           : undefined,
       [accountMetadata, selectedAccountId],
     )
-
-    useEffect(() => {
-      if (!selectedAccountId) {
-        onChange(accountIds[0])
-      }
-    }, [selectedAccountId, accountIds, onChange])
 
     const selectedAccountDetails = useMemo(() => {
       if (!selectedAccountId || !asset) return null

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -1,6 +1,6 @@
 import { useMediaQuery } from '@chakra-ui/react'
 import type { AccountId, AssetId, ChainId } from '@shapeshiftoss/caip'
-import { fromAccountId } from '@shapeshiftoss/caip'
+import { fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type { FeeDataEstimate } from '@shapeshiftoss/chain-adapters'
 import { FeeDataKey } from '@shapeshiftoss/chain-adapters'
 import { AnimatePresence } from 'framer-motion'
@@ -37,7 +37,11 @@ import {
   GenericTransactionDisplayType,
 } from '@/state/slices/actionSlice/types'
 import { preferences } from '@/state/slices/preferencesSlice/preferencesSlice'
-import { selectMarketDataByAssetIdUserCurrency } from '@/state/slices/selectors'
+import {
+  selectFirstAccountIdByChainId,
+  selectMarketDataByAssetIdUserCurrency,
+  selectPortfolioAccountIdsByAssetIdFilter,
+} from '@/state/slices/selectors'
 import { store, useAppDispatch, useAppSelector } from '@/state/store'
 import { breakpoints } from '@/theme/theme'
 
@@ -90,12 +94,23 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
   } = useWallet()
   const [isSmallerThanMd] = useMediaQuery(`(max-width: ${breakpoints.md})`, { ssr: false })
 
+  const filter = useMemo(() => ({ assetId: initialAssetId }), [initialAssetId])
+  const accountIds = useAppSelector(state =>
+    selectPortfolioAccountIdsByAssetIdFilter(state, filter),
+  )
+
   const [addressError, setAddressError] = useState<string | null>(null)
+
+  const defaultAccountId = useMemo(() => {
+    if (accountId) return accountId
+
+    return accountIds[0]
+  }, [accountIds, accountId])
 
   const methods = useForm<SendInput>({
     mode: 'onChange',
     defaultValues: {
-      accountId,
+      accountId: defaultAccountId,
       to: '',
       input,
       vanityAddress: '',
@@ -107,6 +122,7 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
       txHash: '',
     },
   })
+
   const assetId = useWatch<SendInput, SendFormFields.AssetId>({
     name: SendFormFields.AssetId,
     control: methods.control,
@@ -203,10 +219,16 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
     (assetId: AssetId) => {
       // Set all form values
       methods.setValue(SendFormFields.AssetId, assetId)
-      methods.setValue(SendFormFields.AccountId, '')
       methods.setValue(SendFormFields.AmountCryptoPrecision, '')
       methods.setValue(SendFormFields.FiatAmount, '')
       methods.setValue(SendFormFields.FiatSymbol, selectedCurrency)
+
+      const accountId = selectFirstAccountIdByChainId(
+        store.getState(),
+        fromAssetId(assetId).chainId,
+      )
+
+      methods.setValue(SendFormFields.AccountId, accountId ?? '')
 
       // Use requestAnimationFrame to ensure navigation happens after state updates
       requestAnimationFrame(() => {


### PR DESCRIPTION
## Description

There was a race condition on the default account id selection causing an issue with sends if you were coming from the asset view directly

Now we are setting the default account id upper in the tree as a default value of the form so it's already defined

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted in https://discord.com/channels/554694662431178782/1429766121925513366/1430060630924329053

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to send an UTXO from the wallet page
- Try to send an UTXO from the asset page
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/e93646ab-421c-47a4-89ea-bdde15659a59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account selector no longer automatically selects the first account when none is explicitly chosen
  * Send form now intelligently selects the appropriate account when switching assets based on the asset's blockchain network

<!-- end of auto-generated comment: release notes by coderabbit.ai -->