### PR TITLE
fix: batch yield balance queries to respect api limit

### DIFF
--- a/src/react-queries/queries/yieldxyz/useAllYieldBalances.ts
+++ b/src/react-queries/queries/yieldxyz/useAllYieldBalances.ts
@@ -276,7 +276,22 @@ export const useAllYieldBalances = (options: UseAllYieldBalancesOptions = {}) =>
               network,
             }))
 
-            const response = await fetchAggregateBalances(uniqueQueries)
+            // yield.xyz API enforces a maximum of 25 balance queries per request.
+            // Native wallets can easily exceed this with accounts across many chains.
+            const BATCH_SIZE = 25
+            const batches: (typeof uniqueQueries)[] = []
+            for (let i = 0; i < uniqueQueries.length; i += BATCH_SIZE) {
+              batches.push(uniqueQueries.slice(i, i + BATCH_SIZE))
+            }
+
+            const batchResponses = await Promise.all(
+              batches.map(batch => fetchAggregateBalances(batch)),
+            )
+
+            const response = {
+              items: batchResponses.flatMap(r => r.items),
+              errors: batchResponses.flatMap(r => r.errors),
+            }
             const balanceMap: Record<string, AugmentedYieldBalanceWithAccountId[]> = {}
 
             for (const item of response.items) {


### PR DESCRIPTION
## Description

yield.xyz API enforces a maximum of 25 balance queries per request. Native wallets generate 38+ query payloads (accounts across 17+ networks), causing the entire `/yields/balances` request to fail with 400 `"Maximum 25 balance queries allowed per request"`. This silently breaks all position loading - "My Positions (0)".

MetaMask only sends 1-2 queries (single EVM account), so it stayed under the limit - which is why positions work with MetaMask but not native wallet.

Fix: chunk the queries into batches of 25 and merge the responses.

## Issue (if applicable)

closes #12170

## Risk

Low - read-only query batching, no tx/contract interaction changes. Isolated to yield balance fetching.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

yield.xyz balance queries for all wallet types. The fix only splits the existing single request into multiple batched requests when >25 queries are needed.

## Testing

### Engineering

1. Connect a native wallet (keystore import)
2. Navigate to `/#/yields`
3. Verify "My Positions" tab shows positions (previously showed 0)
4. Verify "Active Positions" header shows total value
5. Click "My Positions" tab - individual positions should render with balances, APYs, providers

### Operations

- [ ] Connect native wallet
- [ ] Go to yields page
- [ ] Confirm "My Positions" count is > 0 (was 0 before fix)
- [ ] Confirm position details render correctly (balance amounts, provider names, APYs)

## Screenshots (if applicable)

### qabot run (localhost, native wallet)

https://qabot-kappa.vercel.app/runs/da263f9c-2df1-46c5-a51a-eb854a87c1b9

**Before fix**: "My Positions (0)" - API returns 400 "Maximum 25 balance queries allowed per request"
**After fix**: "My Positions (26)" - $24.66 across 26 positions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability and performance of balance data retrieval to handle larger requests more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
