### PR TITLE
feat: better information architecture of /yields on mobile

### DIFF
--- a/src/lib/yieldxyz/constants.ts
+++ b/src/lib/yieldxyz/constants.ts
@@ -91,6 +91,3 @@ export const COSMOS_ATOM_NATIVE_STAKING_YIELD_ID = 'cosmos-atom-native-staking'
 export const DEFAULT_NATIVE_VALIDATOR_BY_CHAIN_ID: Partial<Record<ChainId, string>> = {
   [cosmosChainId]: SHAPESHIFT_COSMOS_VALIDATOR_ADDRESS,
 }
-
-
-

--- a/src/lib/yieldxyz/constants.ts
+++ b/src/lib/yieldxyz/constants.ts
@@ -91,3 +91,6 @@ export const COSMOS_ATOM_NATIVE_STAKING_YIELD_ID = 'cosmos-atom-native-staking'
 export const DEFAULT_NATIVE_VALIDATOR_BY_CHAIN_ID: Partial<Record<ChainId, string>> = {
   [cosmosChainId]: SHAPESHIFT_COSMOS_VALIDATOR_ADDRESS,
 }
+
+
+

--- a/src/pages/Yields/YieldAssetDetails.tsx
+++ b/src/pages/Yields/YieldAssetDetails.tsx
@@ -344,7 +344,7 @@ export const YieldAssetDetails = memo(() => {
         </Box>
       </Flex>
     )
-  }, [assetInfo, assetYields.length, translate])
+  }, [assetInfo, translate])
 
   const loadingGridElement = useMemo(
     () => (
@@ -354,7 +354,7 @@ export const YieldAssetDetails = memo(() => {
         ))}
       </SimpleGrid>
     ),
-    [],
+    [isMobile],
   )
 
   const loadingListElement = useMemo(
@@ -393,7 +393,7 @@ export const YieldAssetDetails = memo(() => {
         ))}
       </SimpleGrid>
     ),
