### PR TITLE
fix: cetus sells from SUI

### DIFF
--- a/packages/chain-adapters/src/sui/SuiChainAdapter.ts
+++ b/packages/chain-adapters/src/sui/SuiChainAdapter.ts
@@ -443,7 +443,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.SuiMainnet> {
 
       tx.setSender(from)
 
-      if (tokenId) {
+      if (tokenId && tokenId !== '0x2::sui::SUI') {
         // Token transfer - get coin objects for this token type
         const coins = await this.client.getCoins({
           owner: from,


### PR DESCRIPTION
## Description

Cetus rates from SUI are currently broken with a wallet connected but work without a wallet connected.
The problematic call is here in develop i.e this lookup which fails

https://github.com/shapeshift/web/blob/4f2dd78bcc7b95f4ed970a6881478a92a51661c4/packages/chain-adapters/src/sui/SuiChainAdapter.ts#L257-L263

Fixed by properly handling `0x2::sui::SUI` (basically native SUI) and falling back to regular native gas branch.

## Issue (if applicable)

N/A

## Risk

> High Risk PRs Require 2 approvals

Isolated to SUI

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

- Able to get Cetus quotes for SUI sell both with/out a wallet connected
- Able to execute Cetus SUI sell quote
- Worth double-checking token → SUI too e2e too because why not (see Jam)

### Engineering

☝🏽 

### Operations

☝🏽 

## Screenshots (if applicable)

https://jam.dev/c/28fd59cd-cccc-4d69-ad0d-657119b4bdbc

- develop

<img width="1717" height="1043" alt="Screenshot 2025-12-17 at 14 25 19" src="https://github.com/user-attachments/assets/a75543c3-140d-4296-8f30-de14facc612b" />


- this diff

<img width="1728" height="1003" alt="Screenshot 2025-12-17 at 14 25 42" src="https://github.com/user-attachments/assets/c70c48c9-e832-451c-8915-2730bc85a79b" />
<img width="1727" height="998" alt="Screenshot 2025-12-17 at 14 26 12" src="https://github.com/user-attachments/assets/a8b6910c-4263-4210-85c0-cea76c6a4b05" />
