### PR TITLE
fix: increase Node memory limit for dev server to prevent OOM

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "clean:packages": "yarn workspaces foreach -ptiv --exclude @shapeshiftoss/web run clean",
     "codemod:clear-assets-migration": "jscodeshift -t src/state/migrations/transformClearAssets.ts --parser=ts --extensions=ts src/state/migrations/index.ts",
     "deadcode": "yarn ts-prune",
-    "dev:web": "vite",
+    "dev:web": "NODE_OPTIONS=--max-old-space-size=8192 vite",
     "dev:web:linked": "GENERATE_SOURCEMAP=false BROWSER=none yarn dev:web",
     "dev:packages": "yarn tsc --build --watch --preserveWatchOutput tsconfig.packages.json",
     "dev:swap-widget": "yarn workspace @shapeshiftoss/swap-widget dev",


### PR DESCRIPTION
## Description

Vite's dev server worker was crashing with `ERR_WORKER_OUT_OF_MEMORY` due to the default Node.js heap limit (~4GB) being insufficient for this codebase's dependency optimization.

<img width="1850" height="1020" alt="image" src="https://github.com/user-attachments/assets/3e8f467d-0df9-4b22-926f-bd863a0c3b8d" />

This adds `NODE_OPTIONS=--max-old-space-size=8192` to the `dev:web` script, matching the pattern already used by `build:web` (which uses 16GB).

## Issue (if applicable)

N/A - local dev environment issue

## Risk

**Very Low** - Only affects local development environment, no production code changes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None. This is a build tooling change only.

## Testing

### Engineering

1. Run `yarn dev`
2. Verify the dev server starts without `ERR_WORKER_OUT_OF_MEMORY` errors
3. Verify hot reload works normally

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

This is a local development tooling fix with no user-facing impact.

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to improve development environment performance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->