### PR TITLE
feat: add feature flag awareness to release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -146,11 +146,31 @@ const getDevOnlyFlags = (): string[] => {
   return devOnly.sort()
 }
 
+const getPrivateDisabledFlags = (): string[] => {
+  const rootDir = path.resolve(__dirname, '..')
+  const baseFlags = parseEnvFeatureFlags(path.join(rootDir, '.env'))
+  const prodOverrides = parseEnvFeatureFlags(path.join(rootDir, '.env.production'))
+  const privateOverrides = parseEnvFeatureFlags(path.join(rootDir, '.env.private'))
+
+  const prodFlags: Record<string, boolean> = { ...baseFlags, ...prodOverrides }
+  const privateFlags: Record<string, boolean> = { ...baseFlags, ...privateOverrides }
+
+  const allKeys = new Set([...Object.keys(prodFlags), ...Object.keys(privateFlags)])
+  const privateDisabled: string[] = []
+  for (const key of allKeys) {
+    if (prodFlags[key] === true && privateFlags[key] !== true) {
+      privateDisabled.push(key.replace('VITE_FEATURE_', ''))
+    }
+  }
+  return privateDisabled.sort()
+}
+
 const buildReleasePrompt = (
   version: string,
   messages: string[],
   prBodies: Map<number, string>,
   devOnlyFlags: string[],
+  privateDisabledFlags: string[],
 ): string => {
   const commitList = messages
     .map(msg => {
@@ -171,6 +191,13 @@ const buildReleasePrompt = (
           .join('\n')}`
       : ''
 
+  const privateDisabledSection =
+    privateDisabledFlags.length > 0
+      ? `\n\n## Private-build disabled flags (enabled in production, disabled in private build)\n\n${privateDisabledFlags
+          .map(f => `- ${f}`)
+          .join('\n')}`
+      : ''
+
   return `You are a release notes generator for ShapeShift Web, a decentralized crypto exchange.
 
 Given the commit list below for ${version}, produce grouped release notes in markdown with two clearly separated top-level sections.
@@ -184,22 +211,23 @@ Given the commit list below for ${version}, produce grouped release notes in mar
 4. After the bullet list, write 1-2 sentences summarizing what changed and what to test
 5. For internal refactors with no user-facing changes (e.g. migrations, type changes, selector renames), note **regression testing only** and what to sanity-check
 6. For dependency bumps, CI fixes, infra, docker, CSP, and asset data regeneration, group under "## Fixes, deps, and infra" with **no testing required**
+7. If a commit relates to a feature listed in the private-build disabled flags below, append "**Note: disabled in private build.**" to its testing notes within the production section
 
 ### Section 2: "# Dev/local only - no production testing required"
-7. Contains all PRs/commits that are gated behind dev-only feature flags listed below
-8. Match commits to dev-only flags by feature name (e.g. "Celo" matches CELO, "agentic chat" matches AGENTIC_CHAT, "Mantle" matches MANTLE, "Across" matches ACROSS_SWAP, etc.)
-9. Commits whose title explicitly says "behind feature flag" or "under flag" also belong here
-10. Group by feature domain with brief description only - no testing notes needed since these are not visible in production
+8. Contains all PRs/commits that are gated behind dev-only feature flags listed below
+9. Match commits to dev-only flags by feature name (e.g. "Celo" matches CELO, "agentic chat" matches AGENTIC_CHAT, "Mantle" matches MANTLE, "Across" matches ACROSS_SWAP, etc.)
+10. Commits whose title explicitly says "behind feature flag" or "under flag" also belong here
+11. Group by feature domain with brief description only - no testing notes needed since these are not visible in production
 
 ### General rules
-11. Merge/backmerge commits (e.g. "Merge branch 'main' into develop") should be silently dropped
-12. Keep testing notes brief and actionable - what a QA person should click on, not implementation details
-13. Use present tense for summaries ("Enables TON chain" not "Enabled TON chain")
-14. Do NOT use emdashes. Use regular hyphens.
+12. Merge/backmerge commits (e.g. "Merge branch 'main' into develop") should be silently dropped
+13. Keep testing notes brief and actionable - what a QA person should click on, not implementation details
+14. Use present tense for summaries ("Enables TON chain" not "Enabled TON chain")
+15. Do NOT use emdashes. Use regular hyphens.
 
 ## Commits
 
-${commitList}${devOnlySection}`
+${commitList}${devOnlySection}${privateDisabledSection}`
 }
 
 const runClaude = (promptPath: string): Promise<string> => {
@@ -256,8 +284,9 @@ const generateReleaseSummary = async (
   messages: string[],
   prBodies: Map<number, string>,
   devOnlyFlags: string[],
+  privateDisabledFlags: string[],
 ): Promise<string | null> => {
-  const prompt = buildReleasePrompt(version, messages, prBodies, devOnlyFlags)
+  const prompt = buildReleasePrompt(version, messages, prBodies, devOnlyFlags, privateDisabledFlags)
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shapeshift-release-'))
   const promptPath = path.join(tmpDir, 'prompt.txt')
 
@@ -366,7 +395,16 @@ const doRegularRelease = async () => {
   const devOnlyFlags = getDevOnlyFlags()
   console.log(chalk.green(`Detected ${devOnlyFlags.length} dev-only feature flags.`))
 
-  const summary = await generateReleaseSummary(nextVersion, messages, prBodies, devOnlyFlags)
+  const privateDisabledFlags = getPrivateDisabledFlags()
+  console.log(chalk.green(`Detected ${privateDisabledFlags.length} private-build disabled flags.`))
+
+  const summary = await generateReleaseSummary(
+    nextVersion,
+    messages,
+    prBodies,
+    devOnlyFlags,
+    privateDisabledFlags,
+  )
   const prBody = summary ?? messages.join('\n')
 
   if (summary) {


### PR DESCRIPTION
## Description

The release script (`scripts/release.ts`) generates AI-powered release summaries for the ops team. Currently, it has no awareness of which features are gated behind dev-only flags vs production-enabled flags. Rule 4 in the Claude prompt only catches commits whose titles explicitly say "behind feature flag" - it doesn't read the actual `.env` files. This means features like Celo, Agentic Chat, and ~25 other dev-only chains/swappers are not properly annotated, causing the ops team to over-test features that aren't even visible in production.

This PR adds env file parsing to the release script so it can automatically detect dev-only feature flags and produce two clearly separated output sections:

1. **Production changes - testing required** - PRs affecting prod code paths, with testing notes
2. **Dev/local only - no production testing required** - PRs gated behind dev-only flags, no testing needed

Example of updated output:

<img width="1285" height="492" alt="Screenshot 2026-02-24 at 2 44 14 pm" src="https://github.com/user-attachments/assets/dabbbbb4-a3b2-45c4-8610-94718a2adcfb" />

### What changed

- `parseEnvFeatureFlags(filePath)` - Reads a `.env` file and extracts `VITE_FEATURE_*` keys with boolean values
- `getDevOnlyFlags()` - Computes effective prod flags (`.env` + `.env.production`) vs dev flags (`.env` + `.env.development`), returns flags where dev=true and prod!=true
- `buildReleasePrompt` - Updated to accept dev-only flags and restructured prompt rules for two-section output
- Call site in `doRegularRelease` updated to compute and pass dev-only flags

Currently detects 27 dev-only flags (e.g. CELO, AGENTIC_CHAT, MANTLE, FLOWEVM, ACROSS_SWAP) while correctly excluding prod-enabled flags (SOLANA, ARBITRUM, BASE, etc.).

## Issue (if applicable)

N/A

## Risk

Minimal. Changes are isolated to `scripts/release.ts` which is a CLI dev tool only - no runtime, user-facing, or on-chain impact. The script still falls back to raw commit list if Claude generation fails.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None. This only affects the release notes generation tooling.

## Testing

### Engineering

1. Run `npx ts-node scripts/release.ts` - it should still prompt for release type and generate summaries
2. Verify `yarn type-check` passes (no new errors in scripts/release.ts)
4. Verify `yarn lint --fix` passes (no new errors)
5. Spot-check: flags like CELO, AGENTIC_CHAT, MANTLE appear in the dev-only list; flags like SOLANA, ARBITRUM, BASE do not

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

This is a dev tooling change only - no user-facing impact. The output of the release script will now be more useful to operations by clearly separating what needs production testing from what doesn't.

## Screenshots (if applicable)

**Example output with new format (v1.1010.0 commits):**

```markdown
# Production changes - testing required

## Swap widget and RelaySwapper fixes
- fix: disable Tron swaps on RelaySwapper (#12014)
- fix: widget railway delivery (#11987)
- fix: cleanup swap widget (#11865)

Test that swaps execute normally, Tron is properly disabled from RelaySwapper, and the widget loads correctly.

## API authentication changes
- feat: replace API key auth with optional affiliate address tracking (#11959)

Test that the swap flow works normally and verify affiliate tracking is captured if configured.

---

# Dev/local only - no production testing required

## Second-class Relay chain integrations
- feat: integrate Celo (42220) as second-class Relay chain (#11939)
- feat: integrate Flow EVM (747) as second-class Relay chain (#11938)

Adds support for Celo and Flow EVM as second-class Relay chains behind dev-only feature flags.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release note generation to automatically incorporate feature flag information. Release summaries now include details about features enabled only in development builds and features disabled in private builds, ensuring comprehensive documentation of feature availability across all build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->