### PR TITLE
fix: restore translation strings

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1156,6 +1156,9 @@
       "copyFailed": "Failed to copy %{symbol} receive address to clipboard",
       "copyFailedDescription": "Please copy the address manually",
       "setAmount": "Set Amount",
+      "verify": "Verify",
+      "verified": "Verified",
+      "notVerified": "Address Mismatch",
       "blockExplorer": "Explorer",
       "supportedNetworks": "Supported Networks",
       "amountNote": "Enter the amount you want to request. This will generate a QR code with the amount for easier payments."


### PR DESCRIPTION
## Description

Restores more translation strings.

## Issue (if applicable)

Noted by ops in https://discord.com/channels/554694662431178782/1433675437455704184

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

Fixes this guy:

<img width="523" height="701" alt="image" src="https://github.com/user-attachments/assets/10abc7bf-f463-45ba-bb12-3046b0b11a28" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.