### PR TITLE
chore: extract cetus + mysten from build

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -187,6 +187,8 @@ export default defineConfig(({ mode }) => {
               if (id.includes('gridplus-sdk')) return 'gridplus-sdk'
               if (id.includes('tronweb')) return 'tronweb'
               if (id.includes('viem')) return 'viem'
+              if (id.includes('@cetusprotocol')) return '@cetusprotocol'
+              if (id.includes('@mysten')) return '@mysten'
 
               return null
             }


### PR DESCRIPTION
## Description

Fix CI by extracting `@cetusprotocol` and `@mysten' packages.

## Issue (if applicable)

Unblocks release.

## Risk

Low - if CI is green we are good.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

### Engineering

CI should now be green.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Vite manual chunking to extract @cetusprotocol and @mysten into separate bundles.
> 
> - **Build (Vite)**:
>   - Update `rollupOptions.output.manualChunks` to split vendor chunks:
>     - `@cetusprotocol` -> `@cetusprotocol`
>     - `@mysten` -> `@mysten`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 77df6b47b523b454e1dcd547481144ec7a302231. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration to improve module bundling efficiency during the application build process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->