-    [allBalances, getProviderLogo, handleYieldClick, sortedRows],
+    [allBalances, getProviderLogo, handleYieldClick, isMobile, sortedRows],
   )
 
   const listViewElement = useMemo(

--- a/src/pages/Yields/YieldAssetDetails.tsx
+++ b/src/pages/Yields/YieldAssetDetails.tsx
@@ -341,7 +341,6 @@ export const YieldAssetDetails = memo(() => {
           <Heading size='lg'>
             {translate('yieldXYZ.assetYields', { asset: assetInfo.assetName })}
           </Heading>
-
         </Box>
       </Flex>
     )
@@ -385,9 +384,9 @@ export const YieldAssetDetails = memo(() => {
             userBalanceUsd={
               allBalances?.[row.original.id]
                 ? allBalances[row.original.id].reduce(
-                  (sum, b) => sum.plus(bnOrZero(b.amountUsd)),
-                  bnOrZero(0),
-                )
+                    (sum, b) => sum.plus(bnOrZero(b.amountUsd)),
+                    bnOrZero(0),
+                  )
                 : undefined
             }
           />

--- a/src/pages/Yields/components/YieldItem.tsx
+++ b/src/pages/Yields/components/YieldItem.tsx
@@ -21,9 +21,8 @@ import { useNavigate } from 'react-router-dom'
 
 import { Amount } from '@/components/Amount/Amount'
 import { AssetIcon } from '@/components/AssetIcon'
-
 import { bnOrZero } from '@/lib/bignumber/bignumber'
-import { AugmentedYieldDto } from '@/lib/yieldxyz/types'
+import type { AugmentedYieldDto } from '@/lib/yieldxyz/types'
 import { resolveYieldInputAssetIcon } from '@/lib/yieldxyz/utils'
 import { GradientApy } from '@/pages/Yields/components/GradientApy'
 import { useYieldProviders } from '@/react-queries/queries/yieldxyz/useYieldProviders'
@@ -145,8 +144,9 @@ export const YieldItem = memo(
       if (isSingle) {
         return data.yieldItem.providerId
       }
-      return `${stats.count} ${stats.count === 1 ? translate('yieldXYZ.market') : translate('yieldXYZ.markets')
-        }`
+      return `${stats.count} ${
+        stats.count === 1 ? translate('yieldXYZ.market') : translate('yieldXYZ.markets')
+      }`
     }, [data, isSingle, stats.count, translate])
 
     const title = useMemo(() => {
@@ -161,7 +161,6 @@ export const YieldItem = memo(
           variant='dashboard'
           cursor='pointer'
           onClick={handleClick}
-
           borderWidth='1px'
           borderColor='border.base'
           boxShadow='none'
@@ -385,8 +384,6 @@ export const YieldItem = memo(
               )}
             </Stat>
           </HStack>
-
-
         </CardBody>
       </Card>
     )

--- a/src/pages/Yields/components/YieldOpportunityStats.tsx
+++ b/src/pages/Yields/components/YieldOpportunityStats.tsx
@@ -34,6 +34,7 @@ type YieldOpportunityStatsProps = {
   isMyOpportunities?: boolean
   onToggleMyOpportunities?: () => void
   isConnected: boolean
+  isMobile?: boolean
 }
 
 export const YieldOpportunityStats = memo(function YieldOpportunityStats({
@@ -43,6 +44,7 @@ export const YieldOpportunityStats = memo(function YieldOpportunityStats({
   isMyOpportunities,
   onToggleMyOpportunities,
   isConnected,
+  isMobile,
 }: YieldOpportunityStatsProps) {
   const translate = useTranslate()
   const userCurrencyToUsdRate = useAppSelector(selectUserCurrencyToUsdRate)
@@ -190,6 +192,8 @@ export const YieldOpportunityStats = memo(function YieldOpportunityStats({
       </Button>
     )
   }, [onToggleMyOpportunities, buttonBg, buttonHoverBg, buttonText])
+
+  if (isMobile) return null
 
   return (
     <SimpleGrid columns={{ base: 1, md: 3 }} spacing={4} mb={8}>

--- a/src/pages/Yields/components/YieldsList.tsx
+++ b/src/pages/Yields/components/YieldsList.tsx
@@ -711,8 +711,6 @@ export const YieldsList = memo(() => {
     getProviderLogo,
     handleYieldClick,
     isMobile,
-    assetBalancesBaseUnit,
-    assets,
   ])
 
   const allYieldsContentElement = useMemo(() => {

--- a/src/pages/Yields/components/YieldsList.tsx
+++ b/src/pages/Yields/components/YieldsList.tsx
@@ -32,6 +32,7 @@ import { ChainIcon } from '@/components/ChainMenu'
 import { ResultsEmptyNoWallet } from '@/components/ResultsEmptyNoWallet'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { bnOrZero } from '@/lib/bignumber/bignumber'
+import { fromBaseUnit } from '@/lib/math'
 import { YIELD_NETWORK_TO_CHAIN_ID } from '@/lib/yieldxyz/constants'
 import type { AugmentedYieldDto, YieldNetwork } from '@/lib/yieldxyz/types'
 import { resolveYieldInputAssetIcon, searchYields } from '@/lib/yieldxyz/utils'
@@ -50,7 +51,6 @@ import {
   selectPortfolioUserCurrencyBalances,
   selectUserCurrencyToUsdRate,
 } from '@/state/slices/selectors'
-import { fromBaseUnit } from '@/lib/math'
 import { useAppSelector } from '@/state/store'
 
 const tabSelectedSx = { color: 'white', bg: 'blue.500' }
@@ -152,10 +152,10 @@ export const YieldsList = memo(() => {
     () =>
       yields?.meta?.networks
         ? yields.meta.networks.map(net => ({
-          id: net,
-          name: net.charAt(0).toUpperCase() + net.slice(1),
-          chainId: YIELD_NETWORK_TO_CHAIN_ID[net as YieldNetwork],
-        }))
+            id: net,
+            name: net.charAt(0).toUpperCase() + net.slice(1),
+            chainId: YIELD_NETWORK_TO_CHAIN_ID[net as YieldNetwork],
+          }))
         : [],
     [yields],
   )
@@ -164,10 +164,10 @@ export const YieldsList = memo(() => {
     () =>
       yields?.meta?.providers
         ? yields.meta.providers.map(pId => ({
-          id: pId,
-          name: pId.charAt(0).toUpperCase() + pId.slice(1),
-          icon: getProviderLogo(pId),
-        }))
+            id: pId,
+            name: pId.charAt(0).toUpperCase() + pId.slice(1),
+            icon: getProviderLogo(pId),
+          }))
         : [],
     [yields, getProviderLogo],
   )
@@ -210,8 +210,6 @@ export const YieldsList = memo(() => {
           return balances.reduce((sum, b) => sum.plus(bnOrZero(b.amountUsd)), acc)
         }, bnOrZero(0))
 
-
-
         return {
           yields: filteredYields,
           assetSymbol: group.symbol,
@@ -246,15 +244,15 @@ export const YieldsList = memo(() => {
             return 0
         }
       }) as {
-        yields: AugmentedYieldDto[]
-        assetSymbol: string
-        assetName: string
-        assetIcon: string
-        assetId: string | undefined
-        userGroupBalanceUsd: ReturnType<typeof bnOrZero>
-        maxApy: number
-        totalTvlUsd: ReturnType<typeof bnOrZero>
-      }[]
+      yields: AugmentedYieldDto[]
+      assetSymbol: string
+      assetName: string
+      assetIcon: string
+      assetId: string | undefined
+      userGroupBalanceUsd: ReturnType<typeof bnOrZero>
+      maxApy: number
+      totalTvlUsd: ReturnType<typeof bnOrZero>
+    }[]
   }, [
     yields?.assetGroups,
     isMyOpportunities,
@@ -268,7 +266,8 @@ export const YieldsList = memo(() => {
   ])
 
   const recommendedYields = useMemo(() => {
-    if (!isConnected || !yields?.byInputAssetId || !userCurrencyBalances || !assetBalancesBaseUnit) return []
+    if (!isConnected || !yields?.byInputAssetId || !userCurrencyBalances || !assetBalancesBaseUnit)
+      return []
 
     const recommendations: {
       yield: AugmentedYieldDto
@@ -687,21 +686,20 @@ export const YieldsList = memo(() => {
           {translate('yieldXYZ.recommendedForYou')}
         </Text>
         <SimpleGrid columns={{ base: 1, md: 3 }} spacing={{ base: 2, md: 4 }}>
-          {recommendedYields
-            .map(rec => (
-              <YieldItem
-                key={rec.yield.id}
-                data={{
-                  type: 'single',
-                  yieldItem: rec.yield,
-                  providerIcon: getProviderLogo(rec.yield.providerId),
-                }}
-                variant={isMobile ? 'mobile' : 'card'}
-                userBalanceUsd={rec.balanceFiat}
-                titleOverride={rec.yield.token.symbol}
-                onEnter={() => handleYieldClick(rec.yield.id)}
-              />
-            ))}
+          {recommendedYields.map(rec => (
+            <YieldItem
+              key={rec.yield.id}
+              data={{
+                type: 'single',
+                yieldItem: rec.yield,
+                providerIcon: getProviderLogo(rec.yield.providerId),
+              }}
+              variant={isMobile ? 'mobile' : 'card'}
+              userBalanceUsd={rec.balanceFiat}
+              titleOverride={rec.yield.token.symbol}
+              onEnter={() => handleYieldClick(rec.yield.id)}
+            />
+          ))}
         </SimpleGrid>
       </Box>
     )
@@ -719,7 +717,9 @@ export const YieldsList = memo(() => {
 
   const allYieldsContentElement = useMemo(() => {
     if (isLoading)
-      return viewMode === 'grid' || isMobile ? allYieldsLoadingGridElement : allYieldsLoadingListElement
+      return viewMode === 'grid' || isMobile
+        ? allYieldsLoadingGridElement
+        : allYieldsLoadingListElement
     if (yieldsByAsset.length === 0) return allYieldsEmptyElement
     return viewMode === 'grid' || isMobile ? allYieldsGridElement : allYieldsListElement
   }, [
@@ -775,9 +775,9 @@ export const YieldsList = memo(() => {
             userBalanceUsd={
               allBalances?.[row.original.id]
                 ? allBalances[row.original.id].reduce(
-                  (sum, b) => sum.plus(bnOrZero(b.amountUsd)),
-                  bnOrZero(0),
-                )
+                    (sum, b) => sum.plus(bnOrZero(b.amountUsd)),
+                    bnOrZero(0),
+                  )
                 : undefined
             }
           />


### PR DESCRIPTION
## Description
Better information architecture of /yields route for mobile (mostly) and desktop, less is more: don't display the top earnings hero/subheading or filters/grid toggles on mobile; render asset cards when there is a single yield for that asset; keep mobile compact with fewer fields; prefer asset symbols for simplicity; leverage right-side APY for easy comparison.

## Issue (if applicable)
closes #N/A

## Risk
UI-only changes to /yields layout (cards, filters, view toggles); no transaction or protocol logic touched.

## Testing

### Engineering
- Things look better on mobile now!

### Operations
- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)


<img width="501" height="929" alt="Screenshot 2026-01-14 at 00 16 17" src="https://github.com/user-attachments/assets/7a624c49-b082-4812-ba54-4ce9adb17adb" />
<img width="503" height="937" alt="Screenshot 2026-01-14 at 00 16 08" src="https://github.com/user-attachments/assets/56bfb08e-0ec2-4018-80d8-27d2febfb26e" />
<img width="507" height="946" alt="Screenshot 2026-01-14 at 00 15 56" src="https://github.com/user-attachments/assets/db7d2281-73d5-4e18-ba5d-3750530f4c81" />
<img width="466" height="953" alt="Screenshot 2026-01-14 at 00 15 50" src="https://github.com/user-attachments/assets/a6c6383d-6ec7-48d3-a624-cb8d8448a8a7" />
