### PR TITLE
fix: release script squash-merge compat and backmerge automation

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -671,7 +671,9 @@ const doRegularRelease = async () => {
       const existingBackmerge = await findOpenPr('main', 'develop')
       if (existingBackmerge) {
         console.log(
-          chalk.yellow(`Backmerge PR already open: #${existingBackmerge.number}. Enabling auto-merge...`),
+          chalk.yellow(
+            `Backmerge PR already open: #${existingBackmerge.number}. Enabling auto-merge...`,
+          ),
         )
         await pify(exec)(`gh pr merge --auto --merge ${existingBackmerge.number}`)
         console.log(
@@ -872,7 +874,9 @@ const doHotfixRelease = async () => {
       const existingBackmerge = await findOpenPr('main', 'develop')
       if (existingBackmerge) {
         console.log(
-          chalk.yellow(`Backmerge PR already open: #${existingBackmerge.number}. Enabling auto-merge...`),
+          chalk.yellow(
+            `Backmerge PR already open: #${existingBackmerge.number}. Enabling auto-merge...`,
+          ),
         )
         await pify(exec)(`gh pr merge --auto --merge ${existingBackmerge.number}`)
         console.log(


### PR DESCRIPTION
## Description

Three fixes to the release state machine in \`scripts/release.ts\`, all rooted in the same underlying problem: the script was designed (in #12110) assuming rebase merging (same SHAs post-merge), but the repo uses squash merging.

### 1. \`idle\` case - content diff instead of SHA equality for \`prereleaseMerged\`

Before:
\`\`\`ts
const prereleaseMerged = releaseSha !== mainSha
\`\`\`

After squash-merging a release PR, \`releaseSha !== mainSha\` is always true (squash creates a new commit), so the script always thought there was a pending release to cut even right after a fresh one. Fixed by comparing actual file content:

\`\`\`ts
const releaseMatchesMain = !(await git().diff(['origin/main', 'origin/release']))
const prereleaseMerged = releaseSha !== mainSha && !releaseMatchesMain
\`\`\`

### 2. \`tagged_private_stale\` (regular release) - add backmerge PR with auto-merge

After main gets tagged and private is synced, main has diverged from develop (the squash-merged release commit isn't in develop's history). The script was leaving this cleanup to be done manually.

Now creates a \`main -> develop\` backmerge PR automatically and sets auto-merge with merge commit strategy:

\`\`\`ts
await pify(exec)(\`gh pr merge --auto --merge \${backmergeUrl}\`)
\`\`\`

Merge commit strategy is intentional - preserves main's commit in develop's history so the merge base is correct for future releases.

### 3. \`tagged_private_stale\` (hotfix) - same auto-merge treatment

The hotfix path already created the backmerge PR but wasn't setting auto-merge. Now consistent with the regular release path.

## Issue (if applicable)

closes #

## Risk

Low - release script only, no production code touched. Worst case is a script error requiring manual intervention (same as before).

## Testing

### Engineering

Run \`pnpm release\` after a release has been tagged and private is stale:
- should create private sync PR
- should create backmerge PR (main -> develop) and immediately set auto-merge on it
- should NOT create duplicate PRs if run again

For the \`idle\` fix: run \`pnpm release\` right after squash-merging a release - should land in the "fresh start" sub-state (create prerelease PR) instead of "prerelease merged".

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release automation now uses content/diff checks to determine prerelease status, skip private syncs when content is identical, and prefer existing private PRs when available.
  * Private-sync and tagging flows create or reuse private PRs only when needed; logs include PR URLs and skip reasons.
  * Backmerge PRs (main -> develop) are created or reused and configured for auto-merge when required; logging clarified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->