### PR TITLE
fix: input styling on unstake fox

### DIFF
--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -139,6 +139,7 @@ export type TradeAmountInputProps = {
   onToggleIsFiat?: (isInputtingFiatSellAmount: boolean) => void
   placeholder?: string
   activeQuote?: TradeQuote | TradeRate | undefined
+  inputContainerStyleOverride?: React.CSSProperties
 } & PropsWithChildren
 
 const defaultPercentOptions = [0.25, 0.5, 0.75, 1]
@@ -185,6 +186,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
     isFiat,
     activeQuote,
     onToggleIsFiat: handleIsInputtingFiatSellAmountChange,
+    inputContainerStyleOverride,
   }) => {
     const {
       number: { localeParts },
@@ -366,6 +368,11 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
 
     const handleOnMaxClick = useMemo(() => () => onMaxClick(Boolean(isFiat)), [isFiat, onMaxClick])
 
+    const containerStyle = useMemo(
+      () => inputContainerStyleOverride ?? inputContainerStyle,
+      [inputContainerStyleOverride],
+    )
+
     return (
       <FormControl
         borderWidth={1}
@@ -402,7 +409,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
             )}
           </Display.Desktop>
         </Flex>
-        <Flex sx={inputContainerStyle}>
+        <Flex sx={containerStyle}>
           {labelPostFix}
           <Stack
             direction='row'

--- a/src/pages/RFOX/components/Unstake/UnstakeInput.tsx
+++ b/src/pages/RFOX/components/Unstake/UnstakeInput.tsx
@@ -50,6 +50,11 @@ const formControlProps = {
   paddingTop: 0,
 }
 
+const inputContainerStyleOverride = {
+  display: 'flex' as const,
+  flexDirection: 'column' as const,
+}
+
 const defaultFormValues = {
   amountFieldInput: '',
   amountCryptoPrecision: '',
@@ -425,6 +430,7 @@ export const UnstakeInput: React.FC<UnstakeRouteProps & UnstakeInputProps> = ({
             onToggleIsFiat={handleToggleIsFiat}
             percentOptions={percentOptions}
             showInputSkeleton={!isUserBalanceStakingBalanceOfCryptoBaseUnitSuccess}
+            inputContainerStyleOverride={inputContainerStyleOverride}
           />
 
           <Collapse in={hasEnteredValue}>


### PR DESCRIPTION
## Description

Fix styling of trade input on fox unstake. Targeted fix to avoid breaking other important uses of this component.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #11128 

## Risk

Low risk, could make the unstake input render wierd

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

Test that unstake on fox ecosystem renders normally on mobile and desktop

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="659" height="313" alt="image" src="https://github.com/user-attachments/assets/c0572368-3d02-4f63-81d3-cac367b262fc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved input container styling in the Unstake feature for enhanced visual consistency and layout flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->