### PR TITLE
fix: unrug public-api railway ci

### DIFF
--- a/packages/public-api/Dockerfile
+++ b/packages/public-api/Dockerfile
@@ -48,7 +48,7 @@ COPY packages/unchained-client/package.json ./packages/unchained-client/
 COPY packages/utils/package.json ./packages/utils/
 
 # Install dependencies with Railway cache mount (skip build/postinstall scripts that require git/cypress/etc)
-RUN corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile
+RUN corepack enable && corepack prepare pnpm@10.30.3 --activate && pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy unchained-client config and generator files FIRST (rarely changes, enables layer caching)
 COPY packages/unchained-client/openapitools.json ./packages/unchained-client/


### PR DESCRIPTION
## Description

The public-api Railway deployment has been failing since the yarn → pnpm migration (aa07e3c45c, #12049).

**Root cause:** yarn's `--mode skip-build` skipped all lifecycle scripts during install. The pnpm migration replaced it with `pnpm install --frozen-lockfile`, which runs lifecycle scripts. The root `postinstall` script runs `git config --local include.path '.gitconfig'`, which requires a `.git` directory. Docker builds have no `.git` → `fatal: --local can only be used inside a git repository` (exit 128) → build fails.

The Dockerfile comment even documented the intent: _"skip build/postinstall scripts that require git/cypress/etc"_ - it just didn't translate correctly from yarn to pnpm.

**Fix:** `--ignore-scripts` is the direct pnpm equivalent of yarn's `--mode skip-build`. One flag, restores exact parity.

## Issue (if applicable)

closes #

## Risk

Low - Dockerfile only, restores behavior that was working before #12049.

## Testing

### Engineering

Triggered by the pnpm migration in aa07e3c45c (#12049). The regression was latent in the postinstall script which had always existed but was never executed in Docker under yarn due to `--mode skip-build`.

To verify: rebuild the public-api Docker image - `pnpm install --frozen-lockfile --ignore-scripts` will no longer attempt `git config --local` and the build will succeed.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)