### PR TITLE
fix: show networkFeeError at trade confirm

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -157,6 +157,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isLoading: isNetworkFeeCryptoBaseUnitLoading,
     isRefetching: isNetworkFeeCryptoBaseUnitRefetching,
     data: networkFeeCryptoBaseUnit,
+    error: networkFeeError,
   } = useTradeNetworkFeeCryptoBaseUnit({
     hopIndex: currentHopIndex,
     enabled:
@@ -441,6 +442,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
         activeTradeId={activeTradeId}
         isExactAllowance={isExactAllowance}
         isLoading={isNetworkFeeCryptoBaseUnitLoading || isNetworkFeeCryptoBaseUnitRefetching}
+        networkFeeError={networkFeeError}
         onSwapTxBroadcast={onSwapTxBroadcast}
       />
     )
@@ -451,6 +453,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isExactAllowance,
     isNetworkFeeCryptoBaseUnitLoading,
     isNetworkFeeCryptoBaseUnitRefetching,
+    networkFeeError,
     onSwapTxBroadcast,
   ])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
 } from '@chakra-ui/react'
 import { fromAccountId, starknetChainId } from '@shapeshiftoss/caip'
+import { ChainAdapterError } from '@shapeshiftoss/chain-adapters'
 import type { SupportedTradeQuoteStepIndex, TradeQuoteStep } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import { useMutation } from '@tanstack/react-query'
@@ -56,6 +57,7 @@ type TradeFooterButtonProps = {
   activeTradeId: string
   isExactAllowance: boolean
   isLoading?: boolean
+  networkFeeError: Error | null
   onSwapTxBroadcast?: () => void
 }
 
@@ -65,6 +67,7 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
   activeTradeId,
   isExactAllowance,
   isLoading = false,
+  networkFeeError,
   onSwapTxBroadcast,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -324,6 +327,14 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
   const activeQuoteErrors = useAppSelector(selectActiveQuoteErrors)
   const activeQuoteError = useMemo(() => activeQuoteErrors?.[0], [activeQuoteErrors])
 
+  const networkFeeErrorMessage = useMemo(() => {
+    if (!networkFeeError) return undefined
+    if (networkFeeError instanceof ChainAdapterError) {
+      return translate(networkFeeError.metadata.translation, networkFeeError.metadata.options)
+    }
+    return translate('trade.errors.networkFeeEstimateFailed')
+  }, [networkFeeError, translate])
+
   const isButtonLoading = useMemo(() => {
     if (!confirmedTradeExecutionState) return true
 
@@ -389,6 +400,14 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
             </AlertDescription>
           </Alert>
         )}
+        {networkFeeErrorMessage && (
+          <Alert status='warning' size='sm'>
+            <AlertIcon />
+            <AlertDescription>
+              <RawText>{networkFeeErrorMessage}</RawText>
+            </AlertDescription>
+          </Alert>
+        )}
         {streamingProgress && streamingProgress.failedSwaps.length > 0 && (
           <Alert status='warning' size='sm'>
             <AlertIcon />
@@ -402,13 +421,16 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
           </Alert>
         )}
         <Button
-          colorScheme={!!activeQuoteError ? 'red' : 'blue'}
+          colorScheme={!!activeQuoteError || !!networkFeeError ? 'red' : 'blue'}
           size='lg'
           width='full'
           onClick={handleClick}
           isLoading={isButtonLoading}
           isDisabled={
-            tradeButtonProps.isDisabled || !!activeQuoteError || deployAccountMutation.isPending
+            tradeButtonProps.isDisabled ||
+            !!activeQuoteError ||
+            !!networkFeeError ||
+            deployAccountMutation.isPending
           }
           loadingText={
             deployAccountMutation.isPending


### PR DESCRIPTION
## Description

Trade confirm was silently failing on gas estimation and not disabling the button resulting in failed attempt to trade. Expose the error and disable the button if we can't estimate gas.

Follow up if we wish would be falling back to the quote estimated fees and just fetch up to date gas price on execute.

## Issue (if applicable)

<!-----------------------------------------------------------------------------
If applicable, please link to the github issue and put `closes #XXXX` in your comment to auto-close the issue that your PR fixes.
------------------------------------------------------------------------------>

https://discordapp.com/channels/554694662431178782/1483584545369620523/1483591857739927552

## Risk

> High Risk PRs Require 2 approvals

<!-----------------------------------------------------------------------------
Outline the scope of your changes and the risk associated with them. You must use your discretion as an engineer to determine the potential impact of your changes.

WARNING: If your PR introduces a new on-chain transaction or modifies an existing one, please add the "High-Risk" label to this PR and ask for 2 reviewers to approve it before merging.

E.g. an upgrade to `hdwallet` or core state management would be considered higher risk, and might require a full regression test. UI or isolated view changes, or something behind a feature flag may have near zero risk. Small bug fixes might require testing isolated to the specific fix.
------------------------------------------------------------------------------>

Low

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

## Testing

<!-----------------------------------------------------------------------------
We treat every PR to be merged with the same scrutiny as if we were merging directly to production.

Your PR will not be merged if you do not complete the sections below for our engineering and operations teams to test.
------------------------------------------------------------------------------>

- ETH -> KNX (0xf19304e6bFE0A18D2a0171758aA433921F192897) swap with butter currently exposes this fail case

### Engineering

<!-----------------------------------------------------------------------------
Include sufficient information here for an engineer to test your PR. This may include how to test locally, in a built environment, changes to infrastructure etc.
------------------------------------------------------------------------------>

:point_up: 

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

<!-----------------------------------------------------------------------------
If your changes have a user-facing impact, describe how a non-technical QA team can functionally test your changes in a preview environment.

If they are not user-facing please describe how to test for any regressions that may occur.
------------------------------------------------------------------------------>

:point_up:

## Screenshots (if applicable)

<img width="416" height="427" alt="image" src="https://github.com/user-attachments/assets/36d29664-b4bf-4914-8cac-50b1647d7db1" />
