### PR TITLE
fix: show networkFeeError at trade confirm

### DIFF
--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -157,6 +157,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isLoading: isNetworkFeeCryptoBaseUnitLoading,
     isRefetching: isNetworkFeeCryptoBaseUnitRefetching,
     data: networkFeeCryptoBaseUnit,
+    error: networkFeeError,
   } = useTradeNetworkFeeCryptoBaseUnit({
     hopIndex: currentHopIndex,
     enabled:
@@ -441,6 +442,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
         activeTradeId={activeTradeId}
         isExactAllowance={isExactAllowance}
         isLoading={isNetworkFeeCryptoBaseUnitLoading || isNetworkFeeCryptoBaseUnitRefetching}
+        networkFeeError={networkFeeError}
         onSwapTxBroadcast={onSwapTxBroadcast}
       />
     )
@@ -451,6 +453,7 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     isExactAllowance,
     isNetworkFeeCryptoBaseUnitLoading,
     isNetworkFeeCryptoBaseUnitRefetching,
+    networkFeeError,
     onSwapTxBroadcast,
   ])
 

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeFooterButton.tsx
@@ -9,6 +9,7 @@ import {
   Stack,
 } from '@chakra-ui/react'
 import { fromAccountId, starknetChainId } from '@shapeshiftoss/caip'
+import { ChainAdapterError } from '@shapeshiftoss/chain-adapters'
 import type { SupportedTradeQuoteStepIndex, TradeQuoteStep } from '@shapeshiftoss/swapper'
 import { SwapperName } from '@shapeshiftoss/swapper'
 import { useMutation } from '@tanstack/react-query'
@@ -56,6 +57,7 @@ type TradeFooterButtonProps = {
   activeTradeId: string
   isExactAllowance: boolean
   isLoading?: boolean
+  networkFeeError: Error | null
   onSwapTxBroadcast?: () => void
 }
 
@@ -65,6 +67,7 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
   activeTradeId,
   isExactAllowance,
   isLoading = false,
+  networkFeeError,
   onSwapTxBroadcast,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -324,6 +327,14 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
   const activeQuoteErrors = useAppSelector(selectActiveQuoteErrors)
   const activeQuoteError = useMemo(() => activeQuoteErrors?.[0], [activeQuoteErrors])
 
+  const networkFeeErrorMessage = useMemo(() => {
+    if (!networkFeeError) return undefined
+    if (networkFeeError instanceof ChainAdapterError) {
+      return translate(networkFeeError.metadata.translation, networkFeeError.metadata.options)
+    }
+    return translate('trade.errors.networkFeeEstimateFailed')
+  }, [networkFeeError, translate])
+
   const isButtonLoading = useMemo(() => {
     if (!confirmedTradeExecutionState) return true
 
@@ -389,6 +400,14 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
             </AlertDescription>
           </Alert>
         )}
+        {networkFeeErrorMessage && (
+          <Alert status='warning' size='sm'>
+            <AlertIcon />
+            <AlertDescription>
+              <RawText>{networkFeeErrorMessage}</RawText>
+            </AlertDescription>
+          </Alert>
+        )}
         {streamingProgress && streamingProgress.failedSwaps.length > 0 && (
           <Alert status='warning' size='sm'>
             <AlertIcon />
@@ -402,13 +421,16 @@ export const TradeFooterButton: FC<TradeFooterButtonProps> = ({
           </Alert>
         )}
         <Button
-          colorScheme={!!activeQuoteError ? 'red' : 'blue'}
+          colorScheme={!!activeQuoteError || !!networkFeeError ? 'red' : 'blue'}
           size='lg'
           width='full'
           onClick={handleClick}
           isLoading={isButtonLoading}
           isDisabled={
-            tradeButtonProps.isDisabled || !!activeQuoteError || deployAccountMutation.isPending
+            tradeButtonProps.isDisabled ||
+            !!activeQuoteError ||
+            !!networkFeeError ||
+            deployAccountMutation.isPending
           }
           loadingText={
             deployAccountMutation.isPending


### PR DESCRIPTION
This change got merged to release after the release already went out (UI wasn't fresh showing the release as open when I was looking). New PR to get fix into develop for next release.

https://github.com/shapeshift/web/pull/12192

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for network fee estimation failures. Users now receive clear error alerts when network fees cannot be calculated, with the trade button disabled to prevent incomplete transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->