### PR TITLE
chore: bump package versions for npm publish

### DIFF
--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/caip",
-  "version": "8.16.5",
+  "version": "8.16.6",
   "description": "CAIP Implementation",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/chain-adapters",
-  "version": "11.3.6",
+  "version": "11.3.7",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "17.6.7",
+  "version": "17.6.8",
   "packageManager": "yarn@3.5.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/types",
-  "version": "8.6.5",
+  "version": "8.6.6",
   "description": "Common types shared across packages",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/utils",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "packageManager": "yarn@3.5.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bump package versions to prepare for npm publish.

## Version Changes
| Package | Old | New |
|---------|-----|-----|
| @shapeshiftoss/caip | 8.16.5 | 8.16.6 |
| @shapeshiftoss/utils | 1.0.4 | 1.0.5 |
| @shapeshiftoss/types | 8.6.5 | 8.6.6 |
| @shapeshiftoss/chain-adapters | 11.3.6 | 11.3.7 |
| @shapeshiftoss/swapper | 17.6.7 | 17.6.8 |

## Changes Since Last Publish
These packages have not been published since Dec 3rd, 2025. Changes include:
- Katana chain support
- Monad chain support  
- HyperEVM chain support
- Plasma chain support
- Starknet implementation
- Near chain support
- Various bug fixes and improvements

## Publishing Instructions
After merging, someone with npm publish access needs to run:

**Important**: Use `yarn npm publish` (not `npm publish`) to properly resolve `workspace:^` dependencies to actual versions.

```bash
# Build all packages first
yarn build:packages

# Publish in dependency order (dependencies first)
cd packages/caip && yarn npm publish --access public
cd ../types && yarn npm publish --access public
cd ../utils && yarn npm publish --access public
cd ../unchained-client && yarn npm publish --access public
cd ../chain-adapters && yarn npm publish --access public
cd ../contracts && yarn npm publish --access public
cd ../swapper && yarn npm publish --access public
```

Or use workspaces foreach:
```bash
yarn build:packages
yarn workspaces foreach -ptv --exclude @shapeshiftoss/web npm publish --access public
```