### PR TITLE
feat: limit narrow down related assetIds by chainId

### DIFF
--- a/src/components/AssetSearch/components/AssetList.tsx
+++ b/src/components/AssetSearch/components/AssetList.tsx
@@ -1,5 +1,6 @@
 import type { ListProps } from '@chakra-ui/react'
 import { Box, Center, Flex, Icon, Skeleton } from '@chakra-ui/react'
+import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { range } from 'lodash'
 import type { FC, WheelEvent } from 'react'
@@ -25,6 +26,8 @@ export type AssetData = {
   showPrice?: boolean
   onImportClick?: (asset: Asset) => void
   showRelatedAssets?: boolean
+  assetFilterPredicate?: (assetId: AssetId) => boolean
+  chainIdFilterPredicate?: (chainId: ChainId) => boolean
 }
 
 type AssetListProps = AssetData & ListProps
@@ -44,6 +47,8 @@ export const AssetList: FC<AssetListProps> = ({
   height = '50vh',
   onImportClick,
   showRelatedAssets = false,
+  assetFilterPredicate,
+  chainIdFilterPredicate,
 }) => {
   const virtuosoStyle = useMemo(
     () => ({
@@ -62,6 +67,8 @@ export const AssetList: FC<AssetListProps> = ({
       portalsAssets,
       onImportClick,
       showRelatedAssets,
+      assetFilterPredicate,
+      chainIdFilterPredicate,
     }),
     [
       assets,
@@ -72,6 +79,8 @@ export const AssetList: FC<AssetListProps> = ({
       portalsAssets,
       onImportClick,
       showRelatedAssets,
+      assetFilterPredicate,
+      chainIdFilterPredicate,
     ],
   )
 

--- a/src/components/AssetSearch/components/GroupedAssetRow.tsx
+++ b/src/components/AssetSearch/components/GroupedAssetRow.tsx
@@ -1,5 +1,6 @@
 import { ChevronDownIcon, ChevronUpIcon } from '@chakra-ui/icons'
 import { Box, Button, Center, Collapse, Flex, Text as CText, useDisclosure } from '@chakra-ui/react'
+import type { AssetId } from '@shapeshiftoss/caip'
 import { fromAssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import type { FC } from 'react'
@@ -31,6 +32,7 @@ type GroupedAssetRowProps = {
   hideZeroBalanceAmounts?: boolean
   showPrice?: boolean
   onLongPress?: (asset: Asset) => void
+  relatedAssetIds?: AssetId[]
 }
 
 export const GroupedAssetRow: FC<GroupedAssetRowProps> = ({
@@ -40,6 +42,7 @@ export const GroupedAssetRow: FC<GroupedAssetRowProps> = ({
   hideZeroBalanceAmounts,
   showPrice,
   onLongPress,
+  relatedAssetIds: providedRelatedAssetIds,
 }) => {
   const { isOpen, onToggle } = useDisclosure()
   const assets = useAppSelector(selectAssets)
@@ -67,10 +70,13 @@ export const GroupedAssetRow: FC<GroupedAssetRowProps> = ({
     }),
     [asset],
   )
-  const relatedAssetIds = useSelectorWithArgs(
+
+  // Always fetch relatedAssetIds, but prefer provided filtered list if available
+  const allRelatedAssetIds = useSelectorWithArgs(
     selectRelatedAssetIdsInclusiveSorted,
     relatedAssetIdsFilter,
   )
+  const relatedAssetIds = providedRelatedAssetIds ?? allRelatedAssetIds
 
   const handleGroupClick = useCallback(
     (e: React.MouseEvent) => {

--- a/src/components/TradeAssetSearch/TradeAssetSearch.tsx
+++ b/src/components/TradeAssetSearch/TradeAssetSearch.tsx
@@ -305,7 +305,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
     [onSelectFiatCurrency],
   )
 
-  const renferFiatItem = useCallback(
+  const renderFiatItem = useCallback(
     (index: number) => {
       const fiat = searchFiatCurrencies[index]
       return <FiatRow key={fiat.code} fiat={fiat} onClick={handleFiatClick} />
@@ -322,7 +322,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
             <Virtuoso
               className='scroll-container'
               data={searchFiatCurrencies}
-              itemContent={renferFiatItem}
+              itemContent={renderFiatItem}
               style={style}
               overscan={1000}
               increaseViewportBy={INCREASE_VIEWPORT_BY}
@@ -380,6 +380,8 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
                   popularAssets={popularAssets}
                   onAssetClick={handleAssetClick}
                   activeChainId={activeChainId}
+                  assetFilterPredicate={assetFilterPredicate}
+                  chainIdFilterPredicate={chainIdFilterPredicate}
                 />
               )}
             </TabPanel>
@@ -389,7 +391,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
                 <Virtuoso
                   className='scroll-container'
                   data={searchFiatCurrencies}
-                  itemContent={renferFiatItem}
+                  itemContent={renderFiatItem}
                   style={style}
                   overscan={1000}
                   increaseViewportBy={INCREASE_VIEWPORT_BY}
@@ -428,12 +430,15 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
         popularAssets={popularAssets}
         onAssetClick={handleAssetClick}
         activeChainId={activeChainId}
+        assetFilterPredicate={assetFilterPredicate}
+        chainIdFilterPredicate={chainIdFilterPredicate}
       />
     )
   }, [
     activeChainId,
     allowWalletUnsupportedAssets,
     assetFilterPredicate,
+    chainIdFilterPredicate,
     handleAssetClick,
     handleImportIntent,
     hasWallet,
@@ -443,7 +448,7 @@ export const TradeAssetSearch: FC<TradeAssetSearchProps> = ({
     popularAssets,
     portfolioAssetsSortedByBalanceForChain,
     workerSearchState,
-    renferFiatItem,
+    renderFiatItem,
     searchFiatCurrencies,
     searchString,
     showFiatTab,

--- a/src/components/TradeAssetSearch/components/DefaultAssetList.tsx
+++ b/src/components/TradeAssetSearch/components/DefaultAssetList.tsx
@@ -1,4 +1,4 @@
-import type { ChainId } from '@shapeshiftoss/caip'
+import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { useMemo } from 'react'
 
@@ -14,6 +14,8 @@ export type DefaultAssetListProps = {
   popularAssets: Asset[]
   onAssetClick: (asset: Asset) => void
   activeChainId: ChainId | 'All'
+  assetFilterPredicate?: (assetId: AssetId) => boolean
+  chainIdFilterPredicate?: (chainId: ChainId) => boolean
 }
 
 export const DefaultAssetList = ({
@@ -21,6 +23,8 @@ export const DefaultAssetList = ({
   popularAssets,
   onAssetClick,
   activeChainId,
+  assetFilterPredicate,
+  chainIdFilterPredicate,
 }: DefaultAssetListProps) => {
   const { isConnected } = useWallet().state
   const isPortfolioLoading = useAppSelector(selectIsPortfolioLoading)
@@ -56,6 +60,8 @@ export const DefaultAssetList = ({
       groupIsLoading={groupIsLoading}
       onAssetClick={onAssetClick}
       activeChainId={activeChainId}
+      assetFilterPredicate={assetFilterPredicate}
+      chainIdFilterPredicate={chainIdFilterPredicate}
     />
   )
 }

--- a/src/components/TradeAssetSearch/components/GroupedAssetList/GroupedAssetList.tsx
+++ b/src/components/TradeAssetSearch/components/GroupedAssetList/GroupedAssetList.tsx
@@ -1,5 +1,5 @@
 import { Box, Center } from '@chakra-ui/react'
-import type { ChainId } from '@shapeshiftoss/caip'
+import type { AssetId, ChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { useCallback } from 'react'
 import type { ItemProps, TopItemListProps } from 'react-virtuoso'
@@ -32,6 +32,8 @@ export type GroupedAssetListProps = {
   onImportClick?: (asset: Asset) => void
   hideZeroBalanceAmounts: boolean
   activeChainId: ChainId | 'All'
+  assetFilterPredicate?: (assetId: AssetId) => boolean
+  chainIdFilterPredicate?: (chainId: ChainId) => boolean
 }
 
 export const GroupedAssetList = ({
@@ -43,6 +45,8 @@ export const GroupedAssetList = ({
   onImportClick,
   hideZeroBalanceAmounts,
   activeChainId,
+  assetFilterPredicate,
+  chainIdFilterPredicate,
 }: GroupedAssetListProps) => {
   const renderGroupContent = useCallback(
     (index: number) => {
@@ -85,6 +89,8 @@ export const GroupedAssetList = ({
         disableUnsupported: false,
         hideZeroBalanceAmounts,
         onImportClick,
+        assetFilterPredicate,
+        chainIdFilterPredicate,
       }
 
       return (
@@ -97,7 +103,15 @@ export const GroupedAssetList = ({
         />
       )
     },
-    [assets, onAssetClick, hideZeroBalanceAmounts, onImportClick, activeChainId],
+    [
+      assets,
+      onAssetClick,
+      hideZeroBalanceAmounts,
+      onImportClick,
+      activeChainId,
+      assetFilterPredicate,
+      chainIdFilterPredicate,
+    ],
   )
 
   return (


### PR DESCRIPTION
## Description

Does what it says on the box - adds the ability for related assets in asset selection modal to be narrowed down by ChainId, in this specific case, this aligns limit page with CoW-supported chains narrowing, same as assets list in asset search modal modal, chain list in asset search modal, and related asset dropdown.

## Issue (if applicable)

closes https://github.com/shapeshift/web/issues/11576

## Risk

> Low Risk - UI-only changes to asset selection, no on-chain transactions affected

## Testing

### Engineering

- ensure spot related/assets chain/network selection does not show any regression against develop/prod
- ensure limit related assets are properly narrowed by CoW-supported chains

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

https://jam.dev/c/23838218-7134-46c0-8e21-b39447e425a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added asset and chain filter predicates across asset search and trade flows so users can control which assets and networks appear in lists.
  * Related-asset groups now honor provided filters, improving relevance of grouped suggestions.
  * Filters are consistently propagated through search, fiat, and grouped list views for a unified experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->