### PR TITLE
fix: bebop solana signing + thorchain solana lp compute budget

### DIFF
--- a/e2e/fixtures/bebop-solana-swap.yaml
+++ b/e2e/fixtures/bebop-solana-swap.yaml
@@ -1,0 +1,71 @@
+name: Bebop Solana Swaps + THORChain LP
+description: >
+  Test Bebop Solana swapper (gasless signing) and THORChain LP asym SOL deposit.
+  Bebop swaps test the partially-signed tx serialize fix across wallet providers.
+  THORChain LP tests the compute budget fix for memo transactions.
+  Upstream Bebop errors (InsufficientLiquidity code 102, TransactionExecutionError code 208)
+  are expected soft_fails, not our bugs.
+route: /trade
+depends_on:
+  - wallet-health.yaml
+steps:
+  - name: Dismiss stale notifications
+    instruction: >
+      Dismiss any lingering toast notifications, feedback dialogs, or pending transaction banners.
+    expected: No stale notifications visible
+    screenshot: true
+
+  - name: SOL to USDC swap via Bebop
+    instruction: >
+      Select SOL as sell asset and USDC (Solana) as buy asset.
+      Toggle to fiat mode if needed, enter $0.50 sell amount. Wait for quotes to load.
+      Verify Bebop is the selected protocol (look for "Bebop" in the quote details).
+      If Bebop is not shown, check alternate protocols or skip with soft_fail.
+      Click Preview Trade, handle any warning dialogs ("Below recommended minimum",
+      "Price impact" -> click "I understand"). Click "Confirm and Trade", sign the transaction.
+      Wait for the tx to broadcast. Bebop gasless txs are co-signed server-side.
+    expected: Swap broadcasts successfully or shows an upstream Bebop error (not a signing/serialize error)
+    soft_fail_on:
+      - InsufficientLiquidity
+      - TransactionExecutionError
+    screenshot: true
+
+  - name: USDC to SOL swap via Bebop
+    instruction: >
+      Dismiss any feedback dialog. Go back to trade page.
+      Select USDC (Solana) as sell asset and SOL as buy asset.
+      Enter $0.50 sell amount. Wait for quotes.
+      Verify Bebop is the selected protocol. Click Preview Trade, confirm, sign.
+    expected: Swap broadcasts successfully or shows upstream Bebop error
+    soft_fail_on:
+      - InsufficientLiquidity
+      - TransactionExecutionError
+    screenshot: true
+
+  - name: SOL to SKR swap via Bebop
+    instruction: >
+      Dismiss any feedback dialog. Go back to trade page.
+      Select SOL as sell asset. For buy asset, search for token address
+      SKRbvo6Gf7GondiT3BbTfuRDPqLWei4j2Qy2NPGZhW3 in the asset picker.
+      Enter $0.50 sell amount. Wait for quotes.
+      Bebop may return TransactionExecutionError (code 208) for low-liquidity pairs.
+      This is expected upstream behavior, not our bug.
+    expected: Swap broadcasts or shows upstream Bebop error (not signing error)
+    soft_fail_on:
+      - InsufficientLiquidity
+      - TransactionExecutionError
+    screenshot: true
+
+  - name: THORChain LP asym SOL deposit
+    instruction: >
+      Navigate to /#/pools. Find and click the SOL/RUNE pool row.
+      Click "Add Liquidity". Select asymmetric SOL deposit (click the first radio
+      button with value="asset" via JS eval). Enter 0.006 in the SOL amount input.
+      Click "Add Liquidity" button. Accept the lockup warning ("I understand").
+      On the confirm page, click "Confirm and Deposit".
+      Click "Sign transaction" when prompted.
+      Wait for the tx to broadcast and confirm on THORChain.
+    expected: >
+      Deposit broadcasts successfully, shows "Waiting for Confirmation" then "Success".
+      A THORChain tx link should appear. The pending count should increment then decrement.
+    screenshot: true

