### PR TITLE
fix: align public-api Docker image paths and simplify server config

### DIFF
--- a/packages/public-api/.env.example
+++ b/packages/public-api/.env.example
@@ -1,11 +1,6 @@
 # Server Configuration
 PORT=3001
-HOST=0.0.0.0
 NODE_ENV=development
-TRUST_PROXY=1
-
-# Asset Data Path (optional - will auto-detect if not set)
-# ASSET_DATA_PATH=/app/public/generated/generatedAssetData.json
 
 # API Configuration (optional - defaults shown)
 # VITE_PORTALS_API_KEY=

--- a/packages/public-api/.env.example
+++ b/packages/public-api/.env.example
@@ -1,23 +1,69 @@
 # Server Configuration
-PORT=3001
+PORT=3005
 NODE_ENV=development
 
-# API Configuration (optional - defaults shown)
-# VITE_PORTALS_API_KEY=
-# VITE_CHAINALYSIS_API_KEY=
-# VITE_ZRX_API_KEY=
-# VITE_ZERION_API_KEY=
+# Swap Service
+SWAP_SERVICE_BASE_URL=https://dev-api.swap-service.shapeshift.com
 
-# Unchained URLs (defaults to ShapeShift public instances)
-# UNCHAINED_ETHEREUM_HTTP_URL=https://api.ethereum.shapeshift.com
-# UNCHAINED_THORCHAIN_HTTP_URL=https://api.thorchain.shapeshift.com
+# Unchained URLs
+UNCHAINED_ETHEREUM_HTTP_URL=https://dev-api.ethereum.shapeshift.com
+UNCHAINED_BITCOIN_HTTP_URL=https://dev-api.bitcoin.shapeshift.com
+UNCHAINED_THORCHAIN_HTTP_URL=https://dev-api.thorchain.shapeshift.com
+UNCHAINED_MAYACHAIN_HTTP_URL=https://dev-api.mayachain.shapeshift.com
+UNCHAINED_COSMOS_HTTP_URL=https://dev-api.cosmos.shapeshift.com
+UNCHAINED_AVALANCHE_HTTP_URL=https://dev-api.avalanche.shapeshift.com
+UNCHAINED_BNBSMARTCHAIN_HTTP_URL=https://dev-api.bnbsmartchain.shapeshift.com
+UNCHAINED_BASE_HTTP_URL=https://dev-api.base.shapeshift.com
+UNCHAINED_ARBITRUM_HTTP_URL=https://dev-api.arbitrum.shapeshift.com
+UNCHAINED_OPTIMISM_HTTP_URL=https://dev-api.optimism.shapeshift.com
+UNCHAINED_POLYGON_HTTP_URL=https://dev-api.polygon.shapeshift.com
+UNCHAINED_GNOSIS_HTTP_URL=https://dev-api.gnosis.shapeshift.com
+UNCHAINED_DOGECOIN_HTTP_URL=https://dev-api.dogecoin.shapeshift.com
+UNCHAINED_LITECOIN_HTTP_URL=https://dev-api.litecoin.shapeshift.com
+UNCHAINED_BITCOINCASH_HTTP_URL=https://dev-api.bitcoincash.shapeshift.com
 
-# Rate Limiting (requests per minute per IP, defaults shown)
-# RATE_LIMIT_GLOBAL_MAX=300
-# RATE_LIMIT_DATA_MAX=120
-# RATE_LIMIT_SWAP_RATES_MAX=60
-# RATE_LIMIT_SWAP_QUOTE_MAX=45
+# Node URLs
+THORCHAIN_NODE_URL=https://dev-api.thorchain.shapeshift.com/lcd
+MAYACHAIN_NODE_URL=https://api.mayachain.shapeshift.com/lcd
+TRON_NODE_URL=https://api.trongrid.io
+SUI_NODE_URL=https://fullnode.mainnet.sui.io
 
-# Partner API Keys (add your partner keys here)
-# Format: API_KEY_<PARTNER_ID>=<api_key>:<name>:<fee_share_percentage>
-# Example: API_KEY_PARTNER1=abc123:MyPartner:50
+# Midgard URLs
+THORCHAIN_MIDGARD_URL=https://dev-api.thorchain.shapeshift.com/midgard/v2
+MAYACHAIN_MIDGARD_URL=https://dev-api.mayachain.shapeshift.com/midgard/v2
+
+# Swapper API URLs
+COWSWAP_BASE_URL=https://api.cow.fi
+PORTALS_BASE_URL=https://api.portals.fi
+ZRX_BASE_URL=https://api.proxy.shapeshift.com/api/v1/zrx/
+JUPITER_API_URL=https://quote-api.jup.ag/v6
+RELAY_API_URL=https://api.relay.link
+ACROSS_API_URL=https://app.across.to/api
+DEBRIDGE_API_URL=https://dln.debridge.finance/v1.0
+CHAINFLIP_API_URL=https://chainflip-broker.io
+
+# Swapper API Keys (leave empty if not using)
+CHAINFLIP_API_KEY=
+BEBOP_API_KEY=
+NEAR_INTENTS_API_KEY=
+TENDERLY_API_KEY=
+TENDERLY_ACCOUNT_SLUG=
+TENDERLY_PROJECT_SLUG=
+ACROSS_INTEGRATOR_ID=
+
+# Affiliate
+DEFAULT_AFFILIATE_BPS=60
+
+# Feature Flags
+FEATURE_THORCHAINSWAP_LONGTAIL=true
+FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL=true
+FEATURE_CHAINFLIP_SWAP_DCA=true
+
+# Rate Limiting (requests per minute per IP)
+RATE_LIMIT_GLOBAL_MAX=300
+RATE_LIMIT_DATA_MAX=120
+RATE_LIMIT_SWAP_RATES_MAX=60
+RATE_LIMIT_SWAP_QUOTE_MAX=45
+RATE_LIMIT_SWAP_STATUS_MAX=60
+RATE_LIMIT_AFFILIATE_STATS_MAX=30
+RATE_LIMIT_AFFILIATE_MUTATION_MAX=20

