### PR TITLE
fix: zcash no support for MM/Trezor

### DIFF
--- a/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
+++ b/src/hooks/useWalletSupportsChain/useWalletSupportsChain.ts
@@ -52,6 +52,7 @@ import { KeyManager } from '@/context/WalletProvider/KeyManager'
 import { useIsSnapInstalled } from '@/hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { METAMASK_RDNS } from '@/lib/mipd'
+import { isNativeHDWallet } from '@/lib/utils'
 import { selectAccountIdsByChainIdFilter } from '@/state/slices/portfolioSlice/selectors'
 import { selectFeatureFlag } from '@/state/slices/selectors'
 import { store, useAppSelector } from '@/state/store'
@@ -157,11 +158,9 @@ export const walletSupportsChain = ({
         !(wallet instanceof GridPlusHDWallet)
       )
     case zecChainId:
-      return (
-        supportsBTC(wallet) &&
-        !(wallet instanceof PhantomHDWallet) &&
-        !(wallet instanceof GridPlusHDWallet)
-      )
+      // Only native wallet supports ZCash for now
+      // TODO(gomes): include more as more wallets supported for ZCash
+      return supportsBTC(wallet) && isNativeHDWallet(wallet)
     case ethChainId:
       return supportsETH(wallet)
     case avalancheChainId:

--- a/src/state/slices/portfolioSlice/utils/index.ts
+++ b/src/state/slices/portfolioSlice/utils/index.ts
@@ -70,7 +70,7 @@ import { queryClient } from '@/context/QueryClientProvider/queryClient'
 import type { BigNumber } from '@/lib/bignumber/bignumber'
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { fetchPortalsAccount, fetchPortalsPlatforms, maybeTokenImage } from '@/lib/portals/utils'
-import { assertUnreachable, middleEllipsis } from '@/lib/utils'
+import { assertUnreachable, isNativeHDWallet, middleEllipsis } from '@/lib/utils'
 import { isSpammyNftText, isSpammyTokenText } from '@/state/blacklist'
 import type { ReduxState } from '@/state/reducer'
 import type { UpsertAssetsPayload } from '@/state/slices/assetsSlice/assetsSlice'
@@ -403,11 +403,9 @@ export const isAssetSupportedByWallet = (assetId: AssetId, wallet: HDWallet): bo
         !(wallet instanceof GridPlusHDWallet)
       )
     case zecChainId:
-      return (
-        supportsBTC(wallet) &&
-        !(wallet instanceof PhantomHDWallet) &&
-        !(wallet instanceof GridPlusHDWallet)
-      )
+      // Only native wallet supports ZCash for now
+      // TODO(gomes): include more as more wallets supported for ZCash
+      return supportsBTC(wallet) && isNativeHDWallet(wallet)
     case cosmosChainId:
       return supportsCosmos(wallet)
     case thorchainChainId:


### PR DESCRIPTION
## Description

Makes ZCash support checks inclusive (native) vs. exclusive.

## Issue (if applicable)

N/A

## Risk

Low risk - Restricts ZCash support to native wallet only. This is a defensive measure to prevent unsupported wallets from attempting ZCash transactions.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

ZCash chain support for MetaMask and Trezor wallets.

## Testing

### Engineering

- Zcash derivation with native still works
- Other wallets do not display ZCash as an available chain in account management
- Verify that MetaMask and Trezor cannot access ZCash chain

### Operations

- Zcash derivation with native still works
- Other wallets do not display ZCash as an available chain in account management

## Screenshots (if applicable)

https://jam.dev/c/2321ebd5-95c4-43ea-8959-33770b4923d8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Zcash wallet compatibility detection to ensure accurate support identification across wallet types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->