--- a/packages/hdwallet-gridplus/src/solana.ts
+++ b/packages/hdwallet-gridplus/src/solana.ts
@@ -96,8 +96,16 @@ export async function solanaSignSerializedTx(
 
   transaction.addSignature(new PublicKey(address), signature)
 
-  return {
-    serialized: Buffer.from(transaction.serialize()).toString('base64'),
-    signatures: transaction.signatures.map(sig => Buffer.from(sig).toString('base64')),
+  // Extract signatures before serialize - for partially-signed txs (e.g. gasless Bebop),
+  // serialize() throws because not all required signatures are present yet.
+  const signatures = transaction.signatures.map(sig => Buffer.from(sig).toString('base64'))
+
+  let serialized: string
+  try {
+    serialized = Buffer.from(transaction.serialize()).toString('base64')
+  } catch {
+    serialized = msg.serializedTx
   }
+
+  return { serialized, signatures }
 }

--- a/packages/hdwallet-ledger/src/solana.ts
+++ b/packages/hdwallet-ledger/src/solana.ts
@@ -64,8 +64,18 @@ export async function solanaSignSerializedTx(
 
   transaction.addSignature(new PublicKey(address), res.payload.signature)
 
-  return {
-    serialized: Buffer.from(transaction.serialize()).toString('base64'),
-    signatures: transaction.signatures.map(signature => Buffer.from(signature).toString('base64')),
+  // Extract signatures before serialize - for partially-signed txs (e.g. gasless Bebop),
+  // serialize() throws because not all required signatures are present yet.
+  const signatures = transaction.signatures.map(signature =>
+    Buffer.from(signature).toString('base64'),
+  )
+
+  let serialized: string
+  try {
+    serialized = Buffer.from(transaction.serialize()).toString('base64')
+  } catch {
+    serialized = msg.serializedTx
   }
+
+  return { serialized, signatures }
 }

--- a/packages/hdwallet-native/src/solana.ts
+++ b/packages/hdwallet-native/src/solana.ts
@@ -76,12 +76,23 @@ export function MixinNativeSolanaWallet<TBase extends core.Constructor<NativeHDW
         const txBytes = Buffer.from(msg.serializedTx, 'base64')
         const transaction = VersionedTransaction.deserialize(txBytes)
         const signedTransaction = await this.adapter!.signTransaction(transaction, msg.addressNList)
-        return {
-          serialized: Buffer.from(signedTransaction.serialize()).toString('base64'),
-          signatures: signedTransaction.signatures.map(signature =>
-            Buffer.from(signature).toString('base64'),
-          ),
+
+        // Extract signatures before attempting serialize - for partially-signed txs
+        // (e.g. gasless Bebop where Bebop is the fee payer), serialize() throws because
+        // not all required signatures are present yet. The caller may only need signatures.
+        const signatures = signedTransaction.signatures.map(signature =>
+          Buffer.from(signature).toString('base64'),
+        )
+
+        let serialized: string
+        try {
+          serialized = Buffer.from(signedTransaction.serialize()).toString('base64')
+        } catch {
+          // Partial signing - serialize the message without signature verification
+          serialized = msg.serializedTx
         }
+
+        return { serialized, signatures }
       })
     }
   }