--- a/packages/public-api/Dockerfile
+++ b/packages/public-api/Dockerfile
@@ -80,12 +80,12 @@ FROM node:22-alpine AS runner
 
 WORKDIR /app
 
-# Copy only the bundled server, smoke tests, and asset data (node_modules not needed - esbuild bundles everything)
-COPY --from=builder /app/packages/public-api/dist/server.cjs ./server.cjs
-COPY --from=builder /app/public/generated/generatedAssetData.json ./public/generated/
+# Copy only the bundled server, docs, and asset data (node_modules not needed - esbuild bundles everything)
+COPY --from=builder /app/packages/public-api/dist/server.cjs ./packages/public-api/dist/server.cjs
+COPY --from=builder /app/packages/public-api/docs ./packages/public-api/docs
+COPY --from=builder /app/public/generated/generatedAssetData.json ./public/generated/generatedAssetData.json
 
 # Set environment
 ENV NODE_ENV=production
-ENV ASSET_DATA_PATH=/app/public/generated/generatedAssetData.json
 
-CMD ["node", "server.cjs"]
+CMD ["node", "packages/public-api/dist/server.cjs"]

--- a/packages/public-api/src/assets.ts
+++ b/packages/public-api/src/assets.ts
@@ -15,30 +15,7 @@ export const initAssets = (): Promise<void> => {
   console.log('Initializing assets...')
 
   try {
-    // Try to load from the generated asset data file
-    // First check env var, then relative to cwd, then relative to monorepo root
-    const possiblePaths = [
-      process.env.ASSET_DATA_PATH,
-      path.join(process.cwd(), 'public/generated/generatedAssetData.json'),
-      path.join(process.cwd(), '../../public/generated/generatedAssetData.json'),
-      path.join(process.cwd(), 'generatedAssetData.json'),
-    ].filter(Boolean) as string[]
-
-    let assetDataPath: string | undefined
-    for (const p of possiblePaths) {
-      if (fs.existsSync(p)) {
-        assetDataPath = p
-        break
-      }
-    }
-
-    if (!assetDataPath) {
-      const error = new Error(
-        `Asset data file not found in any of the expected locations: ${possiblePaths.join(', ')}`,
-      )
-      console.warn(error.message)
-      return Promise.reject(error)
-    }
+    const assetDataPath = path.join(__dirname, '../../../public/generated/generatedAssetData.json')
 
     const assetDataJson = JSON.parse(fs.readFileSync(assetDataPath, 'utf8'))
     const localAssetData = assetDataJson.byId

--- a/packages/public-api/src/config.ts
+++ b/packages/public-api/src/config.ts
@@ -64,7 +64,3 @@ const getSwapServiceBaseUrl = (): string => {
 }
 
 export const SWAP_SERVICE_BASE_URL = getSwapServiceBaseUrl()
-
-// API server config
-export const API_PORT = parseInt(process.env.PORT || '3001', 10)
-export const API_HOST = process.env.HOST || '0.0.0.0'

--- a/packages/public-api/src/config.ts
+++ b/packages/public-api/src/config.ts
@@ -1,66 +1,41 @@
 import type { SwapperConfig } from '@shapeshiftoss/swapper'
 
-// Server-side config that mirrors the web app's config but from environment variables
+import { env } from './env'
+
 export const getServerConfig = (): SwapperConfig => ({
-  VITE_UNCHAINED_THORCHAIN_HTTP_URL:
-    process.env.UNCHAINED_THORCHAIN_HTTP_URL || 'https://api.thorchain.shapeshift.com',
-  VITE_UNCHAINED_MAYACHAIN_HTTP_URL:
-    process.env.UNCHAINED_MAYACHAIN_HTTP_URL || 'https://api.mayachain.shapeshift.com',
-  VITE_UNCHAINED_COSMOS_HTTP_URL:
-    process.env.UNCHAINED_COSMOS_HTTP_URL || 'https://api.cosmos.shapeshift.com',
-  VITE_THORCHAIN_NODE_URL: process.env.THORCHAIN_NODE_URL || 'https://thornode.ninerealms.com',
-  VITE_MAYACHAIN_NODE_URL: process.env.MAYACHAIN_NODE_URL || 'https://tendermint.mayachain.info',
-  VITE_TRON_NODE_URL: process.env.TRON_NODE_URL || 'https://api.trongrid.io',
-  VITE_FEATURE_THORCHAINSWAP_LONGTAIL: process.env.FEATURE_THORCHAINSWAP_LONGTAIL === 'true',
-  VITE_FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL:
-    process.env.FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL === 'true',
-  VITE_THORCHAIN_MIDGARD_URL:
-    process.env.THORCHAIN_MIDGARD_URL || 'https://midgard.ninerealms.com/v2',
-  VITE_MAYACHAIN_MIDGARD_URL:
-    process.env.MAYACHAIN_MIDGARD_URL || 'https://midgard.mayachain.info/v2',
-  VITE_UNCHAINED_BITCOIN_HTTP_URL:
-    process.env.UNCHAINED_BITCOIN_HTTP_URL || 'https://api.bitcoin.shapeshift.com',
-  VITE_UNCHAINED_DOGECOIN_HTTP_URL:
-    process.env.UNCHAINED_DOGECOIN_HTTP_URL || 'https://api.dogecoin.shapeshift.com',
-  VITE_UNCHAINED_LITECOIN_HTTP_URL:
-    process.env.UNCHAINED_LITECOIN_HTTP_URL || 'https://api.litecoin.shapeshift.com',
-  VITE_UNCHAINED_BITCOINCASH_HTTP_URL:
-    process.env.UNCHAINED_BITCOINCASH_HTTP_URL || 'https://api.bitcoincash.shapeshift.com',
-  VITE_UNCHAINED_ETHEREUM_HTTP_URL:
-    process.env.UNCHAINED_ETHEREUM_HTTP_URL || 'https://api.ethereum.shapeshift.com',
-  VITE_UNCHAINED_AVALANCHE_HTTP_URL:
-    process.env.UNCHAINED_AVALANCHE_HTTP_URL || 'https://api.avalanche.shapeshift.com',
-  VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL:
-    process.env.UNCHAINED_BNBSMARTCHAIN_HTTP_URL || 'https://api.bnbsmartchain.shapeshift.com',
-  VITE_UNCHAINED_BASE_HTTP_URL:
-    process.env.UNCHAINED_BASE_HTTP_URL || 'https://api.base.shapeshift.com',
-  VITE_COWSWAP_BASE_URL: process.env.COWSWAP_BASE_URL || 'https://api.cow.fi',
-  VITE_PORTALS_BASE_URL: process.env.PORTALS_BASE_URL || 'https://api.portals.fi',
-  VITE_ZRX_BASE_URL: process.env.ZRX_BASE_URL || 'https://api.proxy.shapeshift.com/api/v1/zrx/',
-  VITE_CHAINFLIP_API_KEY: process.env.CHAINFLIP_API_KEY || '',
-  VITE_CHAINFLIP_API_URL: process.env.CHAINFLIP_API_URL || 'https://chainflip-broker.io',
-  VITE_FEATURE_CHAINFLIP_SWAP_DCA: process.env.FEATURE_CHAINFLIP_SWAP_DCA === 'true',
-  VITE_JUPITER_API_URL: process.env.JUPITER_API_URL || 'https://quote-api.jup.ag/v6',
-  VITE_RELAY_API_URL: process.env.RELAY_API_URL || 'https://api.relay.link',
-  VITE_BEBOP_API_KEY: process.env.BEBOP_API_KEY || '',
-  VITE_NEAR_INTENTS_API_KEY: process.env.NEAR_INTENTS_API_KEY || '',
-  VITE_TENDERLY_API_KEY: process.env.TENDERLY_API_KEY || '',
-  VITE_TENDERLY_ACCOUNT_SLUG: process.env.TENDERLY_ACCOUNT_SLUG || '',
-  VITE_TENDERLY_PROJECT_SLUG: process.env.TENDERLY_PROJECT_SLUG || '',
-  VITE_SUI_NODE_URL: process.env.SUI_NODE_URL || 'https://fullnode.mainnet.sui.io',
-  VITE_ACROSS_API_URL: process.env.ACROSS_API_URL || 'https://app.across.to/api',
-  VITE_ACROSS_INTEGRATOR_ID: process.env.ACROSS_INTEGRATOR_ID || '',
-  VITE_DEBRIDGE_API_URL: process.env.DEBRIDGE_API_URL || 'https://dln.debridge.finance/v1.0',
+  VITE_UNCHAINED_THORCHAIN_HTTP_URL: env.UNCHAINED_THORCHAIN_HTTP_URL,
+  VITE_UNCHAINED_MAYACHAIN_HTTP_URL: env.UNCHAINED_MAYACHAIN_HTTP_URL,
+  VITE_UNCHAINED_COSMOS_HTTP_URL: env.UNCHAINED_COSMOS_HTTP_URL,
+  VITE_THORCHAIN_NODE_URL: env.THORCHAIN_NODE_URL,
+  VITE_MAYACHAIN_NODE_URL: env.MAYACHAIN_NODE_URL,
+  VITE_TRON_NODE_URL: env.TRON_NODE_URL,
+  VITE_FEATURE_THORCHAINSWAP_LONGTAIL: env.FEATURE_THORCHAINSWAP_LONGTAIL,
+  VITE_FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL: env.FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL,
+  VITE_THORCHAIN_MIDGARD_URL: env.THORCHAIN_MIDGARD_URL,
+  VITE_MAYACHAIN_MIDGARD_URL: env.MAYACHAIN_MIDGARD_URL,
+  VITE_UNCHAINED_BITCOIN_HTTP_URL: env.UNCHAINED_BITCOIN_HTTP_URL,
+  VITE_UNCHAINED_DOGECOIN_HTTP_URL: env.UNCHAINED_DOGECOIN_HTTP_URL,
+  VITE_UNCHAINED_LITECOIN_HTTP_URL: env.UNCHAINED_LITECOIN_HTTP_URL,
+  VITE_UNCHAINED_BITCOINCASH_HTTP_URL: env.UNCHAINED_BITCOINCASH_HTTP_URL,
+  VITE_UNCHAINED_ETHEREUM_HTTP_URL: env.UNCHAINED_ETHEREUM_HTTP_URL,
+  VITE_UNCHAINED_AVALANCHE_HTTP_URL: env.UNCHAINED_AVALANCHE_HTTP_URL,
+  VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL: env.UNCHAINED_BNBSMARTCHAIN_HTTP_URL,
+  VITE_UNCHAINED_BASE_HTTP_URL: env.UNCHAINED_BASE_HTTP_URL,
+  VITE_COWSWAP_BASE_URL: env.COWSWAP_BASE_URL,
+  VITE_PORTALS_BASE_URL: env.PORTALS_BASE_URL,
+  VITE_ZRX_BASE_URL: env.ZRX_BASE_URL,
+  VITE_CHAINFLIP_API_KEY: env.CHAINFLIP_API_KEY,
+  VITE_CHAINFLIP_API_URL: env.CHAINFLIP_API_URL,
+  VITE_FEATURE_CHAINFLIP_SWAP_DCA: env.FEATURE_CHAINFLIP_SWAP_DCA,
+  VITE_JUPITER_API_URL: env.JUPITER_API_URL,
+  VITE_RELAY_API_URL: env.RELAY_API_URL,
+  VITE_BEBOP_API_KEY: env.BEBOP_API_KEY,
+  VITE_NEAR_INTENTS_API_KEY: env.NEAR_INTENTS_API_KEY,
+  VITE_TENDERLY_API_KEY: env.TENDERLY_API_KEY,
+  VITE_TENDERLY_ACCOUNT_SLUG: env.TENDERLY_ACCOUNT_SLUG,
+  VITE_TENDERLY_PROJECT_SLUG: env.TENDERLY_PROJECT_SLUG,
+  VITE_SUI_NODE_URL: env.SUI_NODE_URL,
+  VITE_ACROSS_API_URL: env.ACROSS_API_URL,
+  VITE_ACROSS_INTEGRATOR_ID: env.ACROSS_INTEGRATOR_ID,
+  VITE_DEBRIDGE_API_URL: env.DEBRIDGE_API_URL,
 })
-
-// Swap service backend URL
-const getSwapServiceBaseUrl = (): string => {
-  if (process.env.SWAP_SERVICE_BASE_URL) return process.env.SWAP_SERVICE_BASE_URL
-  if (process.env.NODE_ENV === 'production') {
-    throw new Error('SWAP_SERVICE_BASE_URL must be set in production')
-  }
-  console.warn('[config] SWAP_SERVICE_BASE_URL not set, using dev default')
-  return 'https://dev-api.swap-service.shapeshift.com'
-}
-
-export const SWAP_SERVICE_BASE_URL = getSwapServiceBaseUrl()

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod'
 
 const url = z.string().url()
-const flag = z.string().transform(v => v === 'true')
+const flag = z.enum(['true', 'false']).transform(v => v === 'true')
 
 const envSchema = z.object({
   // Server
-  PORT: z.string().default('3005'),
+  PORT: z.string().regex(/^\d+$/, 'PORT must be numeric').default('3005'),
   NODE_ENV: z.string().default('development'),
 
   // Swap service
@@ -63,16 +63,16 @@ const envSchema = z.object({
   FEATURE_CHAINFLIP_SWAP_DCA: flag,
 
   // Affiliate
-  DEFAULT_AFFILIATE_BPS: z.string(),
+  DEFAULT_AFFILIATE_BPS: z.string().regex(/^\d+$/, 'DEFAULT_AFFILIATE_BPS must be numeric'),
 
   // Rate limiting
-  RATE_LIMIT_GLOBAL_MAX: z.coerce.number(),
-  RATE_LIMIT_DATA_MAX: z.coerce.number(),
-  RATE_LIMIT_SWAP_RATES_MAX: z.coerce.number(),
-  RATE_LIMIT_SWAP_QUOTE_MAX: z.coerce.number(),
-  RATE_LIMIT_SWAP_STATUS_MAX: z.coerce.number(),
-  RATE_LIMIT_AFFILIATE_STATS_MAX: z.coerce.number(),
-  RATE_LIMIT_AFFILIATE_MUTATION_MAX: z.coerce.number(),
+  RATE_LIMIT_GLOBAL_MAX: z.coerce.number().int().min(1),
+  RATE_LIMIT_DATA_MAX: z.coerce.number().int().min(1),
+  RATE_LIMIT_SWAP_RATES_MAX: z.coerce.number().int().min(1),
+  RATE_LIMIT_SWAP_QUOTE_MAX: z.coerce.number().int().min(1),
+  RATE_LIMIT_SWAP_STATUS_MAX: z.coerce.number().int().min(1),
+  RATE_LIMIT_AFFILIATE_STATS_MAX: z.coerce.number().int().min(1),
+  RATE_LIMIT_AFFILIATE_MUTATION_MAX: z.coerce.number().int().min(1),
 })
 
 const result = envSchema.safeParse(process.env)

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -1,0 +1,88 @@
+import { z } from 'zod'
+
+const url = z.string().url()
+const flag = z.string().transform(v => v === 'true')
+
+const envSchema = z.object({
+  // Server
+  PORT: z.string().default('3005'),
+  NODE_ENV: z.string().default('development'),
+
+  // Swap service
+  SWAP_SERVICE_BASE_URL: url,
+
+  // Unchained URLs
+  UNCHAINED_ETHEREUM_HTTP_URL: url,
+  UNCHAINED_BITCOIN_HTTP_URL: url,
+  UNCHAINED_THORCHAIN_HTTP_URL: url,
+  UNCHAINED_MAYACHAIN_HTTP_URL: url,
+  UNCHAINED_COSMOS_HTTP_URL: url,
+  UNCHAINED_AVALANCHE_HTTP_URL: url,
+  UNCHAINED_BNBSMARTCHAIN_HTTP_URL: url,
+  UNCHAINED_BASE_HTTP_URL: url,
+  UNCHAINED_ARBITRUM_HTTP_URL: url,
+  UNCHAINED_OPTIMISM_HTTP_URL: url,
+  UNCHAINED_POLYGON_HTTP_URL: url,
+  UNCHAINED_GNOSIS_HTTP_URL: url,
+  UNCHAINED_DOGECOIN_HTTP_URL: url,
+  UNCHAINED_LITECOIN_HTTP_URL: url,
+  UNCHAINED_BITCOINCASH_HTTP_URL: url,
+
+  // Node URLs
+  THORCHAIN_NODE_URL: url,
+  MAYACHAIN_NODE_URL: url,
+  TRON_NODE_URL: url,
+  SUI_NODE_URL: url,
+
+  // Midgard URLs
+  THORCHAIN_MIDGARD_URL: url,
+  MAYACHAIN_MIDGARD_URL: url,
+
+  // Swapper API URLs
+  COWSWAP_BASE_URL: url,
+  PORTALS_BASE_URL: url,
+  ZRX_BASE_URL: url,
+  JUPITER_API_URL: url,
+  RELAY_API_URL: url,
+  ACROSS_API_URL: url,
+  DEBRIDGE_API_URL: url,
+  CHAINFLIP_API_URL: url,
+
+  // Swapper API keys (optional)
+  CHAINFLIP_API_KEY: z.string().default(''),
+  BEBOP_API_KEY: z.string().default(''),
+  NEAR_INTENTS_API_KEY: z.string().default(''),
+  TENDERLY_API_KEY: z.string().default(''),
+  TENDERLY_ACCOUNT_SLUG: z.string().default(''),
+  TENDERLY_PROJECT_SLUG: z.string().default(''),
+  ACROSS_INTEGRATOR_ID: z.string().default(''),
+
+  // Feature flags
+  FEATURE_THORCHAINSWAP_LONGTAIL: flag,
+  FEATURE_THORCHAINSWAP_L1_TO_LONGTAIL: flag,
+  FEATURE_CHAINFLIP_SWAP_DCA: flag,
+
+  // Affiliate
+  DEFAULT_AFFILIATE_BPS: z.string(),
+
+  // Rate limiting
+  RATE_LIMIT_GLOBAL_MAX: z.coerce.number(),
+  RATE_LIMIT_DATA_MAX: z.coerce.number(),
+  RATE_LIMIT_SWAP_RATES_MAX: z.coerce.number(),
+  RATE_LIMIT_SWAP_QUOTE_MAX: z.coerce.number(),
+  RATE_LIMIT_SWAP_STATUS_MAX: z.coerce.number(),
+  RATE_LIMIT_AFFILIATE_STATS_MAX: z.coerce.number(),
+  RATE_LIMIT_AFFILIATE_MUTATION_MAX: z.coerce.number(),
+})
+
+const result = envSchema.safeParse(process.env)
+
+if (!result.success) {
+  console.error('Missing or invalid environment variables:')
+  for (const issue of result.error.issues) {
+    console.error(`  ${issue.path.join('.')}: ${issue.message}`)
+  }
+  process.exit(1)
+}
+
+export const env = result.data

--- a/packages/public-api/src/index.ts
+++ b/packages/public-api/src/index.ts
@@ -4,7 +4,6 @@ import cors from 'cors'
 import express from 'express'
 
 import { getAssetsById, initAssets } from './assets'
-import { API_HOST, API_PORT } from './config'
 import { quoteStore } from './lib/quoteStore'
 import { resolvePartnerCode } from './middleware/auth'
 import {
@@ -23,13 +22,15 @@ import { getRates } from './routes/rates'
 import { getSwapStatus } from './routes/status'
 import { initSwapperDeps } from './swapperDeps'
 
+const PORT = process.env.PORT || '3001'
+
 const startServer = async () => {
   await initAssets()
   initSwapperDeps(getAssetsById())
 
   const app = express()
 
-  app.set('trust proxy', process.env.TRUST_PROXY === '1' ? 1 : false)
+  app.set('trust proxy', 1)
 
   app.use(cors())
   app.use(express.json())
@@ -74,8 +75,8 @@ const startServer = async () => {
     },
   )
 
-  app.listen(API_PORT, API_HOST, () => {
-    console.log(`Public API server running at http://${API_HOST}:${API_PORT}`)
+  app.listen(PORT, () => {
+    console.log(`Public API server running on port: ${PORT}`)
   })
 }
 

--- a/packages/public-api/src/index.ts
+++ b/packages/public-api/src/index.ts
@@ -4,6 +4,7 @@ import cors from 'cors'
 import express from 'express'
 
 import { getAssetsById, initAssets } from './assets'
+import { env } from './env'
 import { quoteStore } from './lib/quoteStore'
 import { resolvePartnerCode } from './middleware/auth'
 import {
@@ -21,8 +22,6 @@ import { getQuote } from './routes/quote'
 import { getRates } from './routes/rates'
 import { getSwapStatus } from './routes/status'
 import { initSwapperDeps } from './swapperDeps'
-
-const PORT = process.env.PORT || '3001'
 
 const startServer = async () => {
   await initAssets()
@@ -75,8 +74,8 @@ const startServer = async () => {
     },
   )
 
-  app.listen(PORT, () => {
-    console.log(`Public API server running on port: ${PORT}`)
+  app.listen(env.PORT, () => {
+    console.log(`Public API server running on port: ${env.PORT}`)
   })
 }
 

--- a/packages/public-api/src/middleware/auth.ts
+++ b/packages/public-api/src/middleware/auth.ts
@@ -1,15 +1,12 @@
 import type { NextFunction, Request, Response } from 'express'
 
-const DEFAULT_AFFILIATE_BPS = '60'
-
-// Microservices URL for partner code resolution
-const MICROSERVICES_URL = process.env.MICROSERVICES_URL || 'http://localhost:3001'
+import { env } from '../env'
 
 const resolvePartnerCodeFromService = async (
   code: string,
 ): Promise<{ affiliateAddress: string; bps: string } | null> => {
   try {
-    const response = await fetch(`${MICROSERVICES_URL}/v1/partner/${encodeURIComponent(code)}`)
+    const response = await fetch(`${env.SWAP_SERVICE_BASE_URL}/v1/partner/${encodeURIComponent(code)}`)
 
     if (response.ok) {
       const data = (await response.json()) as {
@@ -51,7 +48,7 @@ export const resolvePartnerCode = async (
 
   // No partner code provided — use default BPS for unattributed swaps
   req.affiliateInfo = {
-    affiliateBps: DEFAULT_AFFILIATE_BPS,
+    affiliateBps: env.DEFAULT_AFFILIATE_BPS,
   }
 
   next()

--- a/packages/public-api/src/middleware/auth.ts
+++ b/packages/public-api/src/middleware/auth.ts
@@ -6,7 +6,9 @@ const resolvePartnerCodeFromService = async (
   code: string,
 ): Promise<{ affiliateAddress: string; bps: string } | null> => {
   try {
-    const response = await fetch(`${env.SWAP_SERVICE_BASE_URL}/v1/partner/${encodeURIComponent(code)}`)
+    const response = await fetch(
+      `${env.SWAP_SERVICE_BASE_URL}/v1/partner/${encodeURIComponent(code)}`,
+    )
 
     if (response.ok) {
       const data = (await response.json()) as {

--- a/packages/public-api/src/middleware/rateLimit.ts
+++ b/packages/public-api/src/middleware/rateLimit.ts
@@ -1,17 +1,12 @@
 import type { Options, RateLimitRequestHandler } from 'express-rate-limit'
 import rateLimit from 'express-rate-limit'
 
+import { env } from '../env'
+
 const WINDOW_MS = 60 * 1000
 
 export enum RateLimitErrorCode {
   RateLimitExceeded = 'RATE_LIMIT_EXCEEDED',
-}
-
-const parseEnvInt = (key: string, defaultValue: number): number => {
-  const value = process.env[key]
-  if (!value) return defaultValue
-  const parsed = parseInt(value, 10)
-  return isNaN(parsed) ? defaultValue : parsed
 }
 
 const rateLimitHandler: Options['handler'] = (_req, res) => {
@@ -21,18 +16,19 @@ const rateLimitHandler: Options['handler'] = (_req, res) => {
   })
 }
 
-const createLimiter = (envKey: string, defaultMax: number): RateLimitRequestHandler =>
+const createLimiter = (max: number): RateLimitRequestHandler =>
   rateLimit({
     windowMs: WINDOW_MS,
-    max: parseEnvInt(envKey, defaultMax),
+    max,
     standardHeaders: 'draft-7',
     legacyHeaders: false,
     handler: rateLimitHandler,
   })
 
-export const globalLimiter = createLimiter('RATE_LIMIT_GLOBAL_MAX', 300)
-export const dataLimiter = createLimiter('RATE_LIMIT_DATA_MAX', 120)
-export const swapRatesLimiter = createLimiter('RATE_LIMIT_SWAP_RATES_MAX', 60)
-export const swapQuoteLimiter = createLimiter('RATE_LIMIT_SWAP_QUOTE_MAX', 45)
-export const swapStatusLimiter = createLimiter('RATE_LIMIT_SWAP_STATUS_MAX', 60)
-export const affiliateStatsLimiter = createLimiter('RATE_LIMIT_AFFILIATE_STATS_MAX', 30)
+export const globalLimiter = createLimiter(env.RATE_LIMIT_GLOBAL_MAX)
+export const dataLimiter = createLimiter(env.RATE_LIMIT_DATA_MAX)
+export const swapRatesLimiter = createLimiter(env.RATE_LIMIT_SWAP_RATES_MAX)
+export const swapQuoteLimiter = createLimiter(env.RATE_LIMIT_SWAP_QUOTE_MAX)
+export const swapStatusLimiter = createLimiter(env.RATE_LIMIT_SWAP_STATUS_MAX)
+export const affiliateStatsLimiter = createLimiter(env.RATE_LIMIT_AFFILIATE_STATS_MAX)
+export const affiliateMutationLimiter = createLimiter(env.RATE_LIMIT_AFFILIATE_MUTATION_MAX)

--- a/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
+++ b/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express'
 
-import { SWAP_SERVICE_BASE_URL } from '../../config'
+import { env } from '../../env'
 import { registry } from '../../registry'
 import type { ErrorResponse } from '../../types'
 import type { AffiliateStatsResponse } from './types'
@@ -59,7 +59,7 @@ export const getAffiliateStats = async (req: Request, res: Response): Promise<vo
     const { address, startDate, endDate } = parseResult.data
 
     // Build backend URL with query params
-    const backendUrl = new URL(`/swaps/affiliate-fees/${address}`, SWAP_SERVICE_BASE_URL)
+    const backendUrl = new URL(`/swaps/affiliate-fees/${address}`, env.SWAP_SERVICE_BASE_URL)
     if (startDate) {
       backendUrl.searchParams.append('startDate', String(startDate))
     }

--- a/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
+++ b/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
@@ -59,7 +59,7 @@ export const getAffiliateStats = async (req: Request, res: Response): Promise<vo
     const { address, startDate, endDate } = parseResult.data
 
     // Build backend URL with query params
-    const backendUrl = new URL(`/swaps/affiliate-fees/${address}`, env.SWAP_SERVICE_BASE_URL)
+    const backendUrl = new URL(`${env.SWAP_SERVICE_BASE_URL}/swaps/affiliate-fees/${address}`)
     if (startDate) {
       backendUrl.searchParams.append('startDate', String(startDate))
     }

--- a/packages/public-api/src/routes/status/getSwapStatus.ts
+++ b/packages/public-api/src/routes/status/getSwapStatus.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express'
 
-import { quoteStore } from '../../lib/quoteStore'
 import { env } from '../../env'
+import { quoteStore } from '../../lib/quoteStore'
 import { registry } from '../../registry'
 import type { ErrorResponse } from '../../types'
 import { PartnerCodeHeaderSchema } from '../../types'

--- a/packages/public-api/src/routes/status/getSwapStatus.ts
+++ b/packages/public-api/src/routes/status/getSwapStatus.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express'
 
-import { SWAP_SERVICE_BASE_URL } from '../../config'
 import { quoteStore } from '../../lib/quoteStore'
+import { env } from '../../env'
 import { registry } from '../../registry'
 import type { ErrorResponse } from '../../types'
 import { PartnerCodeHeaderSchema } from '../../types'
@@ -103,7 +103,7 @@ export const getSwapStatus = async (req: Request, res: Response): Promise<void> 
       const getController = new AbortController()
       const getTimeout = setTimeout(() => getController.abort(), STATUS_TIMEOUT_MS)
       try {
-        const swapResponse = await fetch(`${SWAP_SERVICE_BASE_URL}/swaps/${quoteId}`, {
+        const swapResponse = await fetch(`${env.SWAP_SERVICE_BASE_URL}/swaps/${quoteId}`, {
           signal: getController.signal,
         })
         if (swapResponse.ok) {

--- a/packages/public-api/src/routes/status/utils.ts
+++ b/packages/public-api/src/routes/status/utils.ts
@@ -1,5 +1,5 @@
 import { getAsset } from '../../assets'
-import { SWAP_SERVICE_BASE_URL } from '../../config'
+import { env } from '../../env'
 import type { quoteStore } from '../../lib/quoteStore'
 import { STATUS_TIMEOUT_MS } from './constants'
 
@@ -53,7 +53,7 @@ export const registerSwapInService = async (
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), STATUS_TIMEOUT_MS)
   try {
-    const postResponse = await fetch(`${SWAP_SERVICE_BASE_URL}/swaps`, {
+    const postResponse = await fetch(`${env.SWAP_SERVICE_BASE_URL}/swaps`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       signal: controller.signal,

--- a/packages/public-api/src/swapperDeps.ts
+++ b/packages/public-api/src/swapperDeps.ts
@@ -16,6 +16,7 @@ import type { AssetsByIdPartial } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 
 import { getServerConfig } from './config'
+import { env } from './env'
 
 type GasFeeData = {
   gasPrice: string
@@ -35,33 +36,23 @@ type UtxoNetworkFees = {
   slow: { satsPerKiloByte: number }
 }
 
-const getEvmUnchainedUrls = (): Record<string, string> => {
-  const config = getServerConfig()
-  return {
-    [KnownChainIds.EthereumMainnet]: config.VITE_UNCHAINED_ETHEREUM_HTTP_URL,
-    [KnownChainIds.ArbitrumMainnet]:
-      process.env.UNCHAINED_ARBITRUM_HTTP_URL || 'https://api.arbitrum.shapeshift.com',
-    [KnownChainIds.OptimismMainnet]:
-      process.env.UNCHAINED_OPTIMISM_HTTP_URL || 'https://api.optimism.shapeshift.com',
-    [KnownChainIds.PolygonMainnet]:
-      process.env.UNCHAINED_POLYGON_HTTP_URL || 'https://api.polygon.shapeshift.com',
-    [KnownChainIds.GnosisMainnet]:
-      process.env.UNCHAINED_GNOSIS_HTTP_URL || 'https://api.gnosis.shapeshift.com',
-    [KnownChainIds.AvalancheMainnet]: config.VITE_UNCHAINED_AVALANCHE_HTTP_URL,
-    [KnownChainIds.BnbSmartChainMainnet]: config.VITE_UNCHAINED_BNBSMARTCHAIN_HTTP_URL,
-    [KnownChainIds.BaseMainnet]: config.VITE_UNCHAINED_BASE_HTTP_URL,
-  }
-}
+const getEvmUnchainedUrls = (): Record<string, string> => ({
+  [KnownChainIds.EthereumMainnet]: env.UNCHAINED_ETHEREUM_HTTP_URL,
+  [KnownChainIds.ArbitrumMainnet]: env.UNCHAINED_ARBITRUM_HTTP_URL,
+  [KnownChainIds.OptimismMainnet]: env.UNCHAINED_OPTIMISM_HTTP_URL,
+  [KnownChainIds.PolygonMainnet]: env.UNCHAINED_POLYGON_HTTP_URL,
+  [KnownChainIds.GnosisMainnet]: env.UNCHAINED_GNOSIS_HTTP_URL,
+  [KnownChainIds.AvalancheMainnet]: env.UNCHAINED_AVALANCHE_HTTP_URL,
+  [KnownChainIds.BnbSmartChainMainnet]: env.UNCHAINED_BNBSMARTCHAIN_HTTP_URL,
+  [KnownChainIds.BaseMainnet]: env.UNCHAINED_BASE_HTTP_URL,
+})
 
-const getUtxoUnchainedUrls = (): Record<string, string> => {
-  const config = getServerConfig()
-  return {
-    [KnownChainIds.BitcoinMainnet]: config.VITE_UNCHAINED_BITCOIN_HTTP_URL,
-    [KnownChainIds.DogecoinMainnet]: config.VITE_UNCHAINED_DOGECOIN_HTTP_URL,
-    [KnownChainIds.LitecoinMainnet]: config.VITE_UNCHAINED_LITECOIN_HTTP_URL,
-    [KnownChainIds.BitcoinCashMainnet]: config.VITE_UNCHAINED_BITCOINCASH_HTTP_URL,
-  }
-}
+const getUtxoUnchainedUrls = (): Record<string, string> => ({
+  [KnownChainIds.BitcoinMainnet]: env.UNCHAINED_BITCOIN_HTTP_URL,
+  [KnownChainIds.DogecoinMainnet]: env.UNCHAINED_DOGECOIN_HTTP_URL,
+  [KnownChainIds.LitecoinMainnet]: env.UNCHAINED_LITECOIN_HTTP_URL,
+  [KnownChainIds.BitcoinCashMainnet]: env.UNCHAINED_BITCOINCASH_HTTP_URL,
+})
 
 const GAS_FEES_TIMEOUT_MS = 10_000
 


### PR DESCRIPTION
## Summary

- Fix production Docker image by mirroring monorepo directory structure so `__dirname`-relative paths work for both docs and asset data — no env vars needed
- Add env.ts with Zod schema validation — server fails fast at startup with clear errors for any missing or invalid env vars, eliminating all process.env reads and fallbacks scattered across the codebase
- Hardcode `trust proxy: 1` (required for `express-rate-limit` to correctly identify client IPs behind Railway's proxy)
- Remove SWAP_SERVICE_BASE_URL re-export from config.ts — all usages read from env directly
- Remove MICROSERVICES_URL — partner code resolution now uses SWAP_SERVICE_BASE_URL consistently
- Expose DEFAULT_AFFILIATE_BPS as a configurable env var
- Simplify `PORT` — no `parseInt` needed since `app.listen` accepts strings
- Remove unused `API_HOST`, `API_PORT` config and `TRUST_PROXY`/`ASSET_DATA_PATH` env vars
- Simplify asset loading to a single `__dirname`-relative path instead of a fallback array
- Comprehensive .env.example with all vars explicit and pointing to dev endpoints

## Test plan
- [x] Docker image builds and starts without errors
- [x] `/health` responds correctly
- [x] `/docs` loads without ENOENT errors
- [x] Assets load correctly (31k+ assets)
- [x] Rate limiting works correctly with `trust proxy: 1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated default environment example with many concrete service endpoints, API key placeholders, affiliate/feature flags, and extended rate-limit defaults.
  * Added runtime environment validation to detect misconfiguration and fail fast.
  * Adjusted asset data resolution and container image/startup layout for the public API.
* **Refactor**
  * Centralized environment sourcing for server startup, middleware, and service integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->