### PR TITLE
fix: check isLocked on MetaMask auto-reconnect

### DIFF
--- a/src/context/WalletProvider/WalletProvider.tsx
+++ b/src/context/WalletProvider/WalletProvider.tsx
@@ -680,6 +680,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
               try {
                 await localMetaMaskWallet.initialize()
                 const deviceId = await localMetaMaskWallet.getDeviceID()
+                const isLocked = await localMetaMaskWallet.isLocked()
                 dispatch({
                   type: WalletActions.SET_WALLET,
                   payload: {
@@ -690,7 +691,7 @@ export const WalletProvider = ({ children }: { children: React.ReactNode }): JSX
                     connectedType: KeyManager.MetaMask,
                   },
                 })
-                dispatch({ type: WalletActions.SET_IS_LOCKED, payload: false })
+                dispatch({ type: WalletActions.SET_IS_LOCKED, payload: isLocked })
                 dispatch({
                   type: WalletActions.SET_IS_CONNECTED,
                   payload: true,


### PR DESCRIPTION
Fixes #10676

## Problem
When MetaMask is locked and page is refreshed, the app doesn't properly detect the locked state. This causes:
- No locked icon shown for MM
- Wallet menu click is dead (no response)

## Root Cause
On auto-reconnect, the code always set `isLocked: false` without actually checking if MetaMask was locked.

## Fix
Added `await localMetaMaskWallet.isLocked()` check before dispatching the locked state, similar to how it's done in the manual connect flow.

---
🤖 This PR was created by Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed wallet lock state detection to correctly reflect the actual MetaMask wallet status instead of always displaying as unlocked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->