### PR TITLE
fix: generic notification translation strings

### DIFF
--- a/src/components/Layout/Header/ActionCenter/components/Notifications/GenericTransactionNotification.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Notifications/GenericTransactionNotification.tsx
@@ -63,6 +63,7 @@ export const GenericTransactionNotification = ({
         // Spread all serializable metadata fields first to ensure all values are available for interpolation
         ...serializableMetadata,
         // Then override with computed/transformed values
+        amount: action.transactionMetadata.amountCryptoPrecision, // Map to 'amount' for translation strings
         symbol: asset.symbol, // Symbol comes from asset, not metadata
         newAddress: firstFourLastFour(action.transactionMetadata.newAddress ?? ''), // Formatted version
       },


### PR DESCRIPTION
## Description

Fixed translation parameter issues in `GenericTransactionNotification` component that were causing literal placeholders (e.g., `%{assetAmountsAndSymbols}`, `%{poolName}`, `%{contractName}`, `%{cooldownPeriod}`) to render in toast notifications instead of the actual values.

The component was originally designed with a limited set of translation parameters and wasn't updated when new notification types were added. This PR adds all available metadata fields from `ActionGenericTransactionMetadata` to the translation args, ensuring all current and future translation messages have access to the parameters they need.

**Affected Notifications:**
- THORChain LP deposits/withdrawals - now correctly shows pool name and asset amounts
- RFOX unstaking - now correctly shows cooldown period
- Approval transactions - now correctly shows contract name
- All other generic transaction notifications using metadata fields

## Issue (if applicable)

Addresses finding in polish: https://discord.com/channels/554694662431178782/1432735171362295961

Closes https://github.com/shapeshift/web/issues/10969

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

**Test the fix by triggering notifications for the following transaction types:**

1. **THORChain LP Withdraw:**
   - Navigate to THORChain LP pool positions
   - Initiate a withdrawal (any type: sym, asset-only, or rune-only)
   - Verify toast notification shows actual asset amounts and pool name (e.g., "Your withdraw of 0.5 ETH and 100 RUNE from the ETH/RUNE pool is processing")
   - Verify action center card also displays correctly

2. **THORChain LP Deposit:**
   - Initiate a deposit to any THORChain LP pool
   - Verify toast shows amount, symbol, and pool name correctly

3. **RFOX Unstaking:**
   - Unstake RFOX tokens
   - Verify toast shows amount, symbol, and cooldown period correctly

4. **Token Approvals:**
   - Initiate any transaction requiring token approval (THORChain LP, RFOX staking, etc.)
   - Verify approval notification shows contract name and amount correctly

5. **TCY Staking/Unstaking:**
   - Test TCY stake and unstake operations
   - Verify amounts and symbols display correctly

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Cleaned up transaction notification payloads to remove non-serializable data so notifications serialize reliably.
  * Ensured notifications include asset symbol, amount, and a shortened/new address for clearer, localized messages.
  * Made translation data tolerant of optional/missing values to prevent rendering issues in localized notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands and sanitizes translation args in `GenericTransactionNotification` by spreading serializable metadata and overriding key fields for correct interpolation.
> 
> - **Notifications**:
>   - **`src/components/.../GenericTransactionNotification.tsx`**:
>     - Build translation args by spreading serializable `transactionMetadata` fields (excluding `confirmedQuote`), then override with computed `amount`, `symbol` (from `asset`), and formatted `newAddress`.
>     - Update translation arg typing to allow optional values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5f7bc0c97b36d483e057e6ffcd64b3cd22aba4b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->