### PR TITLE
fix: refetch second accounts balances on send

### DIFF
--- a/src/components/Layout/Header/ActionCenter/components/Notifications/GenericTransactionNotification.tsx
+++ b/src/components/Layout/Header/ActionCenter/components/Notifications/GenericTransactionNotification.tsx
@@ -58,7 +58,7 @@ export const GenericTransactionNotification = ({
     // Destructure to exclude non-serializable fields from the spread
     const {
       confirmedQuote: _confirmedQuote,
-      involvedAccountIds: _involvedAccountIds,
+      accountIdsToRefetch: _accountIdsToRefetch,
       ...serializableMetadata
     } = action.transactionMetadata
     return [

--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -169,10 +169,10 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
         return selectInternalAccountIdByAddress(store.getState(), internalAccountIdFilter)
       })()
 
-      const involvedAccountIds = [formAccountId]
+      const accountIdsToRefetch = [formAccountId]
 
       if (internalReceiveAccountId) {
-        involvedAccountIds.push(internalReceiveAccountId)
+        accountIdsToRefetch.push(internalReceiveAccountId)
       }
 
       dispatch(
@@ -184,7 +184,7 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
             txHash,
             chainId: fromAccountId(formAccountId).chainId,
             accountId: formAccountId,
-            involvedAccountIds,
+            accountIdsToRefetch,
             assetId,
             amountCryptoPrecision: formAmountCryptoPrecision,
             message: 'modals.send.status.pendingBody',

--- a/src/hooks/useActionCenterSubscribers/useSendActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSendActionSubscriber.tsx
@@ -34,7 +34,7 @@ export const useSendActionSubscriber = () => {
 
   const completeAction = useCallback(
     (action: ReturnType<typeof selectPendingWalletSendActions>[number]) => {
-      const { txHash, accountId, involvedAccountIds } = action.transactionMetadata
+      const { txHash, accountId, accountIdsToRefetch } = action.transactionMetadata
 
       dispatch(
         actionSlice.actions.upsertAction({
@@ -53,9 +53,9 @@ export const useSendActionSubscriber = () => {
 
       if (isSecondClassChain) {
         const { getAccount } = portfolioApi.endpoints
-        const accountIdsToRefresh = involvedAccountIds ?? [accountId]
+        const accountIdsToRefreshList = accountIdsToRefetch ?? [accountId]
 
-        accountIdsToRefresh.forEach(accountIdToRefresh => {
+        accountIdsToRefreshList.forEach(accountIdToRefresh => {
           dispatch(
             getAccount.initiate(
               { accountId: accountIdToRefresh, upsertOnFetch: true },

--- a/src/state/slices/actionSlice/types.ts
+++ b/src/state/slices/actionSlice/types.ts
@@ -105,7 +105,7 @@ type ActionGenericTransactionMetadata = {
   queryId?: GenericTransactionQueryId
   message: string
   accountId: AccountId
-  involvedAccountIds?: AccountId[]
+  accountIdsToRefetch?: AccountId[]
   txHash: string
   chainId: ChainId
   assetId: AssetId


### PR DESCRIPTION
## Description

Add involved account ids inside the send action, so we can know if we need to refetch balances if its an internal account!

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted while testing monad

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Send MON to a second account
- Notice the balance of the second account is updated after success
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/7f653d22-d217-4889-9bb0-79431033caaa

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Send actions now include associated account IDs so multiple related accounts can be tracked and refreshed.
  * Translation interpolation now omits internal metadata fields to ensure only serializable data is used.

* **Bug Fixes**
  * Account refresh logic improved to refresh all accounts involved in a transaction, keeping balances and history accurate across accounts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->