### PR TITLE
fix: tron trc20 balances for non-activated accounts + send warning

### DIFF
--- a/e2e/fixtures/tron-non-activated-balances.yaml
+++ b/e2e/fixtures/tron-non-activated-balances.yaml
@@ -7,7 +7,7 @@ depends_on:
   - wallet-health.yaml
 steps:
   - name: Navigate to Tron USDT asset page
-    instruction: Navigate to the Tron USDT asset page at /assets/eip155:195/slip44:195 or search for USDT on Tron in the asset list
+    instruction: Navigate to the Tron USDT asset page at /assets/tron:0x2b6653dc/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t
     expected: The USDT (Tron) asset page is visible
     screenshot: true
 
@@ -35,5 +35,10 @@ steps:
       recipient needs TRX to move them.
     expected: >
       A warning alert is visible saying the recipient address hasn't been activated and they'll
-      need TRX to use the tokens. The Continue/Preview button is still enabled.
+      need TRX to use the tokens.
+    screenshot: true
+
+  - name: Verify send is not blocked
+    instruction: Enter a valid non-zero USDT amount, for example 1.
+    expected: The Preview button is enabled - the warning is informational only and does not block the send flow.
     screenshot: true

--- a/e2e/fixtures/tron-non-activated-balances.yaml
+++ b/e2e/fixtures/tron-non-activated-balances.yaml
@@ -1,0 +1,39 @@
+name: Tron Non-Activated Account Balances
+description: >
+  Verifies fix for #12190 - USDT/TRC20 tokens show in portfolio for non-activated Tron accounts,
+  and send flow shows a warning when sending TRC20 to a non-activated recipient address.
+route: /
+depends_on:
+  - wallet-health.yaml
+steps:
+  - name: Navigate to Tron USDT asset page
+    instruction: Navigate to the Tron USDT asset page at /assets/eip155:195/slip44:195 or search for USDT on Tron in the asset list
+    expected: The USDT (Tron) asset page is visible
+    screenshot: true
+
+  - name: Verify USDT balance visible for Tron account
+    instruction: Check the account balances shown for USDT on Tron. Look for any TRX/Tron wallet accounts listed.
+    expected: At least one account shows a USDT balance (even if zero TRX balance)
+    screenshot: true
+
+  - name: Open send modal for Tron USDT
+    instruction: Click the Send button on the USDT Tron asset page to open the send flow
+    expected: The send modal opens showing the address input screen
+    screenshot: true
+
+  - name: Enter non-activated Tron recipient address
+    instruction: >
+      In the address input field, type the known non-activated Tron address: TNJ1pzzz8Tzip6Nid6DxMVso3zM4bLFDxu
+      Wait for address validation to complete.
+    expected: The address is accepted and validated (no red error), navigation to amount screen happens
+    screenshot: true
+
+  - name: Verify non-activated recipient warning shows
+    instruction: >
+      On the send amount screen, look for a yellow/orange warning alert about the recipient address
+      not being activated on Tron. The warning should mention that tokens will arrive but the
+      recipient needs TRX to move them.
+    expected: >
+      A warning alert is visible saying the recipient address hasn't been activated and they'll
+      need TRX to use the tokens. The Continue/Preview button is still enabled.
+    screenshot: true

--- a/packages/unchained-client/src/tron/api.ts
+++ b/packages/unchained-client/src/tron/api.ts
@@ -92,6 +92,7 @@ export class TronApi {
             'TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8', // USDC
           ]
 
+          const MAX_FALLBACK_CONTRACTS = 20
           const discoveredContracts = new Set<string>(HARDCODED_TOP_TOKENS)
 
           const trc20TxResponse = await fetch(
@@ -109,13 +110,19 @@ export class TronApi {
             }
           }
 
-          for (const contractAddress of discoveredContracts) {
+          for (const contractAddress of Array.from(discoveredContracts).slice(
+            0,
+            MAX_FALLBACK_CONTRACTS,
+          )) {
             await this.throttle()
             const balance = await this.getTRC20Balance({ address: params.pubkey, contractAddress })
             if (balance !== '0') tokens.push({ contractAddress, balance })
           }
-        } catch (_fallbackErr) {
-          // Fallback also failed - continue with what we have
+        } catch (fallbackErr) {
+          console.error('Failed TRC20 fallback discovery for non-activated TRON account', {
+            address: `${params.pubkey.slice(0, 6)}...${params.pubkey.slice(-4)}`,
+            error: fallbackErr,
+          })
         }
       }
     } catch (err) {

--- a/packages/unchained-client/src/tron/api.ts
+++ b/packages/unchained-client/src/tron/api.ts
@@ -109,20 +109,11 @@ export class TronApi {
             }
           }
 
