### PR TITLE
chore: update near affiliate address

### DIFF
--- a/packages/utils/src/treasury.ts
+++ b/packages/utils/src/treasury.ts
@@ -38,7 +38,7 @@ export const DAO_TREASURY_ARBITRUM = '0x38276553F8fbf2A027D901F8be45f00373d8Dd48
 export const DAO_TREASURY_BASE = '0x9c9aA90363630d4ab1D9dbF416cc3BBC8d3Ed502'
 export const DAO_TREASURY_SOLANA = 'Bh7R3MeJ98D7Ersxh7TgVQVQUSmDMqwrFVHH9DLfb4u3'
 export const DAO_TREASURY_BITCOIN = 'bc1qr2whxtd0gvqnctcxlynwejp6fvntv0mtxkv0dlv02vyale8h69ysm6l32n'
-export const DAO_TREASURY_NEAR = 'f471d0b0f90593d85125f38aaf5458748d6f23fd5b437b844d293d8e87557070'
+export const DAO_TREASURY_NEAR = 'shapeshifttokenomics.sputnik-dao.near'
 export const DAO_TREASURY_STARKNET =
   '0x052a1132ea4db81Bde863AFb18a4d4CE5de9d3efdfda6b3DaA6484e26425D467'
 export const DAO_TREASURY_TON = 'UQBGXUskbTDkLXJO_Q6cQFVbbkgvXKplcIhijiO5oDcB5qkI'


### PR DESCRIPTION
## Description

Update the NEAR DAO treasury address from a raw public key (`f471d0b0f90593d85125f38aaf5458748d6f23fd5b437b844d293d8e87557070`) to the human-readable Sputnik DAO address (`shapeshifttokenomics.sputnik-dao.near`).

## Issue (if applicable)

N/A

## Risk

Low risk change, but high risk outcome if I got the change wrong.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

NEAR affiliate/treasury routing only.

## Testing

For paranoia, ensure that trading via Near results in affiliate fees being sent here: https://near.rocks/account/shapeshifttokenomics.sputnik-dao.near

### Engineering

👆

### Operations

👆

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

<img width="1216" height="1446" alt="image" src="https://github.com/user-attachments/assets/4478438c-f525-4469-a80c-158845af9155" />
