### PR TITLE
fix: second-class evm adapter tokens fetching

### DIFF
--- a/packages/chain-adapters/src/evm/hyperevm/HyperEvmChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/hyperevm/HyperEvmChainAdapter.ts
@@ -12,7 +12,7 @@ const DEFAULT_CHAIN_ID = KnownChainIds.HyperEvmMainnet
 
 export type ChainAdapterArgs = {
   rpcUrl: string
-  knownTokens?: TokenInfo[]
+  getKnownTokens: () => TokenInfo[]
 }
 
 export const isHyperEvmChainAdapter = (adapter: unknown): adapter is ChainAdapter => {
@@ -33,7 +33,7 @@ export class ChainAdapter extends SecondClassEvmAdapter<KnownChainIds.HyperEvmMa
       rootBip44Params: ChainAdapter.rootBip44Params,
       supportedChainIds: SUPPORTED_CHAIN_IDS,
       rpcUrl: args.rpcUrl,
-      knownTokens: args.knownTokens ?? [],
+      getKnownTokens: args.getKnownTokens,
     })
   }
 

--- a/packages/chain-adapters/src/evm/monad/MonadChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/monad/MonadChainAdapter.ts
@@ -12,7 +12,7 @@ const DEFAULT_CHAIN_ID = KnownChainIds.MonadMainnet
 
 export type ChainAdapterArgs = {
   rpcUrl: string
-  knownTokens?: TokenInfo[]
+  getKnownTokens: () => TokenInfo[]
 }
 
 export const isMonadChainAdapter = (adapter: unknown): adapter is ChainAdapter => {
@@ -33,7 +33,7 @@ export class ChainAdapter extends SecondClassEvmAdapter<KnownChainIds.MonadMainn
       rootBip44Params: ChainAdapter.rootBip44Params,
       supportedChainIds: SUPPORTED_CHAIN_IDS,
       rpcUrl: args.rpcUrl,
-      knownTokens: args.knownTokens ?? [],
+      getKnownTokens: args.getKnownTokens,
     })
   }
 

--- a/packages/chain-adapters/src/evm/plasma/PlasmaChainAdapter.ts
+++ b/packages/chain-adapters/src/evm/plasma/PlasmaChainAdapter.ts
@@ -12,7 +12,7 @@ const DEFAULT_CHAIN_ID = KnownChainIds.PlasmaMainnet
 
 export type ChainAdapterArgs = {
   rpcUrl: string
-  knownTokens?: TokenInfo[]
+  getKnownTokens: () => TokenInfo[]
 }
 
 export const isPlasmaChainAdapter = (adapter: unknown): adapter is ChainAdapter => {
@@ -33,7 +33,7 @@ export class ChainAdapter extends SecondClassEvmAdapter<KnownChainIds.PlasmaMain
       rootBip44Params: ChainAdapter.rootBip44Params,
       supportedChainIds: SUPPORTED_CHAIN_IDS,
       rpcUrl: args.rpcUrl,
-      knownTokens: args.knownTokens ?? [],
+      getKnownTokens: args.getKnownTokens,
     })
   }
 

