### PR TITLE
fix: skip native build for utf-8-validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,5 +339,10 @@
     "gridplus-sdk/bs58check": "2.1.2",
     "@rainbow-me/rainbowkit": "2.1.7",
     "zod": "3.25.76"
+  },
+  "dependenciesMeta": {
+    "utf-8-validate": {
+      "built": false
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14104,6 +14104,9 @@ __metadata:
     wouter: ^3.6.0
   peerDependencies:
     lit-html: ^2.6.1
+  dependenciesMeta:
+    utf-8-validate:
+      built: false
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Description

`yarn install` fails because `utf-8-validate@6.0.4` (a transitive dependency via `@metamask/sdk`) requires a native C++ build via `node-gyp`. On systems with Python 3.12+, `node-gyp@9.3.1` crashes with `ModuleNotFoundError: No module named 'distutils'` since Python 3.12 removed `distutils` from the standard library.

This causes `yarn install` to exit with a non-zero code, which can break CI pipelines (not ours, but the error logging is annoying) even though `utf-8-validate` is functionally optional — the `ws` WebSocket library automatically falls back to a pure JavaScript UTF-8 validation implementation when the native addon isn't available.

The fix adds `dependenciesMeta` to `package.json` telling Yarn to skip the native build step for `utf-8-validate`. This is the Yarn 3-idiomatic way to disable builds for specific packages.

`develop`:

<img width="1165" height="54" alt="Screenshot 2026-02-16 at 4 41 00 pm" src="https://github.com/user-attachments/assets/7f416630-2abd-4c74-a790-4a14f1bafe7a" />

<img width="341" height="41" alt="Screenshot 2026-02-16 at 4 40 08 pm" src="https://github.com/user-attachments/assets/49f02839-b025-4d51-8997-0e12f64399e9" />

This branch:

<img width="1028" height="48" alt="Screenshot 2026-02-16 at 4 38 17 pm" src="https://github.com/user-attachments/assets/8479943e-d74a-48a6-91eb-5e25757239a2" />

<img width="361" height="48" alt="Screenshot 2026-02-16 at 4 40 33 pm" src="https://github.com/user-attachments/assets/76ea1bcc-0e77-4053-b0ac-d915f404a3a1" />

## Issue (if applicable)

N/A

## Risk

Near zero. `utf-8-validate` is an optional performance optimization for WebSocket UTF-8 frame validation. The `ws` library has a built-in JS fallback that is used automatically. No protocols, transactions, wallets, or contract interactions are affected.

## Testing

### Engineering

1. Run `yarn install` on a machine with Python 3.12+ — should complete successfully with warnings instead of failing
2. Verify the warnings confirm the build was skipped:
   ```
   utf-8-validate@npm:5.0.10 lists build scripts, but its build has been explicitly disabled through configuration.
   utf-8-validate@npm:6.0.4 lists build scripts, but its build has been explicitly disabled through configuration.
   ```
3. Verify app runs normally — WebSocket functionality (wallet connections, etc.) is unaffected

### Operations

- [x] :checkered_flag: Not user-facing — build/install tooling fix only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency configuration in package management to optimize build processes while maintaining all existing functionality and public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->