### PR TITLE
fix: bump NativeQrScanner minimum version to 3.7.2

### DIFF
--- a/src/hooks/useMobileFeaturesCompatibility.ts
+++ b/src/hooks/useMobileFeaturesCompatibility.ts
@@ -12,7 +12,7 @@ export enum MobileFeature {
 
 export const MOBILE_FEATURE_MINIMUM_VERSIONS: Record<MobileFeature, string> = {
   [MobileFeature.RatingModal]: '3.3.1',
-  [MobileFeature.NativeQrScanner]: '3.4.0',
+  [MobileFeature.NativeQrScanner]: '3.7.2',
 }
 
 type MobileFeatureInfo = {


### PR DESCRIPTION
## Description

Bumps the `NativeQrScanner` minimum mobile app version from `3.4.0` to `3.7.2` in `useMobileFeaturesCompatibility`.

The native QR scanner handler (mobile-app PR #156) ships in mobile app **v3.7.2**, but the version gate was incorrectly set to `3.4.0`. This caused mobile apps v3.4.0–3.7.1 to attempt native scanning via `openNativeQRScanner` postMessage, resulting in a 60-second spinner timeout with no way to scan.

With this fix:
- Mobile app **< 3.7.2**: version check fails → web-based `html5-qrcode` scanner used (old flow)
- Mobile app **>= 3.7.2**: version check passes → native scanner used (new flow)

## Issue (if applicable)

N/A

## Risk

**Low** — Single constant change. No new transactions, no protocol/wallet/contract changes. Only affects the version gating logic for QR scanner feature detection on mobile.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

1. Verify in `src/hooks/useMobileFeaturesCompatibility.ts` that `NativeQrScanner` minimum version is `'3.7.2'`.
2. In a mobile webview with app version < 3.7.2, confirm the web-based QR scanner is used.
3. In a mobile webview with app version >= 3.7.2, confirm the native QR scanner is invoked.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

No user-facing change for desktop users. Mobile users on older app versions will correctly fall back to the web-based scanner instead of hitting a timeout.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated minimum version requirement for mobile QR scanner feature to enhance compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->