### PR TITLE
fix: restore some translation strings

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1069,30 +1069,6 @@
         }
       }
     },
-    "settings": {
-      "currencies": {
-        "CNY": "Chinese Yuan",
-        "USD": "US Dollar",
-        "EUR": "Euro",
-        "JPY": "Japanese Yen",
-        "GBP": "British Pound",
-        "KRW": "South Korean Won",
-        "INR": "Indian Rupee",
-        "CAD": "Canadian Dollar",
-        "HKD": "Hong Kong Dollar",
-        "AUD": "Australian Dollar",
-        "TWD": "Taiwan Dollar",
-        "BRL": "Brazilian Real",
-        "CHF": "Swiss Franc",
-        "THB": "Thai Baht",
-        "MXN": "Mexican Peso",
-        "RUB": "Russian Ruble",
-        "SAR": "Saudi Riyal",
-        "SGD": "Singapore Dollar",
-        "ILS": "Israeli Shekel",
-        "IDR": "Indonesian Rupiah"
-      }
-    },
     "send": {
       "confirmSend": "Confirm send",
       "consolidate": {
@@ -1249,7 +1225,29 @@
       "currencyFormat": "Currency Format",
       "language": "Language",
       "balanceThreshold": "Balance Threshold",
-      "balanceThresholdTooltip": "On dashboard and charts, hide balances below this value"
+      "balanceThresholdTooltip": "On dashboard and charts, hide balances below this value",
+      "currencies": {
+        "CNY": "Chinese Yuan",
+        "USD": "US Dollar",
+        "EUR": "Euro",
+        "JPY": "Japanese Yen",
+        "GBP": "British Pound",
+        "KRW": "South Korean Won",
+        "INR": "Indian Rupee",
+        "CAD": "Canadian Dollar",
+        "HKD": "Hong Kong Dollar",
+        "AUD": "Australian Dollar",
+        "TWD": "Taiwan Dollar",
+        "BRL": "Brazilian Real",
+        "CHF": "Swiss Franc",
+        "THB": "Thai Baht",
+        "MXN": "Mexican Peso",
+        "RUB": "Russian Ruble",
+        "SAR": "Saudi Riyal",
+        "SGD": "Singapore Dollar",
+        "ILS": "Israeli Shekel",
+        "IDR": "Indonesian Rupiah"
+      }
     },
     "ramp": {
       "payWith": "Pay With",


### PR DESCRIPTION
## Description

Restores translation keys that were incorrectly removed in commit b51a5f2a3e during a translation audit. The removal script didn't account for dynamic key construction patterns where translation keys are built using template literals (e.g., `` `walletProvider.${keyManager}.connect.header` ``).

## Issue (if applicable)

Follow-up from https://github.com/shapeshift/web/pull/10937

## Risk

Low, though the biggest impact will be translated text not appearing in some places if there are missing keys.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

This PR by definition only fixes bugs and should not create any. If there were any accidentally removed in the [previous PR](https://github.com/shapeshift/web/pull/10937), then this should fix them.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple currencies in settings (CNY, EUR, JPY, GBP, KRW, INR, CAD, AUD, TWD, and others)
  * Enhanced onboarding experience with new sections covering multi-chain capabilities and self-custody options
  * Improved claim flow with enhanced status messaging for better user feedback
* **Chores**
  * Updated WalletConnect session metadata fields

<!-- end of auto-generated comment: release notes by coderabbit.ai -->