### PR TITLE
fix: double rating modal toast

### DIFF
--- a/src/components/RatingModal.tsx
+++ b/src/components/RatingModal.tsx
@@ -85,6 +85,7 @@ export const RatingModal = () => {
           status: 'success',
         })
         close()
+        return
       }
 
       // Remove me when we get back the feedback gathering feature on


### PR DESCRIPTION
## Description

does what it says on the box

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/11188

## Risk

> High Risk PRs Require 2 approvals

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

### Engineering

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

- develop

<img width="535" height="306" alt="Screenshot 2025-11-27 at 13 15 33" src="https://github.com/user-attachments/assets/5328411e-67e3-4e1f-be74-73042a0f1f71" />

- this diff

<img width="543" height="211" alt="Screenshot 2025-11-27 at 14 01 05" src="https://github.com/user-attachments/assets/e7b20464-405b-42a4-ac71-4e7d36340df1" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the 5-star rating flow to prevent duplicate confirmation messages and unnecessary actions. When users submit a 5-star rating, the app now only displays the dedicated 5-star feedback without additional generic notifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->