### PR TITLE
fix: bump Claude max-turns from 3 to 10 in release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -239,7 +239,7 @@ const isCcrAvailable = (): Promise<boolean> => {
   })
 }
 
-const CLAUDE_ARGS = ['-p', '--model', 'opus', '--max-turns', '3']
+const CLAUDE_ARGS = ['-p', '--model', 'opus', '--max-turns', '10']
 
 const runClaude = async (promptPath: string): Promise<string> => {
   try {


### PR DESCRIPTION
## Description

Bumps `--max-turns` from `3` to `10` for the Claude CLI invocation in the release script. The previous limit was too low for Claude to read files and analyze commits, causing "Reached max turns (3)" errors during AI release summary generation.

Maybe I have too many MCPs installed, I'm not sure.

<img width="644" height="418" alt="Screenshot 2026-03-10 at 4 29 54 pm" src="https://github.com/user-attachments/assets/437f990f-5f41-4cb9-b72b-4a0392bf490a" />

## Issue (if applicable)

N/A

## Risk

Zero risk. This only affects the AI-generated release summary step and has no impact on the actual release process, on-chain transactions, or user-facing functionality.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

- Verified with `pnpm run type-check` — no new type errors introduced.
- Change is a single constant update in `scripts/release.ts:242`.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

This change only affects the internal release tooling and is not user-facing.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced script processing by increasing the maximum number of iterations allowed during automated runs, enabling more comprehensive processing cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->