### PR TITLE
fix: use content diff for private sync state detection in release script

### DIFF
--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -664,8 +664,8 @@ const doRegularRelease = async () => {
         const privatePrUrl = await createPr({
           base: 'private',
           head: 'main',
-          title: `chore: sync private to ${nextVersion}`,
-          body: `Sync private branch to main after release ${nextVersion}.`,
+          title: `chore: sync private to ${latestTag}`,
+          body: `Sync private branch to main after release ${latestTag}.`,
         })
         if (privatePrUrl) {
           console.log(chalk.green(`Private sync PR created: ${privatePrUrl}`))
@@ -874,8 +874,8 @@ const doHotfixRelease = async () => {
         const privatePrUrl = await createPr({
           base: 'private',
           head: 'main',
-          title: `chore: sync private to ${nextVersion}`,
-          body: `Sync private branch to main after hotfix ${nextVersion}.`,
+          title: `chore: sync private to ${latestTag}`,
+          body: `Sync private branch to main after hotfix ${latestTag}.`,
         })
         if (privatePrUrl) {
           console.log(chalk.green(`Private sync PR created: ${privatePrUrl}`))


### PR DESCRIPTION
SHA comparison for `private` branch breaks with squash merges - private's SHA will never equal main's SHA even when content is identical, so the script gets permanently stuck in `tagged_private_stale` and can never reach `idle`. New release = borked.

## changes
- `deriveReleaseState` / `deriveHotfixState`: replace `privateSha` param with `privateContentMatchesMain` boolean (computed via `git diff`, squash-safe)
- `doRegularRelease` / `doHotfixRelease`: compute content diff before state derivation
- `tagged_private_stale` log message: use `latestTag` instead of `nextVersion` (was showing wrong version)
- `createPr`: return `null` on "No commits between" instead of crashing, callers handle gracefully

## risk
Low - release script only, no prod code.

## testing
Run `GITHUB_TOKEN= pnpm release` after a release where private was synced via squash - should show `idle` (ready for next release) instead of `tagged_private_stale`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better handling when private branches are already synchronized with main — no redundant backmerge or PRs.
  * Graceful behavior when no commits exist between branches, avoiding erroneous PR creation and improving logging/fallback messages.

* **Refactor**
  * Release and hotfix decision logic simplified to use a content-match check for private vs main branches.
  * Control flow and logging streamlined for clearer, idempotent release operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->