### PR TITLE
fix: hotfix release flow ships only hotfix commits and uses patch bump

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -574,7 +574,7 @@ const isReleaseInProgress = async (): Promise<boolean> => {
 }
 
 const createRelease = async () => {
-  ;(await inquireReleaseType()) === 'Regular' ? await doRegularRelease() : doHotfixRelease()
+  ;(await inquireReleaseType()) === 'Regular' ? await doRegularRelease() : await doHotfixRelease()
 }
 
 const mergeRelease = async () => {


### PR DESCRIPTION
## Description

The hotfix option in `yarn release` was shipping all commits since the last tag instead of just the hotfix commits. When a hotfix branch had any develop ancestry, `getCommits()` used `${latestTag}..origin/${branch}` which included everything since the last release tag — not just the hotfix.

This PR fixes three issues:

1. **Commit range**: Hotfix branches now use `origin/main..origin/${branch}` so only commits not on main are included
2. **Branch verification**: After the user confirms their branch is off `origin/main`, a programmatic check validates the merge-base matches `origin/main`'s SHA — catches mistakes where the branch is actually off develop
3. **Version bump**: Hotfixes now use `patch` bump instead of `minor` (both at PR creation and at merge time via PR title prefix detection)

The flow:

<img width="1161" height="177" alt="Screenshot 2026-02-24 at 3 52 06 pm" src="https://github.com/user-attachments/assets/f8192f94-cb7c-459e-9fa2-cf5c0f3b72b6" />

<img width="1457" height="230" alt="Screenshot 2026-02-24 at 3 52 19 pm" src="https://github.com/user-attachments/assets/fd63aff6-367f-4289-95fc-d725746e0575" />

<img width="1463" height="457" alt="Screenshot 2026-02-24 at 3 53 41 pm" src="https://github.com/user-attachments/assets/1fe18990-5b22-416b-b6c5-773a43319b40" />

## Issue (if applicable)

## Risk

Low risk. Only affects the `scripts/release.ts` CLI tool — no runtime application code changes. The release script is only run manually by developers.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None. This is a developer tooling fix only.

## Testing

### Engineering

1. Create a test branch off `origin/main` with a single commit
2. Run `yarn release` → select Hotfix
3. Verify the commit list shows ONLY the hotfix commit, not develop history
4. Verify the PR title uses patch version (e.g. `chore: hotfix release v1.1010.1`)
5. After PR merge, run `yarn release` again → verify `mergeRelease()` tags with patch version
6. Run `yarn release` on develop → verify the hotfix commit is NOT in the regular release diff

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

This is a developer-only CLI tool change with no user-facing impact.

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive selection of unreleased commits for targeted hotfix cherry-picks
  * Added confirmations and expanded progress/status messages during hotfix flow
  * Cleaner multi-line commit output for readability

* **Chores**
  * Replaced draft-PR hotfix path with explicit cherry-pick, tag, merge and push sequence
  * Improved unreleased-commit detection with early exits when nothing to do
  * Hardened cherry-pick and merge flow with better error handling and automatic main reset on failure
<!-- end of auto-generated comment: release notes by coderabbit.ai -->