### PR TITLE
fix: relay quotes

### DIFF
--- a/packages/swapper/src/swappers/RelaySwapper/utils/getTrade.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/getTrade.ts
@@ -246,7 +246,7 @@ export async function getTrade<T extends 'quote' | 'rate'>({
   const { data: quote } = maybeQuote.unwrap()
 
   const orderId = quote.protocol?.v2?.orderId
-  if (!orderId) {
+  if (!orderId && sellAsset.chainId === btcChainId) {
     return Err(
       makeSwapErrorRight({
         message: 'Relay quote missing protocol.v2.orderId',

--- a/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
@@ -25,7 +25,7 @@ export type RelayTransactionMetadata = {
   psbt?: string
   opReturnData?: string
   relayId: string
-  orderId: string
+  orderId: string | undefined
 }
 
 export type RelayStatus = {
@@ -148,7 +148,7 @@ export type RelayQuoteStep = {
 }
 
 export type RelayProtocolV2 = {
-  orderId: string
+  orderId: string | undefined
   orderData?: unknown
   paymentDetails?: {
     chainId: string


### PR DESCRIPTION
## Description

Sometime the relay API isn't returning an orderId (cf the BTC fix we had)

In case it's not BTC, we can continue as all the request data is contained in the data of the TX

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

Spotted while developing

## Risk
Let's say high because we almost lost some users funds already
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Try to swap on small chains in production, you might face places where you don't see the relay quote
- Try to swap using this branch you'll see the quote
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/f1a406e3-71c7-4d58-bb44-aa063f4d3d14

Tested with the generic evm chain PR (spotted while testing celo/linea)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relay order handling and validation logic to enhance cross-chain transaction support. Trades on non-Bitcoin blockchain networks can now proceed successfully when certain order identifiers are temporarily unavailable, while Bitcoin transactions continue to enforce strict validation requirements. Updated underlying data structures to support optional order identifiers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->