### PR TITLE
fix: disable preview button in fiat ramp if no quotes available

### DIFF
--- a/src/components/MultiHopTrade/components/FiatRamps/FiatRampTrade.tsx
+++ b/src/components/MultiHopTrade/components/FiatRamps/FiatRampTrade.tsx
@@ -427,7 +427,8 @@ const RampRoutes = memo(({ onChangeTab, direction }: RampRoutesProps) => {
       shouldDisablePreviewButton:
         !hasUserEnteredAmount ||
         (!sellAsset && !sellFiatCurrency) ||
-        (!buyAsset && !buyFiatCurrency),
+        (!buyAsset && !buyFiatCurrency) ||
+        !selectedQuote,
       networkFeeFiatUserCurrency: selectedQuote?.networkFee ?? '0',
       quoteStatusTranslation:
         direction === FiatRampAction.Buy ? 'fiatRamps.previewPurchase' : 'fiatRamps.previewSale',
@@ -472,11 +473,11 @@ const RampRoutes = memo(({ onChangeTab, direction }: RampRoutesProps) => {
     buyAsset,
     sellFiatCurrency,
     buyFiatCurrency,
+    selectedQuote,
     hasUserEnteredAmount,
     rampIcon,
     isFetchingQuotes,
     rateValue,
-    selectedQuote?.networkFee,
     navigate,
   ])
 


### PR DESCRIPTION
## Description

Disabling the preview button on fiat ramps swapper if no quotes are available

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://discord.com/channels/554694662431178782/1429939103176065145/1433577313978683564

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try a pair that isn't up for any swapper like selling or buying to PEPE on BSC
- Notice the preview button is disabled
- Try a pair that is working like USDC to BTC 
- Notice the preview button is working as expected

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/bf0b073d-c551-4f63-83bd-524a0a410387

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the preview button state and footer display to properly respond to quote selection changes in the fiat ramp trading interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->