### PR TITLE
chore: add .sisyphus/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ yarn-error.log*
 *.iml
 .idea/
 .playwright-mcp/
+.sisyphus/


### PR DESCRIPTION
## Description

Add `.sisyphus/` to `.gitignore`. This is a local agent tooling directory (OpenCode/Sisyphus work-tracking state) that should not be committed, similar to the already-ignored `.playwright-mcp/`.

## Issue (if applicable)

N/A

## Risk

Zero risk. Gitignore-only change with no impact on code, protocols, transactions, wallets, or contract interactions.

## Testing

### Engineering

No testing required — gitignore change only.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to ignore additional build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->