### PR TITLE
fix: remove monad and gnosis from portals as it's no longer supported

### DIFF
--- a/packages/swapper/src/swappers/PortalsSwapper/constants.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/constants.ts
@@ -6,7 +6,6 @@ export const chainIdToPortalsNetwork: Partial<Record<KnownChainIds, string>> = {
   [KnownChainIds.OptimismMainnet]: 'optimism',
   [KnownChainIds.BnbSmartChainMainnet]: 'bsc',
   [KnownChainIds.PolygonMainnet]: 'polygon',
-  [KnownChainIds.GnosisMainnet]: 'gnosis',
   [KnownChainIds.ArbitrumMainnet]: 'arbitrum',
   [KnownChainIds.BaseMainnet]: 'base',
   [KnownChainIds.HyperEvmMainnet]: 'hyperevm',

--- a/src/lib/portals/constants.ts
+++ b/src/lib/portals/constants.ts
@@ -5,9 +5,7 @@ import {
   baseChainId,
   bscChainId,
   ethChainId,
-  gnosisChainId,
   hyperEvmChainId,
-  monadChainId,
   optimismChainId,
   polygonChainId,
 } from '@shapeshiftoss/caip'
@@ -20,9 +18,7 @@ export const CHAIN_ID_TO_PORTALS_NETWORK: Partial<Record<ChainId, string>> = {
   [bscChainId]: 'bsc',
   [optimismChainId]: 'optimism',
   [arbitrumChainId]: 'arbitrum',
-  [gnosisChainId]: 'gnosis',
   [baseChainId]: 'base',
-  [monadChainId]: 'monad',
   [hyperEvmChainId]: 'hyperevm',
 }
 

--- a/src/state/apis/portals/utils.ts
+++ b/src/state/apis/portals/utils.ts
@@ -5,7 +5,6 @@ import {
   baseChainId,
   bscChainId,
   ethChainId,
-  gnosisChainId,
   optimismChainId,
   polygonChainId,
 } from '@shapeshiftoss/caip'
@@ -17,7 +16,6 @@ export enum SupportedPortalsNetwork {
   Ethereum = 'ethereum',
   Optimism = 'optimism',
   Polygon = 'polygon',
-  Gnosis = 'gnosis',
   Arbitrum = 'arbitrum',
   Base = 'base',
 }
@@ -28,7 +26,6 @@ const PORTALS_NETWORKS_TO_CHAIN_ID_MAP: Record<SupportedPortalsNetwork, ChainId>
   [SupportedPortalsNetwork.Ethereum]: ethChainId,
   [SupportedPortalsNetwork.Optimism]: optimismChainId,
   [SupportedPortalsNetwork.Polygon]: polygonChainId,
-  [SupportedPortalsNetwork.Gnosis]: gnosisChainId,
   [SupportedPortalsNetwork.Arbitrum]: arbitrumChainId,
   [SupportedPortalsNetwork.Base]: baseChainId,
 } as const


### PR DESCRIPTION
## Description

Portals api is throwing errors that it currently doesn't support Gnosis and Monad even though the docs say it does. The API on the explore page on mobile returns status 400 : "each value in networks must be one of the following values: ethereum, optimism, arbitrum, polygon, avalanche, bsc, base, sonic, hyperevm". Removing it for now to un-break the explore page but we can check later if this gets fixed on their end and revert.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #11652 

## Risk

Low risk, we could lose access to some gnosis stuff on portals but it's already completely breaking some pages.

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

* Explore page on mobile loads ok when clicking into sub sections
* Sanity check swaps to and from gnosis show up with quotes
* Make sure one click defi still loads as expected on the markets page

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)

<img width="625" height="1313" alt="image" src="https://github.com/user-attachments/assets/7b2cbeb0-81af-44ab-9c1a-9b4109ddd239" />

