### PR TITLE
fix: route links trade properly so they prefill

### DIFF
--- a/src/components/AssetHeader/AssetActions.tsx
+++ b/src/components/AssetHeader/AssetActions.tsx
@@ -18,10 +18,10 @@ import { useCallback, useMemo } from 'react'
 import { FaCreditCard, FaEllipsisH } from 'react-icons/fa'
 import { TbExternalLink, TbFlag, TbStar, TbStarFilled } from 'react-icons/tb'
 import { useTranslate } from 'react-polyglot'
-import { useNavigate } from 'react-router-dom'
 
 import { SwapIcon } from '@/components/Icons/SwapIcon'
 import { FiatRampAction } from '@/components/Modals/FiatRamps/FiatRampsCommon'
+import { useTradeNavigation } from '@/components/MultiHopTrade/hooks/useTradeNavigation'
 import { WalletActions } from '@/context/WalletProvider/actions'
 import { KeyManager } from '@/context/WalletProvider/KeyManager'
 import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
@@ -82,8 +82,8 @@ export const AssetActions: React.FC<AssetActionProps> = ({
   cryptoBalance,
   isMobile,
 }) => {
-  const navigate = useNavigate()
   const appDispatch = useAppDispatch()
+  const { navigateToTrade } = useTradeNavigation()
 
   const send = useModal('send')
   const receive = useModal('receive')
@@ -163,8 +163,8 @@ export const AssetActions: React.FC<AssetActionProps> = ({
 
   const handleTradeClick = useCallback(() => {
     vibrate('heavy')
-    navigate(`/trade/${assetId}`)
-  }, [assetId, navigate])
+    navigateToTrade(assetId)
+  }, [assetId, navigateToTrade])
 
   const handleMoreClick = useCallback(() => {
     vibrate('heavy')

--- a/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
+++ b/src/components/MarketTableVirtualized/MarketsTableVirtualized.tsx
@@ -4,7 +4,6 @@ import type { Asset } from '@shapeshiftoss/types'
 import { noop } from 'lodash'
 import { memo, useCallback, useMemo, useState } from 'react'
 import { useTranslate } from 'react-polyglot'
-import { useNavigate } from 'react-router-dom'
 import type { Column, Row } from 'react-table'
 
 import { WatchAssetButton } from '../AssetHeader/WatchAssetButton'
@@ -16,6 +15,7 @@ import { VolumeCell } from './VolumeCell'
 
 import { AssetList } from '@/components/AssetSearch/components/AssetList'
 import { GroupedAssets } from '@/components/MarketTableVirtualized/GroupedAssets'
+import { useTradeNavigation } from '@/components/MultiHopTrade/hooks/useTradeNavigation'
 import { InfiniteTable } from '@/components/ReactTable/InfiniteTable'
 import { Text } from '@/components/Text'
 import { useFetchFiatAssetMarketData } from '@/state/apis/fiatRamps/hooks'
@@ -30,7 +30,7 @@ type MarketsTableVirtualizedProps = {
 export const MarketsTableVirtualized: React.FC<MarketsTableVirtualizedProps> = memo(
   ({ rows, onRowClick, onRowLongPress }) => {
     const translate = useTranslate()
-    const navigate = useNavigate()
+    const { navigateToTrade } = useTradeNavigation()
     const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
 
     const [visibleAssetIds, setVisibleAssetIds] = useState<Set<string>>(new Set())
@@ -47,9 +47,9 @@ export const MarketsTableVirtualized: React.FC<MarketsTableVirtualizedProps> = m
         e.stopPropagation()
         const assetId = e.currentTarget.getAttribute('data-asset-id')
         if (!assetId) return
-        navigate(`/trade/${assetId}`)
+        navigateToTrade(assetId)
       },
-      [navigate],
+      [navigateToTrade],
     )
 
     const tradeTranslation = useMemo(

--- a/src/components/MarketsTable.tsx
+++ b/src/components/MarketsTable.tsx
@@ -5,13 +5,13 @@ import { truncate } from 'lodash'
 import { memo, useCallback, useMemo } from 'react'
 import { RiArrowRightDownFill, RiArrowRightUpFill } from 'react-icons/ri'
 import { useTranslate } from 'react-polyglot'
-import { useNavigate } from 'react-router-dom'
 import type { Column, Row } from 'react-table'
 
 import { WatchAssetButton } from './AssetHeader/WatchAssetButton'
 
 import { Amount } from '@/components/Amount/Amount'
 import { Display } from '@/components/Display'
+import { useTradeNavigation } from '@/components/MultiHopTrade/hooks/useTradeNavigation'
 import { ReactTableNoPager } from '@/components/ReactTable/ReactTableNoPager'
 import { AssetCell } from '@/components/StakingVaults/Cells'
 import { Text } from '@/components/Text'
@@ -40,7 +40,7 @@ type MarketsTableProps = {
 export const MarketsTable: React.FC<MarketsTableProps> = memo(
   ({ rows, onRowClick, forceCompactView }) => {
     const translate = useTranslate()
-    const navigate = useNavigate()
+    const { navigateToTrade } = useTradeNavigation()
     const [isLargerThanMd] = useMediaQuery(`(min-width: ${breakpoints['md']})`, { ssr: false })
     const [isLargerThanLg] = useMediaQuery(`(min-width: ${breakpoints['lg']})`, { ssr: false })
     const showHeaders = isLargerThanMd && !forceCompactView
@@ -63,9 +63,9 @@ export const MarketsTable: React.FC<MarketsTableProps> = memo(
         e.stopPropagation()
         const assetId = e.currentTarget.getAttribute('data-asset-id')
         if (!assetId) return
-        navigate(`/trade/${assetId}`)
+        navigateToTrade(assetId)
       },
-      [navigate],
+      [navigateToTrade],
     )
     const columns: Column<Asset>[] = useMemo(
       () => [

--- a/src/components/MultiHopTrade/hooks/useTradeNavigation.ts
+++ b/src/components/MultiHopTrade/hooks/useTradeNavigation.ts
@@ -1,0 +1,43 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+import { btcAssetId, ethAssetId, fromAssetId } from '@shapeshiftoss/caip'
+import { useCallback } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
+
+interface UseTradeNavigationOptions {
+  sellAssetIdOverride?: AssetId
+  initialAmount?: string
+}
+
+export const useTradeNavigation = () => {
+  const navigate = useNavigate()
+
+  const navigateToTrade = useCallback(
+    (buyAssetId: AssetId, options?: UseTradeNavigationOptions) => {
+      if (options?.sellAssetIdOverride) {
+        const initialAmount = options.initialAmount ?? '0'
+        navigate(`/trade/${buyAssetId}/${options.sellAssetIdOverride}/${initialAmount}`)
+        return
+      }
+
+      const nativeSellAssetId = getChainAdapterManager()
+        .get(fromAssetId(buyAssetId).chainId)
+        ?.getFeeAssetId()
+
+      const sellAssetId = (() => {
+        if (buyAssetId !== nativeSellAssetId) return nativeSellAssetId
+        if (buyAssetId === ethAssetId) return btcAssetId
+        return ethAssetId
+      })()
+
+      if (!sellAssetId) return
+
+      const initialAmount = options?.initialAmount ?? '0'
+      navigate(`/trade/${buyAssetId}/${sellAssetId}/${initialAmount}`)
+    },
+    [navigate],
+  )
+
+  return { navigateToTrade }
+}


### PR DESCRIPTION
## Description

This fixes our deep linking to trade page to ensure we prefill whatever asset was clicked as the buy asset and corresponding native asset as the sell asset.

I've also centralised the logic and added some better defaults for native assets. Deep linking from non-eth native assets will now default the sell asset to ETH. Deep linking from ETH will set the sell asset to BTC.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #10791 

## Risk

Low-medium. Might break trade deep linking where it's currently working.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Think of all places where you're in an asset context and click "trade" to navigate to the trade page with the buy asset pre filled. Make sure that works. Two examples are on the asset page and on the explore assets page (on desktop)

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

https://jam.dev/c/d4bfcd98-f991-428f-971c-4c3db4ec1843


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved trade route navigation handling for better code organization and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->