### PR TITLE
fix: limit order translations

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -912,6 +912,14 @@
     "sellBuy": "Sell → Buy",
     "limitExecution": "Limit/Execution",
     "statusHead": "Status",
+    "expiryOption": {
+      "oneHour": "1 hour",
+      "oneDay": "1 day",
+      "threeDays": "3 days",
+      "sevenDays": "7 days",
+      "twentyEightDays": "28 days",
+      "custom": "Custom"
+    },
     "expires": "Expires %{time}",
     "errors": {
       "nativeSellAssetNotSupported": "Native sell asset not supported",
@@ -947,6 +955,7 @@
       }
     },
     "limitOrderFilled": "Limit order filled",
+    "limitOrderPartiallyFilled": "Limit order partially filled",
     "assetToAsset": "%{sellAmount} %{sellAsset} to %{buyAmount} %{buyAsset}"
   },
   "modals": {


### PR DESCRIPTION
## Description

Some needed limit order translations were removed in https://github.com/shapeshift/web/pull/10937, and not caught.

Bring them back.

## Issue (if applicable)

N/A

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

UI should look like this:

<img width="568" height="293" alt="Screenshot 2025-10-31 at 4 28 05 pm" src="https://github.com/user-attachments/assets/32af6c2c-eeba-4e2e-93c4-00e1dcf9cbd2" />

Not this:

<img width="1006" height="536" alt="image" src="https://github.com/user-attachments/assets/1e9f6b2c-2f02-4fed-a016-5c8052d2a792" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See testing steps above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for limit order expiry timeframes with translations for 1 hour, 1 day, 3 days, 7 days, 28 days, and custom durations.
  * Added notification message for partially filled limit orders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->