### PR TITLE
fix: re-add qr scanner button

### DIFF
--- a/src/components/Layout/Header/NavBar/DrawerWalletHeader.tsx
+++ b/src/components/Layout/Header/NavBar/DrawerWalletHeader.tsx
@@ -19,6 +19,7 @@ import { useNavigate } from 'react-router-dom'
 
 import { WalletImage } from './WalletImage'
 
+import { QRCodeIcon } from '@/components/Icons/QRCode'
 import { SUPPORTED_WALLETS } from '@/context/WalletProvider/config'
 import type { InitialState } from '@/context/WalletProvider/WalletProvider'
 import { useModal } from '@/hooks/useModal/useModal'
@@ -30,6 +31,7 @@ import { useAppSelector } from '@/state/store'
 const settingsIcon = <TbSettings />
 const dotsIcon = <Icon as={TbDots} />
 const eyeOffIcon = <Icon as={TbEyeOff} />
+const qrCodeIcon = <QRCodeIcon />
 
 type DrawerHeaderProps = {
   walletInfo: InitialState['walletInfo']
@@ -54,6 +56,7 @@ export const DrawerWalletHeader: FC<DrawerHeaderProps> = memo(
   }) => {
     const translate = useTranslate()
     const settings = useModal('settings')
+    const qrCode = useModal('qrCode')
     const navigate = useNavigate()
 
     const maybeRdns = useAppSelector(selectWalletRdns)
@@ -73,6 +76,10 @@ export const DrawerWalletHeader: FC<DrawerHeaderProps> = memo(
 
       settings.open({})
     }, [settings, onSettingsClick])
+
+    const handleQrCodeClick = useCallback(() => {
+      qrCode.open({})
+    }, [qrCode])
 
     const handleManageHiddenAssetsClick = useCallback(() => {
       navigate('/manage-hidden-assets')
@@ -100,6 +107,14 @@ export const DrawerWalletHeader: FC<DrawerHeaderProps> = memo(
           <Text fontWeight='medium'>{label}</Text>
         </Flex>
         <Flex gap={2}>
+          <IconButton
+            aria-label={translate('modals.send.qrCode')}
+            isRound
+            fontSize='lg'
+            icon={qrCodeIcon}
+            size='md'
+            onClick={handleQrCodeClick}
+          />
           <IconButton
             aria-label='Settings'
             isRound


### PR DESCRIPTION
## Description

Re-adds the QR scanner button to the app via the new wallet drawer.

<img width="727" height="386" alt="Screenshot 2025-10-30 at 12 42 29 pm" src="https://github.com/user-attachments/assets/088f89e9-4581-4e72-8e9d-6ece4e78435c" />

## Issue (if applicable)

N/A, noted during the current release flow: https://discord.com/channels/554694662431178782/1432901947366703259/1432932211321077901

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

Confirm that the QR code scanner works in the wallet drawer.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a QR code button to the wallet header that opens a modal displaying QR code information for enhanced accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->