-          const balanceResults = await Promise.all(
-            Array.from(discoveredContracts).map(contractAddress =>
-              this.getTRC20Balance({ address: params.pubkey, contractAddress }).then(balance => ({
-                contractAddress,
-                balance,
-              })),
-            ),
-          )
-
-          balanceResults.forEach(({ contractAddress, balance }) => {
-            if (balance !== '0') {
-              tokens.push({ contractAddress, balance })
-            }
-          })
+          for (const contractAddress of discoveredContracts) {
+            await this.throttle()
+            const balance = await this.getTRC20Balance({ address: params.pubkey, contractAddress })
+            if (balance !== '0') tokens.push({ contractAddress, balance })
+          }
         } catch (_fallbackErr) {
           // Fallback also failed - continue with what we have
         }

--- a/packages/unchained-client/src/tron/api.ts
+++ b/packages/unchained-client/src/tron/api.ts
@@ -81,6 +81,51 @@ export class TronApi {
             })
           }
         })
+      } else if (!trc20Data.data || trc20Data.data.length === 0) {
+        // Non-activated account: /v1/accounts returns data:[] for addresses that have never sent TRX.
+        // Fall back to discovering TRC20 balances via received transactions + hardcoded top tokens.
+        try {
+          await this.throttle()
+
+          const HARDCODED_TOP_TOKENS = [
+            'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t', // USDT
+            'TEkxiTehnzSmSe2XqrBj4w32RUN966rdz8', // USDC
+          ]
+
+          const discoveredContracts = new Set<string>(HARDCODED_TOP_TOKENS)
+
+          const trc20TxResponse = await fetch(
+            `${this.rpcUrl}/v1/accounts/${params.pubkey}/transactions/trc20?limit=200&only_to=true`,
+          )
+
+          if (trc20TxResponse.ok) {
+            const trc20TxData = await trc20TxResponse.json()
+
+            if (trc20TxData.data && Array.isArray(trc20TxData.data)) {
+              trc20TxData.data.forEach((tx: { token_info?: { address?: string } }) => {
+                const contractAddress = tx.token_info?.address
+                if (contractAddress) discoveredContracts.add(contractAddress)
+              })
+            }
+          }
+
+          const balanceResults = await Promise.all(
+            Array.from(discoveredContracts).map(contractAddress =>
+              this.getTRC20Balance({ address: params.pubkey, contractAddress }).then(balance => ({
+                contractAddress,
+                balance,
+              })),
+            ),
+          )
+
+          balanceResults.forEach(({ contractAddress, balance }) => {
+            if (balance !== '0') {
+              tokens.push({ contractAddress, balance })
+            }
+          })
+        } catch (_fallbackErr) {
+          // Fallback also failed - continue with what we have
+        }
       }
     } catch (err) {
       // TRC20 fetch failed, continue with just TRC10 tokens

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2182,6 +2182,11 @@
       "deployFailed": "Deployment Failed"
     }
   },
+  "tron": {
+    "recipientNotActivated": {
+      "sendWarning": "This address hasn't been activated on Tron yet. Your tokens will arrive, but the recipient won't be able to move them until they also receive some TRX."
+    }
+  },
   "transactionHistory": {
     "transactionHistory": "Transaction History",
     "recentTransactions": "Recent Transactions",

--- a/src/components/Modals/Send/views/SendAmountDetails.tsx
+++ b/src/components/Modals/Send/views/SendAmountDetails.tsx
@@ -20,6 +20,7 @@ import {
   fromAccountId,
   fromAssetId,
   starknetChainId,
+  tronAssetId,
 } from '@shapeshiftoss/caip'
 import { useMutation } from '@tanstack/react-query'
 import get from 'lodash/get'
@@ -47,6 +48,7 @@ import { SlideTransition } from '@/components/SlideTransition'
 import { Text } from '@/components/Text/Text'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { useIsStarknetAccountDeployed } from '@/hooks/useIsStarknetAccountDeployed/useIsStarknetAccountDeployed'
+import { useIsTronAddressActivated } from '@/hooks/useIsTronAddressActivated/useIsTronAddressActivated'
 import { useNotificationToast } from '@/hooks/useNotificationToast'
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { parseAddressInputWithChainId } from '@/lib/address/address'
@@ -113,6 +115,8 @@ export const SendAmountDetails = () => {
     isLoading: isCheckingDeployment,
     refetch: refetchDeploymentStatus,
   } = useIsStarknetAccountDeployed(accountId)
+
+  const { data: isTronRecipientActivated } = useIsTronAddressActivated(to, asset?.chainId)
 
   const deployAccountMutation = useMutation({
     mutationFn: async () => {
@@ -401,6 +405,14 @@ export const SendAmountDetails = () => {
               <AlertIcon />
               <AlertDescription>
                 <Text translation='starknet.deployAccount.sendDescription' />
+              </AlertDescription>
+            </Alert>
+          )}
+          {isTronRecipientActivated === false && asset?.assetId !== tronAssetId && (
+            <Alert status='warning' borderRadius='lg' mb={3}>
+              <AlertIcon />
+              <AlertDescription>
+                <Text translation='tron.recipientNotActivated.sendWarning' />
               </AlertDescription>
             </Alert>
           )}

--- a/src/hooks/useIsTronAddressActivated/useIsTronAddressActivated.ts
+++ b/src/hooks/useIsTronAddressActivated/useIsTronAddressActivated.ts
@@ -1,0 +1,44 @@
+import type { ChainId } from '@shapeshiftoss/caip'
+import { tronChainId } from '@shapeshiftoss/caip'
+import { useQuery } from '@tanstack/react-query'
+
+import { assertGetTronChainAdapter } from '@/lib/utils/tron'
+
+const checkTronAddressActivated = async (
+  to: string | undefined,
+  chainId: ChainId | undefined,
+): Promise<boolean | undefined> => {
+  if (!to || !chainId || chainId !== tronChainId) return undefined
+  if (!to.startsWith('T')) return undefined
+
+  try {
+    const adapter = assertGetTronChainAdapter(chainId)
+    const rpcUrl = adapter.httpProvider.getRpcUrl()
+
+    const response = await fetch(`${rpcUrl}/wallet/getaccount`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ address: to, visible: true }),
+    })
+
+    if (!response.ok) return undefined
+
+    const data = await response.json()
+
+    // Activated accounts have an 'address' field; non-activated accounts return {}
+    return !!data?.address
+  } catch (error) {
+    console.error('Failed to check Tron address activation status:', error)
+    return undefined
+  }
+}
+
+export const useIsTronAddressActivated = (to: string | undefined, chainId: ChainId | undefined) => {
+  return useQuery({
+    queryKey: ['isTronAddressActivated', to, chainId],
+    queryFn: () => checkTronAddressActivated(to, chainId),
+    enabled: Boolean(to) && to?.startsWith('T') && chainId === tronChainId,
+    staleTime: 30_000,
+    refetchInterval: false,
+  })
+}

