### PR TITLE
fix: prevent loading spinner delay after deleting last wallet

### DIFF
--- a/src/pages/ConnectWallet/components/WalletList.tsx
+++ b/src/pages/ConnectWallet/components/WalletList.tsx
@@ -52,6 +52,7 @@ export const MobileWalletList: React.FC<MobileWalletDialogProps> = ({
     queryKey: ['listWallets'],
     staleTime: 0,
     gcTime: 0,
+    retry: false,
     refetchOnMount: true,
     queryFn: async () => {
       const vaults = await listWallets()


### PR DESCRIPTION
## Description

Fixes a loading spinner that would appear for several seconds after deleting the last wallet on mobile.

### Root Cause

In #11180 (0cd2b30), the wallet list query was changed to throw an error when no wallets exist, instead of the previous approach of calling `setError()` directly. This triggers React Query's default retry behavior (3 retries with exponential backoff), causing a multi-second spinner delay before the "no wallets" state is shown.

### Fix

Added `retry: false` to the query options to prevent unnecessary retries when no wallets exist.

## Issue (if applicable)

None, affects current release.

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

N/A

## Testing

When deleting the last wallet from the native app, the empty wallet page should show immediately without showing a useless loading spinner.

### Engineering

👆

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

👆

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified error handling for wallet list loading to display errors immediately instead of attempting automatic retries, providing faster feedback when connection issues occur.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->