### PR TITLE
feat: toggle vultisig flag on

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -8,7 +8,6 @@ import type { KeplrHDWallet } from '@shapeshiftoss/hdwallet-keplr'
 import type { LedgerHDWallet } from '@shapeshiftoss/hdwallet-ledger'
 import type { NativeHDWallet } from '@shapeshiftoss/hdwallet-native'
 import type { TrezorHDWallet } from '@shapeshiftoss/hdwallet-trezor'
-import type { VultisigHDWallet } from '@shapeshiftoss/hdwallet-vultisig'
 import type { WalletConnectV2HDWallet } from '@shapeshiftoss/hdwallet-walletconnectv2'
 import type { NestedArray } from '@shapeshiftoss/types'
 import { HistoryTimeframe, KnownChainIds } from '@shapeshiftoss/types'
@@ -59,10 +58,6 @@ export const isLedgerHDWallet = (wallet: HDWallet): wallet is LedgerHDWallet => 
 
 export const isWalletConnectWallet = (wallet: HDWallet): wallet is WalletConnectV2HDWallet => {
   return wallet.getVendor() === 'WalletConnectV2'
-}
-
-export const isVultisigHDWallet = (wallet: HDWallet): wallet is VultisigHDWallet => {
-  return wallet.getVendor() === 'Vultisig'
 }
 
 // we don't want utils to mutate by default, so spreading here is ok

--- a/src/plugins/walletConnectToDapps/hooks/useIsWalletConnectToDappsSupportedWallet.tsx
+++ b/src/plugins/walletConnectToDapps/hooks/useIsWalletConnectToDappsSupportedWallet.tsx
@@ -8,7 +8,6 @@ import {
   isLedgerHDWallet,
   isNativeHDWallet,
   isTrezorHDWallet,
-  isVultisigHDWallet,
 } from '@/lib/utils'
 
 export const useIsWalletConnectToDappsSupportedWallet = () => {
@@ -26,7 +25,6 @@ export const useIsWalletConnectToDappsSupportedWallet = () => {
       case isGridPlusHDWallet(wallet):
       case isLedgerHDWallet(wallet):
       case isTrezorHDWallet(wallet):
-      case isVultisigHDWallet(wallet):
         return true
       case isKeepKeyHDWallet(wallet): {
         return isEIP712SupportedFirmwareVersion


### PR DESCRIPTION
## Description

here goes nothing

## Issue (if applicable)

N/A

## Risk

> High Risk PRs Require 2 approvals

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

This PR enables the Vultisig wallet feature flag in production. It affects:
- All EVM chain transactions through Vultisig wallet
- Solana transactions through Vultisig wallet
- THORChain transactions through Vultisig wallet
- Cosmos transactions through Vultisig wallet

## Testing

### Engineering

**Testing steps:**
- Able to swap to/from EVM chains (test with 0x i.e Permit2, CoW i.e eth_signTypedDatav4, and another e.g Relay or Bebop for regular Txs testing)
- Able to send native/assets on EVM chains
- Able to swap from/to native/assets on Solana
- Able to send native/assets on Solana
- Able to send native/assets on THORChain (i.e RUNE/TCY/RUJI)
- Able to send ATOM
- Able to swap to/from RUNE/RUJI/TCY
- Able to swap to/from ATOM

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

- EVM chains through wc demo (all besides `eth_sendTransaction` and `eth_signTransaction`)
  https://jam.dev/c/e0cf3307-06f4-4b94-8c07-4a7176c713b2

- EVM chains through swapper - Permit2, regular Txs, eth_signTypedDatav4
  https://jam.dev/c/4fcba93a-a04a-42f0-a3dd-bece304b88de

- Solana through swapper (sends, Txs) + self-send Tx link is happy
  https://jam.dev/c/ec41d098-4222-4a0e-8b75-0ebeea4de5bd

- THOR (swaps to/from RUNE, RUJI/TCY, self-sends)
  https://jam.dev/c/325702df-7d11-4292-84ab-f9969cf80b4e

- ATOM (swaps to ATOM, self-sends)
  https://jam.dev/c/d4e36604-f879-48fe-a27f-9f2c9b8c8d7c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated feature configuration to enable Vultisig Wallet in the production environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->