### PR TITLE
fix: restore more translation strings

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -274,6 +274,7 @@
       "asset": "Asset",
       "balance": "Balance",
       "price": "Price",
+      "apy": "APY",
       "priceChange": "Price Change",
       "allocation": "Allocation",
       "marketCap": "Market Cap",
@@ -1568,7 +1569,9 @@
       "create": {
         "header": "Your Secret Recovery Phrase",
         "body": "Write these 12 words down and store them securely offline. This 12 word phrase is used to recover your wallet private keys.",
-        "button": "Next"
+        "button": "Next",
+        "hideWords": "Hide Words",
+        "showWords": "Show Words"
       },
       "start": {
         "header": "ShapeShift Wallet",
@@ -1902,7 +1905,8 @@
         "connect": {
           "title": "Connect your wallet to a dApp via WalletConnect and trigger transactions",
           "linkPlaceholder": "QR code or connection link",
-          "disclaimerBody": "ShapeShift cannot ensure the safety or security of third-party applications. By using WalletConnect, you assume full responsibility for any risks involved."
+          "disclaimerBody": "ShapeShift cannot ensure the safety or security of third-party applications. By using WalletConnect, you assume full responsibility for any risks involved.",
+          "connect": "Connect"
         },
         "sessionProposal": {
           "unsupportedChain": "Unsupported chain namespace in session proposal.",


### PR DESCRIPTION
## Description

Restores more translation strings following https://github.com/shapeshift/web/pull/10937

## Issue (if applicable)

https://discord.com/channels/554694662431178782/1433675437455704184

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Fixes:

<img width="475" height="631" alt="image" src="https://github.com/user-attachments/assets/46864512-db0e-4b7f-b2ac-ecab4b80d23c" />
<img width="446" height="680" alt="image2" src="https://github.com/user-attachments/assets/57415dba-d663-4e92-afbd-0503e1c321ab" />
<img width="1097" height="166" alt="image3" src="https://github.com/user-attachments/assets/47b4b5cb-9fa0-44ef-9f1b-342e23371f63" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dashboard with APY labeling displayed in portfolio and main sections.
  * Enhanced WalletConnect modal with clearer "Connect" label for improved user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->