### PR TITLE
fix: grouped ledger chunk

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -171,9 +171,6 @@ export default defineConfig(({ mode }) => {
         output: {
           manualChunks: id => {
             if (id.includes('node_modules')) {
-              // @noble and @scure are crypto primitives used by many packages (ledger, viem, solana, etc.)
-              // They must be in a single chunk that loads first to avoid circular dependency initialization issues
-              if (id.match(/(@noble|@scure)/)) return 'noble'
               if (id.match(/(framer-motion|@visx|@coral-xyz)/)) return 'ui'
               if (id.match(/(react-icons|@react-spring|react-datepicker|react-dom)/)) return 'react'
               if (id.match(/(dayjs|lodash|@formatjs)/)) return 'utils'
@@ -187,7 +184,8 @@ export default defineConfig(({ mode }) => {
               if (id.includes('styled-components')) return 'styled-components'
               if (id.includes('protobufjs')) return 'protobuf'
               if (id.includes('date-fns')) return 'date-fns'
-              if (id.includes('@ledgerhq')) return 'ledger'
+              // Group ledger with its crypto dependencies to avoid circular chunk deps
+              if (id.match(/(@ledgerhq|@noble|@scure|@bitgo)/)) return 'ledger'
               if (id.includes('cosmjs-types')) return 'cosmjs-types'
               if (id.includes('osmojs')) return 'osmojs'
               if (id.includes('@arbitrum')) return '@arbitrum'
@@ -211,7 +209,6 @@ export default defineConfig(({ mode }) => {
 
             if (id.includes('assets/translations')) return 'translations'
             if (id.includes('packages/unchained-client')) return 'unchained-client'
-            if (id.includes('packages/caip')) return 'caip'
             if (id.includes('localAssetData')) return 'local-asset-data'
 
             // This chunk should be imported last as it heavily relies on other chunks and default order doesnt work


### PR DESCRIPTION
## Description

Fix production white screen caused by `@noble/curves` circular dependency initialization error.

The hdwallet bump from 1.62.25 to 1.62.28 brought in `@ledgerhq/hw-app-btc@10.13.0`, which depends on `@noble/curves@1.9.7`, `@noble/secp256k1`, and `@bitgo/secp256k1`. The existing `manualChunks` config put `@ledgerhq` into a `'ledger'` chunk, but its crypto dependencies ended up in different chunks. This created cross-chunk circular dependencies that caused `Cannot access before initialization` errors in the production build.

The fix bundles `@noble`, `@scure`, and `@bitgo` packages into the same chunk as `@ledgerhq` to ensure they initialize together.

## Issue (if applicable)

Current release blocker.

## Risk

> High Risk PRs Require 2 approvals

**Medium Risk** - This modifies the Vite/Rollup chunking strategy. The change groups related crypto packages together, which should only improve bundle cohesion. Without this fix, production is completely broken (white screen).

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- Ledger wallet connections
- Any code path that uses `@noble/curves` or `@noble/secp256k1` for cryptographic operations
- viem, @solana, and other packages that depend on @noble (now bundled with ledger chunk)

## Testing

### Engineering

1. Build for production: `yarn build:web`
2. Serve the production build locally or deploy to preview
3. Verify the app loads without white screen
4. Check browser console for any initialization errors
5. Test wallet connections (Ledger, MetaMask, WalletConnect)
6. Verify basic transaction signing flows work

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

1. Deploy to preview environment
2. Verify the app loads (no white screen/crash)
3. Connect a Ledger hardware wallet
4. Connect a MetaMask wallet
5. Attempt a basic swap to verify transaction signing works
6. Verify dashboard and portfolio pages load correctly

## Screenshots (if applicable)

N/A - This is a build configuration fix with no UI changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Vite manualChunks to bundle @noble, @scure, and @bitgo with @ledgerhq under the `ledger` chunk to avoid cross-chunk issues.
> 
> - **Build config (Vite/Rollup)**:
>   - **Chunking**: Replace `includes('@ledgerhq')` with `match(/(@ledgerhq|@noble|@scure|@bitgo)/)` to group related crypto deps into the `ledger` chunk.
>   - Add clarifying comment about avoiding circular chunk dependencies.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6c9ba0ae3d6d2e6cd2ef286efca6326273f2903a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined build configuration to optimize how dependencies are organized and grouped during the build process. This enhancement prevents circular dependency conflicts and improves build stability. The changes focus on better structuring related packages within the bundle. These internal optimizations increase overall reliability without affecting user-facing application features or functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->