### PR TITLE
fix: codex config relative path to agents.md

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,1 +1,1 @@
-model_instructions_file = "AGENTS.md"
+model_instructions_file = "../AGENTS.md"


### PR DESCRIPTION
## Description

Does what it says on the box. Codex resolves `model_instructions_file` relative to `.codex/` dir, so `"AGENTS.md"` was looking for `.codex/AGENTS.md` instead of repo root `AGENTS.md`.

## Risk

Low - config-only change, no runtime impact.

## Testing

### Engineering

```
codex
```

Should no longer error with `No such file or directory`.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)