### PR TITLE
fix: generic notification args

### DIFF
--- a/src/components/Layout/Header/ActionCenter/components/Notifications/GenericTransactionNotification.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Notifications/GenericTransactionNotification.tsx
@@ -54,12 +54,16 @@ export const GenericTransactionNotification = ({
   }, [action, asset])
 
   const translationArgs = useMemo(() => {
-    if (!action) return undefined
+    if (!action || !asset) return undefined
     return [
       action.transactionMetadata.message,
-      { newAddress: firstFourLastFour(action.transactionMetadata.newAddress ?? '') },
-    ] as [string, Record<string, string>]
-  }, [action])
+      {
+        amount: action.transactionMetadata.amountCryptoPrecision,
+        symbol: asset.symbol,
+        newAddress: firstFourLastFour(action.transactionMetadata.newAddress ?? ''),
+      },
+    ] as [string, Record<string, string | number>]
+  }, [action, asset])
 
   const title = useMemo(() => {
     if (!action || !translationComponents || !translationArgs) return undefined


### PR DESCRIPTION
## Description

Toast notifications were showing raw translation placeholders like "Sending %{amount} %{symbol}" instead of the actual interpolated values like "Sending 1.5 ETH".

This PR updates the `translationArgs` to include the missing `amount` and `symbol` values.

## Issue (if applicable)

N/A, current release issue: https://discord.com/channels/554694662431178782/1430380778063138816/1430424870537396305

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

When sending crypto, the pending state toast should resolve the values of amount and symbol:

<img width="394" height="152" alt="Screenshot 2025-10-22 at 4 45 18 pm" src="https://github.com/user-attachments/assets/cfcb27c4-ed1e-4ee1-88b4-56c53e5ed96d" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced transaction notifications to display more complete information, including transaction amount, symbol, and recipient address details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->