### PR TITLE
fix: limit over table overflow on large values

### DIFF
--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderCard.tsx
@@ -28,6 +28,17 @@ import {
 } from '@/state/slices/selectors'
 import { useSelectorWithArgs } from '@/state/store'
 
+const getAdaptivePrecision = (value: string | number): number => {
+  const absValue = bnOrZero(value).abs()
+
+  if (absValue.gte(10000)) return 2
+  if (absValue.gte(1000)) return 3
+  if (absValue.gte(100)) return 4
+  if (absValue.gte(10)) return 5
+
+  return 6
+}
+
 export type LimitOrderCardProps = {
   uid: string
   buyAmountCryptoBaseUnit: string
@@ -202,6 +213,23 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
     [executionPrice, toCrypto, buyAsset],
   )
 
+  const sellAmountPrecision = useMemo(
+    () => getAdaptivePrecision(sellAmountCryptoPrecision),
+    [sellAmountCryptoPrecision],
+  )
+
+  const buyAmountPrecision = useMemo(
+    () => getAdaptivePrecision(buyAmountCryptoPrecision),
+    [buyAmountCryptoPrecision],
+  )
+
+  const limitPricePrecision = useMemo(() => getAdaptivePrecision(limitPrice), [limitPrice])
+
+  const executionPricePrecision = useMemo(
+    () => getAdaptivePrecision(executionPrice),
+    [executionPrice],
+  )
+
   const tagColorScheme = useMemo(() => {
     switch (status) {
       case OrderStatus.OPEN:
@@ -284,7 +312,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
                 value={sellAmountCryptoPrecision}
                 symbol={sellAsset.symbol}
                 fontSize={fontSize}
-                maximumFractionDigits={6}
+                maximumFractionDigits={sellAmountPrecision}
               />
             </HoverTooltip>
             <HoverTooltip placement='top' label={buyAmountCryptoFormatted}>
@@ -292,7 +320,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
                 value={buyAmountCryptoPrecision}
                 symbol={buyAsset.symbol}
                 fontSize={fontSize}
-                maximumFractionDigits={6}
+                maximumFractionDigits={buyAmountPrecision}
               />
             </HoverTooltip>
           </Flex>
@@ -307,7 +335,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
               symbol={buyAsset.symbol}
               color={status === OrderStatus.FULFILLED ? 'text.subtle' : 'text.base'}
               fontSize={fontSize}
-              maximumFractionDigits={6}
+              maximumFractionDigits={limitPricePrecision}
             />
           </HoverTooltip>
           {status === OrderStatus.FULFILLED && (
@@ -317,7 +345,7 @@ export const LimitOrderCard: FC<LimitOrderCardProps> = ({
                 symbol={buyAsset.symbol}
                 fontSize={fontSize}
                 color='text.base'
-                maximumFractionDigits={6}
+                maximumFractionDigits={executionPricePrecision}
               />
             </HoverTooltip>
           )}


### PR DESCRIPTION
## Description

Prevent limit order table from overflowing on mobile when we have values with a high magnitude like 1002.234234. 

This just adds an adaptive precision calc so it gets less precise as the magnitude grows

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #11054 

## Risk

Low risk, will muck with precision on the limit table

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Test that the limit order table (view orders) shows the cross on mobile. Even with large limit orders like in the description
* It won't be perfect but it should be more manageable on smaller screens

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="635" height="353" alt="image" src="https://github.com/user-attachments/assets/44738172-296d-4333-93ab-cdfaadaa8dcd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Limit order amounts and prices now display with adaptive decimal precision, automatically adjusting decimal places based on value magnitude for improved readability across different order sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->