### PR TITLE
fix: set send asset only if scheme url is detected from qr code

### DIFF
--- a/src/components/Modals/Send/Form.tsx
+++ b/src/components/Modals/Send/Form.tsx
@@ -310,8 +310,9 @@ export const Form: React.FC<SendFormProps> = ({ initialAssetId, input = '', acco
 
         methods.setValue(SendFormFields.Input, address)
 
-        // Update assetId and accountId if detected from QR code
-        if (maybeUrlResult.assetId) {
+        // Update assetId and accountId only if from payment URI (not plain address)
+        // Plain addresses should preserve the user's selected asset
+        if (urlDirectResult && maybeUrlResult.assetId) {
           methods.setValue(SendFormFields.AssetId, maybeUrlResult.assetId)
 
           // Get accounts for this asset to ensure we have a valid accountId


### PR DESCRIPTION
## Description

Set the asset in the send modal after scanning only if it was a scheme address in the QR code, so we can select the asset then scan a QR code and the asset stay the one we've selected

<!-- Please describe your changes -->

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

closes #11793

## Risk
Low
> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing
- Go to any asset page
- Select "send"
- Open the QR code modal from this send modal
- Scan a QR code on your mobile app wallet
- The send flow should continue to use the same asset you've been selected
<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

## Screenshots (if applicable)
https://jam.dev/c/6d4cd6e4-d65d-406b-bb7e-42ed7beb8d91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where scanning a QR code with a plain address would override your currently selected asset/account. The system now correctly preserves your asset selection when scanning plain addresses and only updates the asset/account when scanning payment URIs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->