### PR TITLE
fix: disable Tron swaps on RelaySwapper

### DIFF
--- a/packages/swapper/src/swappers/RelaySwapper/constant.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/constant.ts
@@ -30,7 +30,6 @@ import {
   soneiumChainId,
   sonicChainId,
   storyChainId,
-  tronChainId,
   unichainChainId,
   worldChainChainId,
   zkSyncEraChainId,
@@ -87,7 +86,11 @@ export const chainIdToRelayChainId = {
   [gnosisChainId]: gnosis.id,
   [avalancheChainId]: avalanche.id,
   [bscChainId]: bsc.id,
-  [tronChainId]: 728126428,
+  // DISABLED: Tron deposits are built as simple TRC20 transfers instead of depositErc20() vault calls,
+  // and the Relay indexer notification is never sent for non-EVM chains. This causes deposits to be
+  // untracked by Relay, resulting in stuck/lost funds. Re-enable once the Tron transaction building
+  // is verified to use the Relay quote calldata (depositErc20) correctly.
+  // [tronChainId]: 728126428,
   [monadChainId]: monad.id,
   [hyperEvmChainId]: hyperEvm.id,
   [mantleChainId]: mantle.id,


### PR DESCRIPTION
## Description

**Production mitigation** — Disables Tron as a supported chain on the RelaySwapper by removing it from the `chainIdToRelayChainId` mapping. This prevents any Tron quotes from being served via Relay.

### Why

Tron deposits via Relay are broken due to two bugs:

1. **Wrong transaction type**: ShapeShift builds Tron Relay deposits as simple TRC20 `transfer()` calls instead of calling `depositErc20()` on the Relay vault contract. The `depositErc20` method includes a `bytes32 id` parameter that Relay uses to correlate deposits with swap intents on-chain. Without it, Relay cannot track the deposit.

2. **Missing indexer notification**: The Relay indexer notification (`POST /transactions/single`) in `checkTradeStatus` is gated behind `isEvmChainId(chainId)`, so non-EVM chains (Tron, Solana, Bitcoin) never notify Relay about completed deposits. This is the fallback mechanism for Relay to correlate transactions, and it's completely bypassed for Tron.

This combination causes Tron deposits to be **completely untracked** by Relay, resulting in user funds sitting in the vault contract with no way to match them to a swap intent. We confirmed this by investigating a real stuck transaction (`4a76a14976d4ed350d846a33fcd5f8fdf8f0d4053c522c59941c2b7e52f3d6a4`) — 500 USDT sent to the Relay Tron vault that Relay has zero record of.

A follow-up PR will fix the underlying bugs (use Relay quote calldata for `depositErc20`, widen the notification gate to all supported chains).

## Risk

**Low risk** — This is a single-line change that removes Tron from the supported chain mapping. The existing validation in `getTrade.ts` will reject any Tron sell/buy pairs with `UnsupportedTradePair`, which is already handled throughout the UI. All other 33 chains continue working normally.

> Relay cross-chain swaps involving Tron are affected. No other protocols, transaction types, wallets, or contract interactions are impacted.

## Testing

### Engineering

1. Verify Tron assets no longer appear as valid sell/buy options when Relay is the swapper
2. Verify all other Relay-supported chains still return quotes normally
3. Verify no runtime errors when browsing Tron assets (the chain is still supported by other swappers like ButterSwap, NearIntents, Thorchain)

### Operations

- Attempt a swap from Tron USDT to any other chain — Relay should not appear as an available swapper
- Attempt a swap from any EVM chain to Tron USDT — Relay should not appear as an available swapper
- Verify other swappers (ButterSwap, Thorchain, NearIntents) still offer Tron routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Disabled Tron blockchain support in the swapper service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->