### PR TITLE
chore: remove onramper console spew

### DIFF
--- a/src/components/Modals/FiatRamps/fiatRampProviders/onramper/utils.ts
+++ b/src/components/Modals/FiatRamps/fiatRampProviders/onramper/utils.ts
@@ -161,7 +161,6 @@ export const findAssetIdByOnramperCrypto = (crypto: Crypto): AssetId | undefined
     try {
       const chainId = getChainIdFromOnramperNetwork(crypto.network)
       if (!chainId) {
-        console.warn(`Unsupported network: ${crypto.network}`)
         return undefined
       }
 


### PR DESCRIPTION
## Description

Remove onramper spew.

## Issue (if applicable)

N/A, I'm just tired of seeing it and it adds no value.

## Risk

Minimal

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

We should no longer see this in the console:

<img width="1152" height="1148" alt="Screenshot 2025-12-11 at 4 01 26 pm" src="https://github.com/user-attachments/assets/01d2a980-336e-40b7-b4fa-9335ab27694d" />

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

See above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Stops logging a console warning for unsupported OnRamper networks, returning undefined silently.
> 
> - **OnRamper utils**:
>   - Remove `console.warn` on unsupported network in `src/components/Modals/FiatRamps/fiatRampProviders/onramper/utils.ts` within `findAssetIdByOnramperCrypto`, keeping the `undefined` return without logging.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7213ea10c08d39be768439042f0ec41bad2fc170. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated unnecessary console warnings when using the Onramper fiat ramp feature.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->