### PR TITLE
fix: filter related assets by registered chain adapters

### DIFF
--- a/src/state/slices/related-assets-selectors.ts
+++ b/src/state/slices/related-assets-selectors.ts
@@ -41,10 +41,17 @@ export const selectRelatedAssetIdsInclusive = createCachedSelector(
     const relatedAssetKey = asset.relatedAssetKey
     if (!relatedAssetKey) return [asset.assetId]
 
+    const chainAdapterManager = getChainAdapterManager()
+
     const relatedAssetIdsInclusiveWithDuplicates = [relatedAssetKey]
       .concat(relatedAssetIndex[relatedAssetKey] ?? [])
       // Filter out assetIds that are not in the assets store
       .filter(assetId => assets?.[assetId])
+      // Filter out assetIds for chains without registered adapters (e.g. chains behind disabled feature flags)
+      .filter(assetId => {
+        const { chainId } = fromAssetId(assetId)
+        return chainAdapterManager.has(chainId)
+      })
 
     // `asset.assetId` may be the same as `relatedAssetKey`, so dedupe
     const relatedAssetIdsInclusive = Array.from(


### PR DESCRIPTION
## Description

Filters related assets by registered chain adapters (handling the case of disabled chains).

## Issue (if applicable)

Current release blocker: https://discord.com/channels/554694662431178782/1448800347450507356/1449775891948376228

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None

## Testing

We should be able to select Link on Solana (which has a related asset on Plasma) as the buy asset in the swapper.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced related assets display to only show assets from supported blockchain chains, filtering out assets from chains with disabled feature flags or unavailable adapters.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->