### PR TITLE
fix: add font-src to Inter font CSP to unblock font loading

### DIFF
--- a/headers/csps/InterFont.ts
+++ b/headers/csps/InterFont.ts
@@ -3,4 +3,5 @@ import type { Csp } from '../types'
 export const csp: Csp = {
   'style-src': ['https://rsms.me'],
   'default-src': ['https://rsms.me'],
+  'font-src': ['https://rsms.me'],
 }


### PR DESCRIPTION
## Description

The userback widget PR (#11775) introduced an explicit `font-src` CSP directive in `headers/csps/userback.ts`. This caused the browser to stop falling back to `default-src` for font loading, which meant the Inter font from `rsms.me` — configured only in `default-src` and `style-src` in `InterFont.ts` — was blocked by CSP on all deployed environments.

This adds `'font-src': ['https://rsms.me']` to the Inter font CSP configuration to restore font loading.

**Affected environments:** app.shapeshift.com, release.shapeshift.com, private.shapeshift.com (all deployed builds since #11775 was merged).

## Risk

Near zero. This is a one-line CSP header addition that restores previously-working font loading behavior. No protocols, transactions, wallets, or contract interactions are affected.

## Testing

### Engineering

1. Deploy to any preview environment
2. Open browser DevTools → Console
3. Verify there are no `font-src` CSP violation errors for `rsms.me` Inter fonts
4. Verify the Inter font renders correctly (previously falling back to system font)

### Operations

- Open the app in a browser
- Confirm the UI font looks correct (Inter font, not a fallback system font)
- Check the browser console has no font-related CSP errors

## Screenshots (if applicable)

**Before (current production):** 40+ CSP errors blocking Inter font loading:
```
Loading the font 'https://rsms.me/inter/font-files/InterVariable.woff2?v=4.1' violates the following Content Security Policy directive: "font-src https://*.userback.io https://fonts.gstatic.com/". The action has been blocked.
```

**After:** No font-src CSP errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated security policies to support loading fonts from additional sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->