### PR TITLE
chore: hotfix release v1.1001.0

### DIFF
--- a/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
@@ -25,6 +25,7 @@ export type RelayTransactionMetadata = {
   psbt?: string
   opReturnData?: string
   relayId: string
+  orderId: string
 }
 
 export type RelayStatus = {
@@ -146,10 +147,26 @@ export type RelayQuoteStep = {
   items?: RelayQuoteItem[]
 }
 
+export type RelayProtocolV2 = {
+  orderId: string
+  orderData?: unknown
+  paymentDetails?: {
+    chainId: string
+    depository: string
+    currency: string
+    amount: string
+  }
+}
+
+export type RelayProtocol = {
+  v2?: RelayProtocolV2
+}
+
 export type RelayQuote = {
   fees: RelayFees
   details: QuoteDetails
   steps: RelayQuoteStep[]
+  protocol?: RelayProtocol
 }
 
 export const isRelayQuoteUtxoItemData = (


### PR DESCRIPTION
fix: relay btc quotes using requestId instead of orderId