--- a/src/plugins/hyperevm/index.tsx
+++ b/src/plugins/hyperevm/index.tsx
@@ -19,24 +19,25 @@ export default function register(): Plugins {
             [
               KnownChainIds.HyperEvmMainnet,
               () => {
-                // Get all HyperEVM ERC20 tokens from asset service
-                const assetService = getAssetService()
-                const knownTokens = assetService.assets
-                  .filter(asset => {
-                    const { chainId, assetNamespace } = fromAssetId(asset.assetId)
-                    return chainId === hyperEvmChainId && assetNamespace === 'erc20'
-                  })
-                  .map(asset => ({
-                    assetId: asset.assetId,
-                    contractAddress: fromAssetId(asset.assetId).assetReference,
-                    symbol: asset.symbol,
-                    name: asset.name,
-                    precision: asset.precision,
-                  }))
+                const getKnownTokens = () => {
+                  const assetService = getAssetService()
+                  return assetService.assets
+                    .filter(asset => {
+                      const { chainId, assetNamespace } = fromAssetId(asset.assetId)
+                      return chainId === hyperEvmChainId && assetNamespace === 'erc20'
+                    })
+                    .map(asset => ({
+                      assetId: asset.assetId,
+                      contractAddress: fromAssetId(asset.assetId).assetReference,
+                      symbol: asset.symbol,
+                      name: asset.name,
+                      precision: asset.precision,
+                    }))
+                }
 
                 return new hyperevm.ChainAdapter({
                   rpcUrl: getConfig().VITE_HYPEREVM_NODE_URL,
-                  knownTokens,
+                  getKnownTokens,
                 })
               },
             ],

--- a/src/plugins/monad/index.tsx
+++ b/src/plugins/monad/index.tsx
@@ -19,24 +19,25 @@ export default function register(): Plugins {
             [
               KnownChainIds.MonadMainnet,
               () => {
-                // Get all Monad ERC20 tokens from asset service
-                const assetService = getAssetService()
-                const knownTokens = assetService.assets
-                  .filter(asset => {
-                    const { chainId, assetNamespace } = fromAssetId(asset.assetId)
-                    return chainId === monadChainId && assetNamespace === 'erc20'
-                  })
-                  .map(asset => ({
-                    assetId: asset.assetId,
-                    contractAddress: fromAssetId(asset.assetId).assetReference,
-                    symbol: asset.symbol,
-                    name: asset.name,
-                    precision: asset.precision,
-                  }))
+                const getKnownTokens = () => {
+                  const assetService = getAssetService()
+                  return assetService.assets
+                    .filter(asset => {
+                      const { chainId, assetNamespace } = fromAssetId(asset.assetId)
+                      return chainId === monadChainId && assetNamespace === 'erc20'
+                    })
+                    .map(asset => ({
+                      assetId: asset.assetId,
+                      contractAddress: fromAssetId(asset.assetId).assetReference,
+                      symbol: asset.symbol,
+                      name: asset.name,
+                      precision: asset.precision,
+                    }))
+                }
 
                 return new monad.ChainAdapter({
                   rpcUrl: getConfig().VITE_MONAD_NODE_URL,
-                  knownTokens,
+                  getKnownTokens,
                 })
               },
             ],

--- a/src/plugins/plasma/index.tsx
+++ b/src/plugins/plasma/index.tsx
@@ -19,23 +19,25 @@ export default function register(): Plugins {
             [
               KnownChainIds.PlasmaMainnet,
               () => {
-                const assetService = getAssetService()
-                const knownTokens = assetService.assets
-                  .filter(asset => {
-                    const { chainId, assetNamespace } = fromAssetId(asset.assetId)
-                    return chainId === plasmaChainId && assetNamespace === 'erc20'
-                  })
-                  .map(asset => ({
-                    assetId: asset.assetId,
-                    contractAddress: fromAssetId(asset.assetId).assetReference,
-                    symbol: asset.symbol,
-                    name: asset.name,
-                    precision: asset.precision,
-                  }))
+                const getKnownTokens = () => {
+                  const assetService = getAssetService()
+                  return assetService.assets
+                    .filter(asset => {
+                      const { chainId, assetNamespace } = fromAssetId(asset.assetId)
+                      return chainId === plasmaChainId && assetNamespace === 'erc20'
+                    })
+                    .map(asset => ({
+                      assetId: asset.assetId,
+                      contractAddress: fromAssetId(asset.assetId).assetReference,
+                      symbol: asset.symbol,
+                      name: asset.name,
+                      precision: asset.precision,
+                    }))
+                }
 
                 return new plasma.ChainAdapter({
                   rpcUrl: getConfig().VITE_PLASMA_NODE_URL,
-                  knownTokens,
+                  getKnownTokens,
                 })
               },
             ],


### PR DESCRIPTION
## Description

Fix race condition where second-class EVM chain adapters (HyperEVM, Monad, Plasma) were created with an empty token list because the asset service hadn't loaded yet. Changed from static `knownTokens` array to a `getKnownTokens()` getter function that fetches tokens dynamically at call time.

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/11549

## Risk

Low - only affects second-class EVM chains token balance fetching. No changes to transaction handling or core functionality.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

HyperEVM, Monad, and Plasma token balance display.

## Testing

### Engineering

- tokens for second-class EVM chains should be happy again same like in prod

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

- this diff

<img width="1726" height="1052" alt="Screenshot 2025-12-30 at 19 18 51" src="https://github.com/user-attachments/assets/cb43d785-64ef-40e0-a0e3-5f2811f3f24e" />
<img width="1728" height="1041" alt="Screenshot 2025-12-30 at 19 19 10" src="https://github.com/user-attachments/assets/85322fbf-4b65-4388-a300-8bc87c7f395f" />


- prod

<img width="1727" height="1048" alt="Screenshot 2025-12-30 at 19 21 05" src="https://github.com/user-attachments/assets/9860d3f7-5702-4d55-bdee-de9fcd0eb157" />


- develop

<img width="1728" height="1044" alt="Screenshot 2025-12-30 at 19 22 15" src="https://github.com/user-attachments/assets/db186aba-aa05-43db-b94f-af16bd279324" />
<img width="1728" height="1054" alt="Screenshot 2025-12-30 at 19 22 26" src="https://github.com/user-attachments/assets/e7d1b777-228f-4410-884f-8b38a8222b0b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated token retrieval mechanisms across chain adapters to use dynamic sourcing instead of static configurations, improving flexibility in how known tokens are provided to the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->