### PR TITLE
fix: read fresh swap state in trade execution event handlers

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeExecution.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/hooks/useTradeExecution.tsx
@@ -253,7 +253,9 @@ export const useTradeExecution = (
           if (actualBuyAmountCryptoBaseUnit) {
             const freshActiveSwapId = swapSlice.selectors.selectActiveSwapId(store.getState())
             if (freshActiveSwapId) {
-              const currentSwap = swapSlice.selectors.selectSwapsById(store.getState())[freshActiveSwapId]
+              const currentSwap = swapSlice.selectors.selectSwapsById(store.getState())[
+                freshActiveSwapId
+              ]
               if (currentSwap) {
                 dispatch(
                   swapSlice.actions.upsertSwap({
@@ -279,7 +281,9 @@ export const useTradeExecution = (
         if (actualBuyAmountCryptoBaseUnit) {
           const freshActiveSwapId = swapSlice.selectors.selectActiveSwapId(store.getState())
           if (freshActiveSwapId) {
-            const currentSwap = swapSlice.selectors.selectSwapsById(store.getState())[freshActiveSwapId]
+            const currentSwap = swapSlice.selectors.selectSwapsById(store.getState())[
+              freshActiveSwapId
+            ]
             if (currentSwap) {
               dispatch(
                 swapSlice.actions.upsertSwap({


### PR DESCRIPTION
## Description

Fixes stale closures resulting in weird reverts of swaps, which currently happens when a swap is pending, but has amountOut (which is weird, but can happen for e.g NEAR Intents, where there will be a few runs of status calls where swap is PROCESSING (pending) but we *do* have an amountOut in response. This is a symptom of a bigger issue root cause, which this fixes.

## Issue (if applicable)

- closes https://github.com/shapeshift/web/issues/11535

## Risk

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

All swappers - this is a fix in the trade execution event handlers that affects how swap state is read during status polling.

## Testing

### Engineering

- Test NEAR Intents swaps and confirm the swap properly goes to complete, *not* back to "Awaiting execution"
- Regression test with another/few other swappers for the sake of completeness

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

https://jam.dev/c/77c0d6ee-4a64-48be-bafb-dbb24d4c38b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where multi-hop trade confirmation could show outdated buy amounts by ensuring the latest trade state is used during execution, so confirmation displays accurate values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->