### PR TITLE
chore: fix CI, take 2

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -189,6 +189,7 @@ export default defineConfig(({ mode }) => {
               if (id.includes('viem')) return 'viem'
               if (id.includes('@cetusprotocol')) return '@cetusprotocol'
               if (id.includes('@mysten')) return '@mysten'
+              if (id.includes('@shapeshiftoss/hdwallet-vultisig')) return 'hdwallet-vultisig'
 
               return null
             }


### PR DESCRIPTION
## Description

Take 2 at extracting packages - I'll leave this in draft until we've extracted enough.

## Issue (if applicable)

Unblocks release.

## Risk

> High Risk PRs Require 2 approvals

Low - if CI is green we should be good.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

### Engineering

CI should be green.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

N/A

## Screenshots (if applicable)

N/A

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Rollup manual chunk in `vite.config.mts` to group `@shapeshiftoss/hdwallet-vultisig` as `hdwallet-vultisig`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba1aa5d1f4ccc6e613b3df2eac96396941a657ca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized vendor code bundling and chunking for improved build performance and load times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->