### PR TITLE
fix: sentry release naming

### DIFF
--- a/.github/workflows/bootstrap.yml
+++ b/.github/workflows/bootstrap.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/cloudflare.yml
+++ b/.github/workflows/cloudflare.yml
@@ -20,7 +20,10 @@ jobs:
     name: Build
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          # Fetch all history and tags for version extraction via git describe
+          fetch-depth: 0
       - name: Setup Environment (PR)
         if: ${{ github.event_name == 'pull_request' }}
         # github actions run in the context of a special magical merge commit between the head of the PR
@@ -39,12 +42,12 @@ jobs:
           echo "COMMIT_SHORT_HASH=`echo ${GITHUB_SHA} | cut -c1-7`" >> ${GITHUB_ENV}
           echo "CURRENT_BRANCH_NAME=${{ github.ref_name }}" >> ${GITHUB_ENV}
       - name: Extract Version
-        id: version
         run: |
-          # For release commits (e.g., "chore: release v1.971.0"), extract semver
-          # Otherwise use the commit short hash
-          COMMIT_MSG=$(git log -1 --pretty=%B)
-          if [[ "$COMMIT_MSG" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+          # Get version from the closest git tag (e.g., "v1.977.0" -> "1.977.0")
+          # Tags are created by release-please when PRs are merged to main
+          # Fallback to commit hash if no tags exist
+          TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          if [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
             echo "version=${BASH_REMATCH[1]}" >> ${GITHUB_ENV}
           else
             echo "version=${{ env.COMMIT_SHORT_HASH }}" >> ${GITHUB_ENV}
@@ -62,7 +65,7 @@ jobs:
         env: { CONTENT : "${{ toJson(github) }}" }
         run: "echo $CONTENT"
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: OpenJDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'microsoft'
           java-version: '11'
 
       - name: Setup Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
           cache: 'yarn'

--- a/.github/workflows/sentry.yml
+++ b/.github/workflows/sentry.yml
@@ -6,8 +6,8 @@ on:
 
 jobs:
   release:
-    # Only run when PR is merged, not just closed
-    if: github.event.pull_request.merged == true
+    # Only run for merged release PRs (title contains version like "chore: release v1.977.0")
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.title, 'release v')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -30,12 +30,18 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           # Extract version from PR title (e.g., "chore: release v1.971.0" -> "1.971.0")
-          # Or use the merge commit SHA if not a release PR
+          # Fallback to git tag for consistency with deployed version
           if [[ "$PR_TITLE" =~ v([0-9]+\.[0-9]+\.[0-9]+) ]]; then
             VERSION="${BASH_REMATCH[1]}"
           else
-            VERSION="${{ github.event.pull_request.merge_commit_sha }}"
-            VERSION="${VERSION:0:7}"
+            # Use git tag to match deployed version
+            TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            if [[ "$TAG" =~ ^v([0-9]+\.[0-9]+\.[0-9]+)$ ]]; then
+              VERSION="${BASH_REMATCH[1]}"
+            else
+              VERSION="${{ github.event.pull_request.merge_commit_sha }}"
+              VERSION="${VERSION:0:7}"
+            fi
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Description

Fixes Sentry release tracking to correctly use semantic versions instead of commit hashes.

**Problem 1:** Deployed apps were reporting commit hashes (e.g., `c56a776`) to Sentry instead of semantic versions (e.g., `1.977.0`). This was because `cloudflare.yml` tried to extract the version from the merge commit message, which doesn't contain the version string.

**Problem 2:** A Sentry release was being created for every PR merged to main, not just actual release PRs.

**Solution:**
- Changed `cloudflare.yml` to use `git describe --tags --abbrev=0` to get the version from git tags, which is reliable and matches the release version
- Added condition to `sentry.yml` to only run for release PRs (those with "release v" in the title)
- Updated GitHub Actions to v4 and added `fetch-depth: 0` where needed for git operations

## Issue (if applicable)

None, general cleanup.

## Risk

Low - this PR only modifies CI/CD workflows (GitHub Actions). No application code, on-chain transactions, or user-facing features are affected.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None - this is a CI/CD configuration change only.

## Testing

### Engineering

Note, the below can only be performed retrospectively (once this PR is in a release that's merged to `main`).

1. Merge a non-release PR to main:
   - Verify `sentry.yml` workflow is skipped (check "Skipped" status in Actions)
   - Verify deployed app still uses the last release version from git tags

2. Merge a release PR (with title like "chore: release v1.978.0") to main:
   - Verify `sentry.yml` workflow runs and creates a release with the correct semantic version
   - Verify deployed app reports the same version to Sentry
   - Check Sentry dashboard to confirm release is tagged as `1.978.0` not a commit hash

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Nothing to see here for ops!

## Screenshots (if applicable)

Current (sad state):

<img width="1051" height="475" alt="Screenshot 2025-12-03 at 1 35 51 pm" src="https://github.com/user-attachments/assets/06bfd6a0-4310-4f73-8d01-5c59f6e3825c" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use git tags to set release versions for deploys/Sentry, restrict Sentry workflow to release PRs, and bump GitHub Actions to v4 with full fetch depth where needed.
> 
> - **CI/CD Workflows**:
>   - **Versioning**:
>     - `cloudflare.yml`: Extracts `version` from nearest git tag (`git describe`), falling back to commit short hash; passes `VITE_VERSION` into build.
>     - `sentry.yml`: Derives version from PR title or nearest git tag, else falls back to merge SHA; uses `shapeshift-web@{version}` for releases.
>   - **Sentry Workflow Trigger**:
>     - Runs only for merged release PRs (title contains `release v`).
>   - **Actions Upgrades**:
>     - Bump `actions/checkout`, `actions/setup-node`, and `actions/setup-java` to `v4` across `bootstrap.yml`, `cloudflare.yml`, and `pr.yml`.
>     - Add `fetch-depth: 0` to `checkout` where tag-based versioning is needed.
>   - **Build/Deploy**:
>     - `cloudflare.yml`: Keep existing env setup and build mode logic; deploy uses computed branch/hash; ensures tags available for versioning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e379ffdda755d189984d487f22a5cefa6601997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded GitHub Actions to v4 across deployment workflows for improved compatibility.
  * Enhanced version extraction logic to prioritize git tags with fallback mechanisms.
  * Refined release trigger conditions for pull request-based deployments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->