### PR TITLE
fix: unrug Arbitrum OpenAPI spec (DO NOT MERGE)

### DIFF
--- a/packages/unchained-client/arbitrum-swagger.json
+++ b/packages/unchained-client/arbitrum-swagger.json
@@ -549,7 +549,9 @@
 				"description": "Construct a type with a set of properties K of type T"
 			},
 			"StakingDuration": {
-				"$ref": "#/components/schemas/Record_string.number_"
+				"properties": {},
+				"type": "object",
+				"description": "Mapping of staking contract addresses to their duration values in seconds"
 			}
 		},
 		"securitySchemes": {}

--- a/packages/unchained-client/arbitrum-swagger.json
+++ b/packages/unchained-client/arbitrum-swagger.json
@@ -1,0 +1,1290 @@
+{
+	"components": {
+		"examples": {},
+		"headers": {},
+		"parameters": {},
+		"requestBodies": {},
+		"responses": {},
+		"schemas": {
+			"BaseInfo": {
+				"description": "Contains base info about the running coinstack",
+				"properties": {
+					"network": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"network"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenBalance": {
+				"description": "Contains info about a token including balance for an address",
+				"properties": {
+					"contract": {
+						"type": "string"
+					},
+					"decimals": {
+						"type": "number",
+						"format": "double"
+					},
+					"name": {
+						"type": "string"
+					},
+					"symbol": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string",
+						"description": "nft or multi token id"
+					},
+					"balance": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"contract",
+					"decimals",
+					"name",
+					"symbol",
+					"type",
+					"balance"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Account": {
+				"description": "Contains info about an EVM account",
+				"properties": {
+					"balance": {
+						"type": "string"
+					},
+					"unconfirmedBalance": {
+						"type": "string"
+					},
+					"pubkey": {
+						"type": "string"
+					},
+					"nonce": {
+						"type": "number",
+						"format": "double"
+					},
+					"tokens": {
+						"items": {
+							"$ref": "#/components/schemas/TokenBalance"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"balance",
+					"unconfirmedBalance",
+					"pubkey",
+					"nonce",
+					"tokens"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"BadRequestError": {
+				"description": "Contains info about a 400 Bad Request response",
+				"properties": {
+					"error": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"error"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"ValidationError": {
+				"description": "Contains info about a 422 Validation Error response",
+				"properties": {
+					"message": {
+						"type": "string",
+						"enum": [
+							"Validation failed"
+						],
+						"nullable": false
+					},
+					"details": {
+						"properties": {},
+						"additionalProperties": {},
+						"type": "object"
+					}
+				},
+				"required": [
+					"message",
+					"details"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"InternalServerError": {
+				"description": "Contains info about a 500 Internal Server Error response",
+				"properties": {
+					"message": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"message"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenTransfer": {
+				"description": "Contains info about a token including transfer details",
+				"properties": {
+					"contract": {
+						"type": "string"
+					},
+					"decimals": {
+						"type": "number",
+						"format": "double"
+					},
+					"name": {
+						"type": "string"
+					},
+					"symbol": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string",
+						"description": "nft or multi token id"
+					},
+					"from": {
+						"type": "string"
+					},
+					"to": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"contract",
+					"decimals",
+					"name",
+					"symbol",
+					"type",
+					"from",
+					"to",
+					"value"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"InternalTx": {
+				"description": "Contains info about an EVM internal transaction",
+				"properties": {
+					"from": {
+						"type": "string"
+					},
+					"to": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"from",
+					"to",
+					"value"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Tx": {
+				"description": "Contains info about an EVM transaction",
+				"properties": {
+					"txid": {
+						"type": "string"
+					},
+					"blockHash": {
+						"type": "string"
+					},
+					"blockHeight": {
+						"type": "number",
+						"format": "double"
+					},
+					"timestamp": {
+						"type": "number",
+						"format": "double"
+					},
+					"from": {
+						"type": "string"
+					},
+					"to": {
+						"type": "string"
+					},
+					"confirmations": {
+						"type": "number",
+						"format": "double"
+					},
+					"value": {
+						"type": "string"
+					},
+					"fee": {
+						"type": "string"
+					},
+					"gasLimit": {
+						"type": "string"
+					},
+					"gasUsed": {
+						"type": "string"
+					},
+					"gasPrice": {
+						"type": "string"
+					},
+					"status": {
+						"type": "number",
+						"format": "double"
+					},
+					"inputData": {
+						"type": "string"
+					},
+					"tokenTransfers": {
+						"items": {
+							"$ref": "#/components/schemas/TokenTransfer"
+						},
+						"type": "array"
+					},
+					"internalTxs": {
+						"items": {
+							"$ref": "#/components/schemas/InternalTx"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"txid",
+					"blockHeight",
+					"timestamp",
+					"from",
+					"to",
+					"confirmations",
+					"value",
+					"fee",
+					"gasLimit",
+					"gasPrice",
+					"status"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"BaseTxHistory_Tx_": {
+				"description": "Contains paginated base transaction history details",
+				"properties": {
+					"cursor": {
+						"type": "string"
+					},
+					"pubkey": {
+						"type": "string"
+					},
+					"txs": {
+						"items": {
+							"$ref": "#/components/schemas/Tx"
+						},
+						"type": "array"
+					}
+				},
+				"required": [
+					"pubkey",
+					"txs"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TxHistory": {
+				"$ref": "#/components/schemas/BaseTxHistory_Tx_",
+				"description": "Contains info about EVM transaction history"
+			},
+			"SendTxBody": {
+				"description": "Contains the serialized raw transaction hex",
+				"properties": {
+					"hex": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"hex"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCResponse": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"result": {},
+					"error": {
+						"properties": {
+							"data": {},
+							"message": {
+								"type": "string"
+							},
+							"code": {
+								"type": "number",
+								"format": "double"
+							}
+						},
+						"required": [
+							"message",
+							"code"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"RPCRequest": {
+				"properties": {
+					"jsonrpc": {
+						"type": "string",
+						"enum": [
+							"2.0"
+						],
+						"nullable": false
+					},
+					"id": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "number",
+								"format": "double"
+							}
+						]
+					},
+					"method": {
+						"type": "string"
+					},
+					"params": {
+						"items": {},
+						"type": "array"
+					}
+				},
+				"required": [
+					"jsonrpc",
+					"id",
+					"method"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenMetadata": {
+				"description": "Contains info about token metadata (ERC-721/ERC-1155)",
+				"properties": {
+					"address": {
+						"type": "string"
+					},
+					"id": {
+						"type": "string"
+					},
+					"type": {
+						"type": "string"
+					},
+					"name": {
+						"type": "string"
+					},
+					"description": {
+						"type": "string"
+					},
+					"media": {
+						"properties": {
+							"type": {
+								"type": "string",
+								"enum": [
+									"image",
+									"video"
+								]
+							},
+							"url": {
+								"type": "string"
+							}
+						},
+						"required": [
+							"url"
+						],
+						"type": "object"
+					}
+				},
+				"required": [
+					"address",
+					"id",
+					"type",
+					"name",
+					"description",
+					"media"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"TokenType": {
+				"type": "string",
+				"enum": [
+					"erc721",
+					"erc1155"
+				],
+				"description": "Supported token types for token metadata"
+			},
+			"GasEstimate": {
+				"description": "Contains info about estimated gas cost of a transaction",
+				"properties": {
+					"gasLimit": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"gasLimit"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"EstimateGasBody": {
+				"description": "Contains the transaction data to estimate gas cost",
+				"properties": {
+					"data": {
+						"type": "string"
+					},
+					"from": {
+						"type": "string"
+					},
+					"to": {
+						"type": "string"
+					},
+					"value": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"data",
+					"from",
+					"to",
+					"value"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Fees": {
+				"description": "Contains info about legacy and/or EIP-1559 fees",
+				"properties": {
+					"gasPrice": {
+						"type": "string"
+					},
+					"maxFeePerGas": {
+						"type": "string"
+					},
+					"maxPriorityFeePerGas": {
+						"type": "string"
+					}
+				},
+				"required": [
+					"gasPrice"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"GasFees": {
+				"description": "Contains info about current recommended fees to use in a transaction.\nEstimates for slow, average and fast confirmation speeds provided as well.",
+				"properties": {
+					"baseFeePerGas": {
+						"type": "string"
+					},
+					"slow": {
+						"$ref": "#/components/schemas/Fees"
+					},
+					"average": {
+						"$ref": "#/components/schemas/Fees"
+					},
+					"fast": {
+						"$ref": "#/components/schemas/Fees"
+					}
+				},
+				"required": [
+					"slow",
+					"average",
+					"fast"
+				],
+				"type": "object",
+				"additionalProperties": false
+			},
+			"Record_string.number_": {
+				"properties": {},
+				"type": "object",
+				"description": "Construct a type with a set of properties K of type T"
+			},
+			"StakingDuration": {
+				"$ref": "#/components/schemas/Record_string.number_"
+			}
+		},
+		"securitySchemes": {}
+	},
+	"info": {
+		"title": "@shapeshiftoss/arbitrum-api",
+		"version": "10.0.0",
+		"license": {
+			"name": "MIT"
+		},
+		"contact": {}
+	},
+	"openapi": "3.0.0",
+	"paths": {
+		"/api/v1/info": {
+			"get": {
+				"operationId": "GetInfo",
+				"responses": {
+					"200": {
+						"description": "coinstack info",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BaseInfo"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"network": "mainnet"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Get information about the running coinstack",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/account/{pubkey}": {
+			"get": {
+				"operationId": "GetAccount",
+				"responses": {
+					"200": {
+						"description": "account details",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Account"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"balance": "0",
+											"unconfirmedBalance": "0",
+											"nonce": 0,
+											"pubkey": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+											"tokens": [
+												{
+													"balance": "1337",
+													"contract": "0xc770EEfAd204B5180dF6a14Ee197D99d808ee52d",
+													"decimals": 18,
+													"name": "FOX",
+													"symbol": "FOX",
+													"type": "ERC20"
+												}
+											]
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get account details by address",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "account address",
+						"in": "path",
+						"name": "pubkey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/account/{pubkey}/txs": {
+			"get": {
+				"operationId": "GetTxHistory",
+				"responses": {
+					"200": {
+						"description": "transaction history",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TxHistory"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"pubkey": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+											"txs": [
+												{
+													"txid": "0x6850c6f3af68eb60a211af8f07f5b305375d0c94786b79a48371f5143953cb26",
+													"blockHash": "0x969bda3f454330557492deacffb0ee8a7fd1d094cf884926d24c71ad11ed13bb",
+													"blockHeight": 15624164,
+													"timestamp": 1664275343,
+													"status": 1,
+													"from": "0xc730B028dA66EBB14f20e67c68DD809FBC49890D",
+													"to": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+													"confirmations": 3911254,
+													"value": "5384660932716527",
+													"fee": "278408778879000",
+													"gasLimit": "21000",
+													"gasUsed": "21000",
+													"gasPrice": "13257560899"
+												}
+											]
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get transaction history by address",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "account address",
+						"in": "path",
+						"name": "pubkey",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "the cursor returned in previous query (base64 encoded json object with a 'page' property)",
+						"in": "query",
+						"name": "cursor",
+						"required": false,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "page size (10 by default)",
+						"in": "query",
+						"name": "pageSize",
+						"required": false,
+						"schema": {
+							"default": 10,
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"description": "from block number (0 by default)",
+						"in": "query",
+						"name": "from",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					},
+					{
+						"description": "to block number (pending by default)",
+						"in": "query",
+						"name": "to",
+						"required": false,
+						"schema": {
+							"format": "double",
+							"type": "number"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/tx/{txid}": {
+			"get": {
+				"operationId": "GetTransaction",
+				"responses": {
+					"200": {
+						"description": "transaction payload",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/Tx"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"txid": "0x6850c6f3af68eb60a211af8f07f5b305375d0c94786b79a48371f5143953cb26",
+											"blockHash": "0x969bda3f454330557492deacffb0ee8a7fd1d094cf884926d24c71ad11ed13bb",
+											"blockHeight": 15624164,
+											"timestamp": 1664275343,
+											"status": 1,
+											"from": "0xc730B028dA66EBB14f20e67c68DD809FBC49890D",
+											"to": "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+											"confirmations": 3911254,
+											"value": "5384660932716527",
+											"fee": "278408778879000",
+											"gasLimit": "21000",
+											"gasUsed": "21000",
+											"gasPrice": "13257560899"
+										}
+									}
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get transaction details",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "transaction hash",
+						"in": "path",
+						"name": "txid",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/send": {
+			"post": {
+				"operationId": "SendTx",
+				"responses": {
+					"200": {
+						"description": "transaction id",
+						"content": {
+							"application/json": {
+								"schema": {
+									"type": "string"
+								}
+							}
+						}
+					},
+					"400": {
+						"description": "Bad Request",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/BadRequestError"
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Sends raw transaction to be broadcast to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "serialized raw transaction hex",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/SendTxBody",
+								"description": "serialized raw transaction hex"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/jsonrpc": {
+			"post": {
+				"operationId": "DoRpcRequest",
+				"responses": {
+					"200": {
+						"description": "jsonrpc response or batch responses",
+						"content": {
+							"application/json": {
+								"schema": {
+									"anyOf": [
+										{
+											"$ref": "#/components/schemas/RPCResponse"
+										},
+										{
+											"items": {
+												"$ref": "#/components/schemas/RPCResponse"
+											},
+											"type": "array"
+										}
+									]
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"jsonrpc": "2.0",
+											"id": "test",
+											"result": "0x1a4"
+										}
+									}
+								}
+							}
+						}
+					}
+				},
+				"description": "Makes a jsonrpc request to the node.",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "jsonrpc request or batch requests",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"anyOf": [
+									{
+										"$ref": "#/components/schemas/RPCRequest"
+									},
+									{
+										"items": {
+											"$ref": "#/components/schemas/RPCRequest"
+										},
+										"type": "array"
+									}
+								],
+								"description": "jsonrpc request or batch requests"
+							},
+							"example": {
+								"jsonrpc": "2.0",
+								"id": "test",
+								"method": "eth_blockNumber",
+								"params": []
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/metadata/token": {
+			"get": {
+				"operationId": "GetTokenMetadata",
+				"responses": {
+					"200": {
+						"description": "token metadata",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/TokenMetadata"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"address": "0x0000000000000000000000000000000000000000",
+											"id": "123456789",
+											"type": "ERC721",
+											"name": "FoxyFox",
+											"description": "FOXatars are a cyber-fox NFT project created by ShapeShift and Mercle",
+											"media": {
+												"url": "https://storage.mercle.xyz/ipfs/bafybeifihbavnaqwmisq72nwqpmxy3qkfqxj5nvjg7wimluhisp7wkzcru",
+												"type": "image"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get token metadata",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "contract address",
+						"in": "query",
+						"name": "contract",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token identifier",
+						"in": "query",
+						"name": "id",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					},
+					{
+						"description": "token type (erc721 or erc1155)",
+						"in": "query",
+						"name": "type",
+						"required": true,
+						"schema": {
+							"$ref": "#/components/schemas/TokenType"
+						}
+					}
+				]
+			}
+		},
+		"/api/v1/gas/estimate": {
+			"post": {
+				"operationId": "EstimateGas",
+				"responses": {
+					"200": {
+						"description": "estimated gas cost",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GasEstimate"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"gasLimit": "374764"
+										}
+									}
+								}
+							}
+						}
+					},
+					"422": {
+						"description": "Validation Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/ValidationError"
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Estimate gas cost of a transaction",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [],
+				"requestBody": {
+					"description": "transaction data to estimate gas cost",
+					"required": true,
+					"content": {
+						"application/json": {
+							"schema": {
+								"$ref": "#/components/schemas/EstimateGasBody",
+								"description": "transaction data to estimate gas cost"
+							},
+							"example": {
+								"data": "0x",
+								"from": "0x0000000000000000000000000000000000000000",
+								"to": "0x0000000000000000000000000000000000000000",
+								"value": "1337"
+							}
+						}
+					}
+				}
+			}
+		},
+		"/api/v1/gas/fees": {
+			"get": {
+				"operationId": "GetGasFees",
+				"responses": {
+					"200": {
+						"description": "current fees specified in wei",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/GasFees"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"baseFeePerGas": "100000000",
+											"slow": {
+												"gasPrice": "184334277",
+												"maxFeePerGas": "190000001",
+												"maxPriorityFeePerGas": "90000001"
+											},
+											"average": {
+												"gasPrice": "187859277",
+												"maxFeePerGas": "205000001",
+												"maxPriorityFeePerGas": "105000001"
+											},
+											"fast": {
+												"gasPrice": "199001183",
+												"maxFeePerGas": "290000001",
+												"maxPriorityFeePerGas": "190000001"
+											}
+										}
+									}
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get the current recommended gas fees to use in a transaction\n\n* For EIP-1559 transactions, use `maxFeePerGas` and `maxPriorityFeePerGas`\n* For Legacy transactions, use `gasPrice`",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": []
+			}
+		},
+		"/api/v1/rfox/staking-duration/{address}": {
+			"get": {
+				"operationId": "GetRfoxStakingDuration",
+				"responses": {
+					"200": {
+						"description": "staking duration in seconds by staking contract address",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/StakingDuration"
+								},
+								"examples": {
+									"Example 1": {
+										"value": {
+											"0xaC2a4fD70BCD8Bab0662960455c363735f0e2b56": 0,
+											"0x83B51B7605d2E277E03A7D6451B1efc0e5253A2F": 0
+										}
+									}
+								}
+							}
+						}
+					},
+					"500": {
+						"description": "Internal Server Error",
+						"content": {
+							"application/json": {
+								"schema": {
+									"$ref": "#/components/schemas/InternalServerError"
+								}
+							}
+						}
+					}
+				},
+				"description": "Get rFOX staking duration by contract address",
+				"tags": [
+					"v1"
+				],
+				"security": [],
+				"parameters": [
+					{
+						"description": "account address",
+						"in": "path",
+						"name": "address",
+						"required": true,
+						"schema": {
+							"type": "string"
+						}
+					}
+				]
+			}
+		}
+	},
+	"servers": [
+		{
+			"url": "/"
+		}
+	]
+}

--- a/packages/unchained-client/openapitools.json
+++ b/packages/unchained-client/openapitools.json
@@ -149,7 +149,7 @@
         }
       },
       "arbitrum": {
-        "inputSpec": "https://raw.githubusercontent.com/shapeshift/unchained/2551305/node/coinstacks/arbitrum/api/src/swagger.json",
+        "inputSpec": "#{cwd}/arbitrum-swagger.json",
         "generatorName": "typescript-fetch",
         "output": "#{cwd}/src/generated/arbitrum",
         "enablePostProcessFile": true,


### PR DESCRIPTION
## Description

⚠️ **DO NOT MERGE - This PR exists only to validate https://github.com/shapeshift/unchained/pull/1219 works**

PoC validating the unchained fix above. Applies the exact same fix as unchained. 

#### What This PR Does

1. https://github.com/shapeshift/web/pull/11091/commits/67451ba82e9dd28ee21337bc96f36d407c10688b: reproduces the issue by downloading the broken Arbitrum swagger.json locally and referencing it in openapitools.json - nothing to see here 
2. https://github.com/shapeshift/web/pull/11091/commits/38a83f895889a81f192b460e7470b3c690069dec: the akschual fix, applies the fix to the local swagger.json (inline the StakingDuration schema)

#### Background

The issue was introduced in unchained commit [08ce999](https://github.com/shapeshift/unchained/commit/08ce999b79f77709d6c95343b5f794c0a1c6c15e). The `StakingDuration` schema uses a pure `$ref` without inline properties, which triggers a bug in OpenAPI Generator 6.1.0.

## Issue (if applicable)

N/A - This is a validation PR for https://github.com/shapeshift/unchained/pull/1219

## Risk

**Zero risk** - This PR will not be merged. It exists only to validate the unchained fix.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None - not intended for merge.

## Testing

### Engineering

- CI is happy

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

N/A - validation PR only

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)