### PR TITLE
fix: allow external receive address for sunio and stonfi

### DIFF
--- a/packages/swapper/src/swappers/SunioSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/SunioSwapper/endpoints.ts
@@ -88,7 +88,7 @@ export const sunioApi: SwapperApi = {
       sunioMetadata.route,
       step.sellAmountIncludingProtocolFeesCryptoBaseUnit,
       step.buyAmountAfterFeesCryptoBaseUnit,
-      from,
+      tradeQuote.receiveAddress,
       slippageTolerancePercentageDecimal,
     )
 

--- a/src/state/helpers.ts
+++ b/src/state/helpers.ts
@@ -18,16 +18,16 @@ export const isCrossAccountTradeSupported = (swapperName: SwapperName) => {
     case SwapperName.ButterSwap:
     case SwapperName.Bebop:
     case SwapperName.NearIntents:
+    case SwapperName.Stonfi:
+    case SwapperName.Sunio:
       return true
     case SwapperName.Zrx:
     case SwapperName.CowSwap:
     case SwapperName.ArbitrumBridge:
     case SwapperName.Portals:
-    case SwapperName.Cetus:
-    case SwapperName.Sunio:
-    case SwapperName.Avnu:
-    case SwapperName.Stonfi:
     case SwapperName.Test:
+    case SwapperName.Avnu:
+    case SwapperName.Cetus:
       // Technically supported for Arbitrum Bridge, but we disable it for the sake of simplicity for now
       return false
     default:


### PR DESCRIPTION
## Description
Allowing to use secondary account and external address with sunio and stonfi
<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Nothing

## Risk
Quite high, imagine sending a fund to a weird address
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to swap to your addy #0 from your addy #1 OR a an external receive address with Sun.io (TRX to USDT on Tron for example) (note: you should have TRX in the receive address if you want to balance to be updated, as the RPC is returning nothing if it doesn't have any TRX activity)
- Try to swap to your addy #0 from your addy #1 OR a an external receive address with Stonfi (TON to USDT on Ton for example)
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/5bc45de9-2105-42e9-8236-061f36bb4b7d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed transaction parameter handling for Tron network swaps to ensure correct address routing.

* **Updates**
  * Adjusted cross-account swap compatibility: Sunio and Stonfi now available for cross-account trades; Avnu and Cetus support has been modified accordingly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->