### PR TITLE
fix: add starknet code splitting to reduce bundle size

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -222,6 +222,7 @@ export default defineConfig(({ mode }) => {
               if (id.match(/(dayjs|lodash|@formatjs)/)) return 'utils'
               if (id.match(/(@redux|@tanstack)/)) return 'state'
               if (id.match(/(@metaplex-foundation|@solana)/)) return 'solana'
+              if (id.match(/(starknet|@avnu|@starknet-io)/)) return 'starknet'
               if (id.match(/(@sentry|mixpanel|@moralisweb3|moralis)/)) return 'sdk'
               if (id.match(/(embla-carousel)/)) return 'carousel'
               if (id.includes('lightweight-charts')) return 'charts'


### PR DESCRIPTION
## Description

PR #11552 added `@avnu/avnu-sdk` for Starknet token swaps, which pulled in the heavy `starknet` SDK. This increased the main source map from ~24 MB to 26.7 MB, exceeding Cloudflare Pages' 26.2 MB file limit and breaking CI deploys.

This PR adds starknet dependencies to Vite's `manualChunks` configuration, splitting them into a separate chunk following the existing pattern for other heavy dependencies like `@solana`, `@ledgerhq`, etc.

**Result:**
| Source Map | Before | After |
|------------|--------|-------|
| `main-*.js.map` | 26.7 MB ❌ | 22 MB ✅ |
| `starknet-*.js.map` | - | 7.4 MB (new) |

## Issue (if applicable)

Fixes CI deploy failures on develop branch.

## Risk

Low risk - this only affects Vite's chunk splitting configuration. The same code is delivered to users, just in a separate chunk file. This follows the established pattern already used for Solana, Ledger, and other heavy dependencies.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None - this is a build configuration change only.

## Testing

A quick app spot check around trades would not go a stray!

### Engineering

1. Build the app locally: `yarn build:web`
2. Verify `starknet-*.js` chunk exists in `build/assets/`
3. Verify no `.map` file exceeds 26.2 MB: `find build/assets -name '*.map' -exec ls -lh {} \; | sort -hr -k5 | head -5`
4. CI should pass the Cloudflare Pages deploy step

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

This is a build infrastructure fix with no user-facing changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized code-splitting configuration for Starknet-related packages to be bundled in a dedicated chunk, improving build efficiency and load performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->