--- a/src/state/slices/portfolioSlice/utils/index.ts
+++ b/src/state/slices/portfolioSlice/utils/index.ts
@@ -487,8 +487,10 @@ export const checkAccountHasActivity = (account: Account<ChainId>) => {
       return hasActivity
     }
     case CHAIN_NAMESPACE.Tron: {
-      const hasActivity = bnOrZero(account.balance).gt(0)
-
+      const tronAccount = account as Account<KnownChainIds.TronMainnet>
+      const hasActivity =
+        bnOrZero(tronAccount.balance).gt(0) ||
+        (tronAccount.chainSpecific.tokens ?? []).some(token => bnOrZero(token.balance).gt(0))
       return hasActivity
     }
     case CHAIN_NAMESPACE.Sui: {


### PR DESCRIPTION
## Description

Two fixes for Tron non-activated accounts:

1. **TRC20 balance discovery for non-activated accounts** - The TronGrid `/v1/accounts/{addr}` API returns `{"data":[]}` for addresses that have never sent TRX (non-activated). Added a fallback in `TronApi.getAccount()` that checks hardcoded top tokens (USDT, USDC) + scans received TRC20 tx history to discover token contracts, then calls `balanceOf()` via `triggerconstantcontract`. Non-activated accounts with USDT/TRC20 balances now show up in the portfolio.

2. **Send flow warning for non-activated recipient** - Added `useIsTronAddressActivated` hook that checks if a Tron recipient address is activated. On the send amount screen, if the recipient is non-activated and the asset is not native TRX, a yellow warning alert is shown: "This address hasn't been activated on Tron yet. Your tokens will arrive, but the recipient won't be able to move them until they also receive some TRX." Warn-and-allow - send is not blocked.

## Issue (if applicable)

closes #12190

## Risk

Low - Tron-specific changes, under the TRON feature flag. The balance fallback only triggers for non-activated accounts (empty `data[]` response from TronGrid). The send warning is informational only and doesn't block the flow.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Tron TRC20 token sends only.

## Testing

### Engineering

1. Use a Tron address that has received USDT but has 0 TRX (non-activated)
2. Add it to ShapeShift - USDT balance should now show in the portfolio
3. Open the send flow for USDT (Tron), enter a non-activated Tron recipient address
4. Verify the yellow warning appears on the amount screen

qabot run (6/6 passed): http://localhost:8080/runs/99d0a229-c7e4-49b3-b7d5-a3b93922f5d5

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Tron is behind the `VITE_FEATURE_TRON` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Better discovery of TRC20 balances for Tron accounts missing on-chain token listings.
  * Activity detection now counts Tron token balances when evaluating account activity.

* **New Features**
  * User-facing warning when sending to non-activated Tron addresses; send flow remains available.
  * On-send validation checks for Tron address activation.

* **Tests**
  * End-to-end test added for non-activated Tron recipient behavior.

* **Documentation**
  * New translation text for the non-activated Tron recipient warning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->