### PR TITLE
fix: asset generation scripts

### DIFF
--- a/scripts/generateAssetData/coingecko.ts
+++ b/scripts/generateAssetData/coingecko.ts
@@ -87,8 +87,20 @@ import {
   zkSyncEra,
 } from '@shapeshiftoss/utils'
 import axios from 'axios'
+import axiosRetry from 'axios-retry'
 
 import colormap from './color-map.json'
+
+axiosRetry(axios, {
+  retries: 5,
+  retryCondition: err => {
+    return axiosRetry.isNetworkOrIdempotentRequestError(err) || err.response?.status === 429
+  },
+  retryDelay: (retryCount, err) => {
+    const retryAfter = Number(err.response?.headers?.['retry-after'])
+    return isFinite(retryAfter) ? retryAfter * 1000 : axiosRetry.exponentialDelay(retryCount)
+  },
+})
 
 export const colorMap: Record<string, string> = colormap
 

--- a/scripts/generateAssetData/generateRelatedAssetIndex/generateChainRelatedAssetIndex.ts
+++ b/scripts/generateAssetData/generateRelatedAssetIndex/generateChainRelatedAssetIndex.ts
@@ -308,8 +308,6 @@ const processRelatedAssetIds = async (
     return
   }
 
-  console.log(`Processing related assetIds for ${assetId}`)
-
   for (const [key, relatedAssets] of Object.entries(relatedAssetIndex)) {
     if (relatedAssets.includes(assetId)) {
       if (existingRelatedAssetKey !== key) {

--- a/scripts/generateAssetData/generateRelatedAssetIndex/generateRelatedAssetIndex.ts
+++ b/scripts/generateAssetData/generateRelatedAssetIndex/generateRelatedAssetIndex.ts
@@ -317,8 +317,6 @@ const processRelatedAssetIds = async (
     return
   }
 
-  console.log(`Processing related assetIds for ${assetId}`)
-
   // Check if this asset is already in the relatedAssetIndex
   if (!REGEN_ALL) {
     for (const [key, relatedAssets] of Object.entries(relatedAssetIndex)) {

--- a/scripts/generateAssetData/generateRelatedAssetIndex/validators/fungible.ts
+++ b/scripts/generateAssetData/generateRelatedAssetIndex/validators/fungible.ts
@@ -1,9 +1,11 @@
 import type { Infer } from 'myzod'
 import z from 'myzod'
 
-const IconSchema = z.object({
-  url: z.string(),
-})
+const IconSchema = z
+  .object({
+    url: z.string(),
+  })
+  .allowUnknownKeys()
 
 const ExternalLinkSchema = z.object({
   type: z.string(),
@@ -11,11 +13,13 @@ const ExternalLinkSchema = z.object({
   url: z.string(),
 })
 
-const ImplementationSchema = z.object({
-  chain_id: z.string(),
-  address: z.string().nullable().optional(),
-  decimals: z.number(),
-})
+const ImplementationSchema = z
+  .object({
+    chain_id: z.string(),
+    address: z.string().nullable().optional(),
+    decimals: z.number(),
+  })
+  .allowUnknownKeys()
 
 export type ZerionImplementation = Infer<typeof ImplementationSchema>
 
@@ -26,29 +30,33 @@ const ChangesSchema = z.object({
   percent_365d: z.number().nullable().optional(),
 })
 
-const MarketDataSchema = z.object({
-  total_supply: z.number().nullable(),
-  circulating_supply: z.number().nullable(),
-  market_cap: z.number().nullable(),
-  fully_diluted_valuation: z.number().nullable(),
-  price: z.number().nullable(),
-  changes: ChangesSchema,
-})
+const MarketDataSchema = z
+  .object({
+    total_supply: z.number().nullable(),
+    circulating_supply: z.number().nullable(),
+    market_cap: z.number().nullable(),
+    fully_diluted_valuation: z.number().nullable(),
+    price: z.number().nullable(),
+    changes: ChangesSchema,
+  })
+  .allowUnknownKeys()
 
-const AttributesSchema = z.object({
-  name: z.string(),
-  symbol: z.string(),
-  description: z.string().nullable(),
-  icon: IconSchema.nullable().optional(),
-  flags: z
-    .object({
-      verified: z.boolean(),
-    })
-    .optional(),
-  external_links: z.array(ExternalLinkSchema).optional(),
-  implementations: z.array(ImplementationSchema).optional(),
-  market_data: MarketDataSchema,
-})
+const AttributesSchema = z
+  .object({
+    name: z.string(),
+    symbol: z.string(),
+    description: z.string().nullable(),
+    icon: IconSchema.nullable().optional(),
+    flags: z
+      .object({
+        verified: z.boolean(),
+      })
+      .optional(),
+    external_links: z.array(ExternalLinkSchema).optional(),
+    implementations: z.array(ImplementationSchema).optional(),
+    market_data: MarketDataSchema,
+  })
+  .allowUnknownKeys()
 
 const ChartSchema = z.object({
   links: z.object({
@@ -60,15 +68,17 @@ const ChartSchema = z.object({
   }),
 })
 
-const RelationshipsSchema = z.object({
-  chart_day: ChartSchema,
-  chart_hour: ChartSchema,
-  chart_max: ChartSchema,
-  chart_month: ChartSchema,
-  chart_week: ChartSchema,
-  chart_year: ChartSchema,
-  chart_3months: ChartSchema,
-})
+const RelationshipsSchema = z
+  .object({
+    chart_day: ChartSchema,
+    chart_hour: ChartSchema,
+    chart_max: ChartSchema,
+    chart_month: ChartSchema,
+    chart_week: ChartSchema,
+    chart_year: ChartSchema,
+    chart_3months: ChartSchema,
+  })
+  .allowUnknownKeys()
 
 const LinksSchema = z.object({
   self: z.string(),

--- a/scripts/generateAssetData/generateRelatedAssetIndex/validators/fungible.ts
+++ b/scripts/generateAssetData/generateRelatedAssetIndex/validators/fungible.ts
@@ -51,6 +51,7 @@ const AttributesSchema = z
       .object({
         verified: z.boolean(),
       })
+      .allowUnknownKeys()
       .optional(),
     external_links: z.array(ExternalLinkSchema).optional(),
     implementations: z.array(ImplementationSchema).optional(),

--- a/scripts/generateAssetData/setColors.ts
+++ b/scripts/generateAssetData/setColors.ts
@@ -1,4 +1,5 @@
 import type { Asset } from '@shapeshiftoss/types'
+import axios from 'axios'
 
 const colorThief = require('colorthief') as any
 
@@ -10,17 +11,19 @@ export const setColors = async (assets: Asset[]): Promise<Asset[]> => {
   for await (const [index, asset] of filteredAssets.entries()) {
     try {
       if (asset.color === '#FFFFFF' && asset.icon) {
-        // colorThief.getColor returns the most dominant color in the icon.
-        const [r, g, b] = await colorThief.getColor(asset.icon)
+        // colorthief passes the argument directly to sharp, which only handles file paths — not URLs.
+        // Fetch to a buffer first so sharp can process it.
+        const { data } = await axios.get<ArrayBuffer>(asset.icon, { responseType: 'arraybuffer' })
+        const [r, g, b] = await colorThief.getColor(Buffer.from(data))
         const hexColor = `#${toHex(r)}${toHex(g)}${toHex(b)}`
         asset.color = hexColor
       }
     } catch (err) {
-      console.error(err)
-      console.info(
+      const message = err instanceof Error ? err.message : String(err)
+      console.warn(
         `${index + 1}/${filteredAssets.length} Could not get color for ${asset.assetId} iconUrl: ${
           asset.icon
-        }`,
+        } — ${message}`,
       )
     }
   }

--- a/scripts/generateAssetData/setColors.ts
+++ b/scripts/generateAssetData/setColors.ts
@@ -13,7 +13,10 @@ export const setColors = async (assets: Asset[]): Promise<Asset[]> => {
       if (asset.color === '#FFFFFF' && asset.icon) {
         // colorthief passes the argument directly to sharp, which only handles file paths — not URLs.
         // Fetch to a buffer first so sharp can process it.
-        const { data } = await axios.get<ArrayBuffer>(asset.icon, { responseType: 'arraybuffer' })
+        const { data } = await axios.get<ArrayBuffer>(asset.icon, {
+          responseType: 'arraybuffer',
+          timeout: 10_000,
+        })
         const [r, g, b] = await colorThief.getColor(Buffer.from(data))
         const hexColor = `#${toHex(r)}${toHex(g)}${toHex(b)}`
         asset.color = hexColor

--- a/src/lib/portals/constants.ts
+++ b/src/lib/portals/constants.ts
@@ -5,6 +5,7 @@ import {
   baseChainId,
   bscChainId,
   ethChainId,
+  gnosisChainId,
   hyperEvmChainId,
   optimismChainId,
   polygonChainId,
@@ -14,6 +15,7 @@ import invert from 'lodash/invert'
 export const CHAIN_ID_TO_PORTALS_NETWORK: Partial<Record<ChainId, string>> = {
   [avalancheChainId]: 'avalanche',
   [ethChainId]: 'ethereum',
+  [gnosisChainId]: 'gnosis',
   [polygonChainId]: 'polygon',
   [bscChainId]: 'bsc',
   [optimismChainId]: 'optimism',


### PR DESCRIPTION
## Description

Fixes several issues with the asset data generation scripts.

## Changes

- **CoinGecko 429 rate limiting**: Added `axios-retry` (already a repo dependency) to automatically retry requests with exponential backoff, honoring the `retry-after` header
- **colorthief color generation**: `colorthief` 2.6.0 switched from `get-pixels` to `sharp`, which doesn't fetch HTTP URLs. Fixed by fetching the image to a buffer with axios before passing to colorthief
- **Zerion fungible schema**: API now returns additional fields (`trading_volumes` in `market_data`, `chart_5years`/`chart_6months` in relationships, `market_data`/`deployment_date` in implementations). Added `.allowUnknownKeys()` to affected schemas
- **Portals gnosis mapping**: Missing `gnosisChainId` entry caused `networks: []` to be passed to the Portals API, which returned all ~13,347 tokens across all networks instead of gnosis-only tokens
- **Noise reduction**: Removed per-asset `console.log` in `processRelatedAssetIds`

## Testing

- [x] Run `pnpm run generate:asset-data` and verify no 429 failures, color generation errors, or Zerion parse errors
- [x] Verify Portals gnosis token count is reasonable (not ~13,347)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the Gnosis network.

* **Chores**
  * Improved API request reliability with automatic retry handling for transient failures.
  * Relaxed asset data validation to accept additional fields without breaking processing.
  * Enhanced icon color extraction to improve dominant color detection and error reporting.
  * Removed verbose per-asset debug logging during asset generation to reduce noise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->