### PR TITLE
fix: trade routing take 2

### DIFF
--- a/src/context/AppProvider/AppContext.tsx
+++ b/src/context/AppProvider/AppContext.tsx
@@ -154,6 +154,7 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
   // Only runs ONCE per input type - refs ensure we don't reset on navigation
   useEffect(() => {
     if (Object.keys(assetsById).length === 0) return
+    if (hasTradeRouteParams) return
 
     const btcAsset = assetsById[btcAssetId]
     const ethAsset = assetsById[ethAssetId]
@@ -176,7 +177,13 @@ export const AppProvider = ({ children }: { children: React.ReactNode }) => {
       dispatch(limitOrderInput.actions.setSellAsset(usdcAsset))
       hasSetLimitDefaults.current = true
     }
-  }, [assetsById, dispatch, tradeInputBuyAsset.assetId, limitOrderInputBuyAsset.assetId])
+  }, [
+    assetsById,
+    dispatch,
+    hasTradeRouteParams,
+    tradeInputBuyAsset.assetId,
+    limitOrderInputBuyAsset.assetId,
+  ])
 
   useEffect(() => {
     const handleLedgerOpenApp = ({ chainId, reject }: LedgerOpenAppEventArgs) => {


### PR DESCRIPTION
## Description

- follows up on https://github.com/shapeshift/web/pull/11560 which accidentally work in dev server only due to a race condition
- now working on actual builds too

## Issue (if applicable)

N/A

## Risk

Low - simple guard condition added to prevent race condition

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None - this is a UI routing fix only

## Testing

- play around with spot swapper i.e refresh, change pairs, refresh, change tab to limit
- play around with limit swapper i.e refresh, change pairs, refresh, change tab to spot

### Engineering

- make sure to test this with `yarn preview:prod`

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

https://jam.dev/c/30223805-b3f0-48f6-8e08-1478b15c711f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where route parameters for trades or limits were incorrectly being overridden by default initialization values. The application now properly respects route-based initialization when navigating to trade or limit routes via URL parameters, ensuring the intended settings are preserved.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->