### PR TITLE
fix: restore translation strings

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -16,7 +16,6 @@
     "show": "Show",
     "done": "Done",
     "cancel": "Cancel",
-    "delete": "Delete",
     "close": "Close",
     "closed": "Closed",
     "loadMore": "Load More",
@@ -1327,6 +1326,11 @@
         "conflictingApp": "Could not find your KeepKey. Another application may be trying to connect with your KeepKey.",
         "downloadUpdaterApp": "Download updater app"
       },
+      "pin": {
+        "header": "Enter Your PIN",
+        "body": "Use PIN layout shown on your device to find the location to press on the PIN pad.",
+        "button": "Unlock"
+      },
       "settings": {
         "menuLabels": {
           "bootloader": "Bootloader",
@@ -1989,7 +1993,8 @@
           "title": "Connect your wallet to a dApp via WalletConnect and trigger transactions",
           "linkPlaceholder": "QR code or connection link",
           "disclaimerBody": "ShapeShift cannot ensure the safety or security of third-party applications. By using WalletConnect, you assume full responsibility for any risks involved.",
-          "connect": "Connect"
+          "connect": "Connect",
+          "invalidUri": "Invalid URI"
         },
         "sessionProposal": {
           "unsupportedChain": "Unsupported chain namespace in session proposal.",


### PR DESCRIPTION
## Description

Restores more translation strings.

## Issue (if applicable)

Identified in https://discord.com/channels/554694662431178782/1433675437455704184

## Risk

Minimal

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

Resolves:

<img width="617" height="571" alt="image" src="https://github.com/user-attachments/assets/9ed4aeac-4207-413f-924d-dbba477438bd" />

and

`plugins.walletConnectToDapps.modal.connect.invalidUri`

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PIN entry interface for KeepKey wallet connection.
  * Added validation message for invalid WalletConnect URIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->