### PR TITLE
fix: bep-20 dupe assets

### DIFF
--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -370,26 +370,22 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
         chain: this.getType(),
         chainSpecific: {
           nonce: data.nonce,
-          tokens: data.tokens.map(token => {
-            // Hacky workaround to parse unchained-returned BSC tokens as bep-20
-            // We probably shouldn't need this as this seems to be a recent unchained change
-            const namespace =
-              this.chainId === bscChainId && token.type === 'ERC20'
-                ? ASSET_NAMESPACE.bep20
-                : getAssetNamespace(token.type)
-
-            return {
-              balance: token.balance,
-              assetId: toAssetId({
-                chainId: this.chainId,
-                assetNamespace: namespace,
-                assetReference: token.id ? `${token.contract}/${token.id}` : token.contract,
-              }),
-              name: token.name,
-              precision: token.decimals,
-              symbol: token.symbol,
-            }
-          }),
+          tokens: data.tokens.map(token => ({
+            balance: token.balance,
+            assetId: toAssetId({
+              chainId: this.chainId,
+              // Hacky workaround to parse unchained-returned BSC tokens as bep-20
+              // We probably shouldn't need this as this seems to be a recent unchained change
+              assetNamespace:
+                this.chainId === bscChainId && token.type === 'ERC20'
+                  ? ASSET_NAMESPACE.bep20
+                  : getAssetNamespace(token.type),
+              assetReference: token.id ? `${token.contract}/${token.id}` : token.contract,
+            }),
+            name: token.name,
+            precision: token.decimals,
+            symbol: token.symbol,
+          })),
         },
         pubkey,
       } as Account<T>


### PR DESCRIPTION
## Description

Fixes `getAccount` regression currently upserting BEP-20 assets as ERC-20 (see https://github.com/shapeshift/unchained/pull/1188/files#diff-35fa59dd88f8c0830b579c5709add4ba88e3a07e9b070935d9e79aa85780a966R128)

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes https://github.com/shapeshift/web/issues/11121

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low, this is wrong upstream atm and funnels down as dupe assets

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- Run the app
- Ensure there are no dupe BEP-20 with wrong namespace and missing icon for the wrong (erc20: namespace) one

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

- ^

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

- ^

## Screenshots (if applicable)

- develop

<img width="529" height="910" alt="Screenshot 2025-11-17 at 20 16 01" src="https://github.com/user-attachments/assets/ae257d36-9a50-4b1c-a895-c9024bbd363b" />
<img width="484" height="720" alt="Screenshot 2025-11-17 at 20 16 22" src="https://github.com/user-attachments/assets/3dd8e1ce-996d-4052-88e7-e6b0e2d76264" />


- this diff

<img width="542" height="894" alt="Screenshot 2025-11-17 at 20 15 39" src="https://github.com/user-attachments/assets/f25363bd-8e52-49e5-ada7-1627660a4bf0" />
<img width="482" height="708" alt="Screenshot 2025-11-17 at 20 17 09" src="https://github.com/user-attachments/assets/f1390866-7227-42a9-92a7-3761bd120971" />


<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"develop","parentHead":"","trunk":""}
```
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token classification on Binance Smart Chain (BSC) to properly identify BEP20 assets, ensuring accurate token recognition and display throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->