### PR TITLE
fix: restore deposit & withdraw translations

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2479,10 +2479,12 @@
     "thorchainLp": {
       "pairAssets": "%{asset1} and %{asset2}",
       "withdraw": {
-        "processing": "Your withdraw of %{assetAmountsAndSymbols} from the %{poolName} pool is processing."
+        "processing": "Your withdraw of %{assetAmountsAndSymbols} from the %{poolName} pool is processing.",
+        "complete": "Your withdraw of %{assetAmountsAndSymbols} from the %{poolName} pool is complete."
       },
       "deposit": {
-        "processing": "Your deposit of %{amount} %{symbol} to %{poolName} pool is processing."
+        "processing": "Your deposit of %{amount} %{symbol} to %{poolName} pool is processing.",
+        "complete": "Your deposit of %{amount} %{symbol} to %{poolName} pool is complete."
       }
     },
     "deposit": {


### PR DESCRIPTION
## Description

Restores `actionCenter.thorchainLp.withdraw.complete` and `actionCenter.thorchainLp.deposit.complete` translation strings.

## Issue (if applicable)

Found by ops: https://discord.com/channels/554694662431178782/1440121180215443547/1440152611109081139

## Risk

Minimal

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

LP deposit and withdraw notifications should show translations again.

<img width="507" height="314" alt="image" src="https://github.com/user-attachments/assets/3cf4dd15-79f0-4f9e-a83a-bc325885f322" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added completion status messages for THORChain THOR LP withdrawal and deposit transactions, providing improved transaction status feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->