### PR TITLE
fix: restore query cache settings for mobile wallet list

### DIFF
--- a/src/pages/ConnectWallet/components/WalletList.tsx
+++ b/src/pages/ConnectWallet/components/WalletList.tsx
@@ -50,6 +50,8 @@ export const MobileWalletList: React.FC<MobileWalletDialogProps> = ({
     error: queryError,
   } = useQuery({
     queryKey: ['listWallets'],
+    staleTime: 0,
+    gcTime: 0,
     refetchOnMount: true,
     queryFn: async () => {
       const vaults = await listWallets()


### PR DESCRIPTION
## Description

Fixes a bug where deleting the last remaining ShapeShift wallet on mobile would not remove it from the screen.

### Root Cause

In #11180 (0cd2b30), the `staleTime: 0` and `gcTime: 0` React Query options were accidentally removed from the wallet list query. Without these settings, React Query retains cached wallet data even after the query errors (e.g., when no wallets exist), causing the deleted wallet to remain visible.

### Fix

Restored `staleTime: 0` and `gcTime: 0` to ensure the cache is properly cleared when there are no wallets.

## Issue (if applicable)

Release blocker: https://discord.com/channels/554694662431178782/1448800347450507356/1449759347893866528

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

When deleting the last wallet on the mobile app, it should immediately disappear from the screen and you should be presented with a message saying "You have no saved wallets".

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced wallet list query handling to ensure optimal data freshness when connecting wallets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->