--- a/packages/hdwallet-phantom/src/solana.ts
+++ b/packages/hdwallet-phantom/src/solana.ts
@@ -30,12 +30,21 @@ export async function solanaSignSerializedTx(
   const txBytes = Buffer.from(msg.serializedTx, 'base64')
   const transaction = VersionedTransaction.deserialize(txBytes)
   const signedTransaction = await provider.signTransaction(transaction)
-  return {
-    serialized: Buffer.from(signedTransaction.serialize()).toString('base64'),
-    signatures: signedTransaction.signatures.map(signature =>
-      Buffer.from(signature).toString('base64'),
-    ),
+
+  // Extract signatures before serialize - for partially-signed txs (e.g. gasless Bebop),
+  // serialize() throws because not all required signatures are present yet.
+  const signatures = signedTransaction.signatures.map(signature =>
+    Buffer.from(signature).toString('base64'),
+  )
+
+  let serialized: string
+  try {
+    serialized = Buffer.from(signedTransaction.serialize()).toString('base64')
+  } catch {
+    serialized = msg.serializedTx
   }
+
+  return { serialized, signatures }
 }
 
 export async function solanaSendTx(

--- a/packages/hdwallet-trezor/src/solana.ts
+++ b/packages/hdwallet-trezor/src/solana.ts
@@ -109,8 +109,16 @@ export async function solanaSignSerializedTx(
   const signature = Buffer.from(res.payload.signature, 'hex')
   transaction.addSignature(new PublicKey(address), signature)
 
-  return {
-    serialized: Buffer.from(transaction.serialize()).toString('base64'),
-    signatures: transaction.signatures.map(sig => Buffer.from(sig).toString('base64')),
+  // Extract signatures before serialize - for partially-signed txs (e.g. gasless Bebop),
+  // serialize() throws because not all required signatures are present yet.
+  const signatures = transaction.signatures.map(sig => Buffer.from(sig).toString('base64'))
+
+  let serialized: string
+  try {
+    serialized = Buffer.from(transaction.serialize()).toString('base64')
+  } catch {
+    serialized = msg.serializedTx
   }
+
+  return { serialized, signatures }
 }

--- a/packages/hdwallet-vultisig/src/solana.ts
+++ b/packages/hdwallet-vultisig/src/solana.ts
@@ -30,12 +30,21 @@ export async function solanaSignSerializedTx(
   const txBytes = Buffer.from(msg.serializedTx, 'base64')
   const transaction = VersionedTransaction.deserialize(txBytes)
   const signedTransaction = await provider.signTransaction(transaction)
-  return {
-    serialized: Buffer.from(signedTransaction.serialize()).toString('base64'),
-    signatures: signedTransaction.signatures.map(signature =>
-      Buffer.from(signature).toString('base64'),
-    ),
+
+  // Extract signatures before serialize - for partially-signed txs (e.g. gasless Bebop),
+  // serialize() throws because not all required signatures are present yet.
+  const signatures = signedTransaction.signatures.map(signature =>
+    Buffer.from(signature).toString('base64'),
+  )
+
+  let serialized: string
+  try {
+    serialized = Buffer.from(signedTransaction.serialize()).toString('base64')
+  } catch {
+    serialized = msg.serializedTx
   }
+
+  return { serialized, signatures }
 }
 
 export async function solanaSendTx(

--- a/packages/swapper/src/swappers/BebopSwapper/executeSolanaMessage.ts
+++ b/packages/swapper/src/swappers/BebopSwapper/executeSolanaMessage.ts
@@ -4,8 +4,13 @@ import type { SolanaMessageExecutionProps, SolanaMessageToSign, SwapperConfig } 
 import { bebopServiceFactory } from './utils/bebopService'
 
 type BebopOrderResponse = {
-  txHash: string
-  status: string
+  txHash?: string
+  status?: string
+  error?: {
+    errorCode: number
+    message: string
+    requestId: string
+  }
 }
 
 export const executeSolanaMessage = async (
@@ -45,8 +50,14 @@ export const executeSolanaMessage = async (
 
   const { data: orderResponse } = maybeOrderResponse.unwrap()
 
+  if (orderResponse.error) {
+    throw new Error(
+      `Bebop order failed: ${orderResponse.error.message} (code ${orderResponse.error.errorCode})`,
+    )
+  }
+
   if (!orderResponse.txHash) {
-    throw new Error('Bebop order response missing txHash')
+    throw new Error(`Bebop order response missing txHash: ${JSON.stringify(orderResponse)}`)
   }
 
   return orderResponse.txHash

--- a/src/components/Modals/Send/utils.ts
+++ b/src/components/Modals/Send/utils.ts
@@ -22,7 +22,7 @@ import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { isTrezor } from '@shapeshiftoss/hdwallet-trezor'
 import type { CosmosSdkChainId, EvmChainId, KnownChainIds, UtxoChainId } from '@shapeshiftoss/types'
 import { contractAddressOrUndefined } from '@shapeshiftoss/utils'
-import { PublicKey, TransactionInstruction } from '@solana/web3.js'
+import { PublicKey, SystemProgram, TransactionInstruction } from '@solana/web3.js'
 
 import type { SendInput } from './Form'
 
@@ -124,7 +124,7 @@ export const estimateFees = async ({
         : undefined
 
       // For SPL transfers, build complete instruction set including compute budget
-      // For SOL transfers with memo (e.g. THORChain), pass memo instruction for accurate fee estimation
+      // For SOL transfers with memo (e.g. THORChain LP), include both memo AND transfer for accurate CU estimation
       // For pure SOL transfers, pass no instructions to get 0 count (avoids blind signing)
       const instructions = contractAddress
         ? await adapter.buildEstimationInstructions({
@@ -134,7 +134,14 @@ export const estimateFees = async ({
             value,
           })
         : memoInstruction
-        ? [memoInstruction]
+        ? [
+            memoInstruction,
+            SystemProgram.transfer({
+              fromPubkey: new PublicKey(account),
+              toPubkey: new PublicKey(to),
+              lamports: Number(value),
+            }),
+          ]
         : undefined
 
       const getFeeDataInput: GetFeeDataInput<KnownChainIds.SolanaMainnet> = {
@@ -404,6 +411,10 @@ export const handleSendWithMetadata = async ({
 
       const shouldAddComputeBudget = estimationInstructions.length > 1 || Boolean(memoInstruction)
 
+      // Each ComputeBudgetProgram instruction (setComputeUnitLimit, setComputeUnitPrice) costs 150 CU.
+      // Fee estimation doesn't include these, so we add a fixed buffer to cover them.
+      const COMPUTE_BUDGET_INSTRUCTION_OVERHEAD_CU = 300
+
       const input: BuildSendTxInput<KnownChainIds.SolanaMainnet> = {
         to,
         value,
@@ -413,7 +424,9 @@ export const handleSendWithMetadata = async ({
         chainSpecific: shouldAddComputeBudget
           ? {
               tokenId: contractAddress,
-              computeUnitLimit: fees.chainSpecific.computeUnits,
+              computeUnitLimit: String(
+                Number(fees.chainSpecific.computeUnits) + COMPUTE_BUDGET_INSTRUCTION_OVERHEAD_CU,
+              ),
               computeUnitPrice: fees.chainSpecific.priorityFee,
               instructions: memoInstruction ? [memoInstruction] : undefined,
             }


### PR DESCRIPTION
## Description

Cherry-pick of #12131 into release.

Two Solana fixes:

1. **Bebop Solana gasless signing** - all 6 wallet providers handle partially-signed txs in `solanaSignSerializedTx`
2. **THORChain Solana LP compute budget** - fee estimation for SOL+memo txs now includes SystemProgram transfer instruction

See #12131 for full details and qabot evidence.

## Risk

Medium - Solana swaps and LP deposits. Defensive changes (try/catch fallbacks, more accurate estimation).

## Testing

### Engineering

Tested via qabot run `47498e0b-c86e-41ad-a914-cffadd1856a2` on develop. Clean cherry-pick, no conflicts.

### Operations

- [ ] Smoke test a Bebop Solana swap on preview
- [ ] Smoke test a THORChain LP asym SOL deposit on preview