### PR TITLE
fix: second class chains dedupe internal/value

### DIFF
--- a/packages/chain-adapters/src/evm/SecondClassEvmAdapter.ts
+++ b/packages/chain-adapters/src/evm/SecondClassEvmAdapter.ts
@@ -500,6 +500,14 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
         const internalFrom = getAddress(internalTx.from)
         const internalTo = getAddress(internalTx.to)
 
+        // Skip internal transactions that duplicate the native transaction
+        if (
+          isAddressEqual(internalFrom, txFrom) &&
+          isAddressEqual(internalTo, txTo) &&
+          internalTx.value === tx.value
+        )
+          continue
+
         if (isAddressEqual(address, internalFrom)) {
           nativeTransfers.push({
             assetId: this.assetId,


### PR DESCRIPTION
## Description

Native amounts are currently doubled for same-chain second-class EVM Txs (sends/swaps) in upserted Txs, when the Tx is a same-account Tx. The reason here is we parse both the `value` and the internal transfer value out of debug RPC call. This ensures deduping, so Tx value is not doubled in Tx history.

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/11524

## Risk

> High Risk PRs Require 2 approvals

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Second-class EVM chains (XPL, Monad, Plasma, HyperEVM) - fixes duplicate transfer amounts in transaction history for same-account sends and swaps.

## Testing

- make a self-send of native asset for second class EVM chain
- ensure amounts are not doubled in upserted Tx
- do a same-account swap out of native asset for second-class EVM chain
- ditto ensure amount not doubled in Tx history

### Engineering

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

develop 

<img width="1169" height="176" alt="Screenshot 2025-12-24 at 13 08 48" src="https://github.com/user-attachments/assets/47011a85-9ef3-41ff-9548-bc2a96b9224b" />


this diff

<img width="1179" height="391" alt="Screenshot 2025-12-24 at 13 12 35" src="https://github.com/user-attachments/assets/eb5c9ae4-1e4e-4d2a-92cf-3c99a8f551b9" />
<img width="1176" height="309" alt="Screenshot 2025-12-24 at 13 10 45" src="https://github.com/user-attachments/assets/747880ff-b8be-4bae-ba5a-61a315f7594a" />
