### PR TITLE
fix: display requiresBalance protocol fees in network fee UI

### DIFF
--- a/packages/swapper/src/swappers/DebridgeSwapper/utils/fetchDebridgeTrade.ts
+++ b/packages/swapper/src/swappers/DebridgeSwapper/utils/fetchDebridgeTrade.ts
@@ -16,7 +16,7 @@ export type DebridgeFetchQuoteParams = {
   srcChainOrderAuthorityAddress?: string
   dstChainOrderAuthorityAddress?: string
   senderAddress?: string
-  prependOperatingExpenses: 'true'
+  prependOperatingExpenses: 'true' | 'false'
   affiliateFeePercent?: string
   affiliateFeeRecipient?: string
 }

--- a/packages/swapper/src/swappers/DebridgeSwapper/utils/getTrade.ts
+++ b/packages/swapper/src/swappers/DebridgeSwapper/utils/getTrade.ts
@@ -156,7 +156,7 @@ export async function getTrade<T extends 'quote' | 'rate'>({
       srcChainOrderAuthorityAddress: senderAddress,
       dstChainOrderAuthorityAddress: recipientAddress,
       senderAddress,
-      prependOperatingExpenses: 'true',
+      prependOperatingExpenses: 'false',
       affiliateFeePercent,
       affiliateFeeRecipient,
     },
@@ -178,9 +178,7 @@ export async function getTrade<T extends 'quote' | 'rate'>({
     buyAsset,
   })
 
-  const nativePreFee = bnOrZero(quote.fixFee)
-    .plus(bnOrZero(quote.prependedOperatingExpenseCost))
-    .toFixed()
+  const fixFee = bnOrZero(quote.fixFee).toFixed()
 
   const buyAmountBeforeFeesCryptoBaseUnit = buyAmountAfterFeesCryptoBaseUnit
 
@@ -222,10 +220,10 @@ export async function getTrade<T extends 'quote' | 'rate'>({
     feeData: {
       networkFeeCryptoBaseUnit,
       protocolFees:
-        protocolFeeAssetIdForFees && bnOrZero(nativePreFee).gt(0)
+        protocolFeeAssetIdForFees && bnOrZero(fixFee).gt(0)
           ? {
               [protocolFeeAssetIdForFees]: {
-                amountCryptoBaseUnit: nativePreFee,
+                amountCryptoBaseUnit: fixFee,
                 asset: getBaseAsset(sellAsset.chainId),
                 requiresBalance: true,
               },

--- a/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
+++ b/src/components/MultiHopTrade/components/TradeConfirm/TradeConfirmFooter.tsx
@@ -69,13 +69,24 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
   const quoteNetworkFeeCryptoBaseUnit = tradeQuoteStep.feeData.networkFeeCryptoBaseUnit
   const feeAsset = useSelectorWithArgs(selectFeeAssetById, tradeQuoteStep.sellAsset.assetId)
   const sellAsset = useSelectorWithArgs(selectAssetById, tradeQuoteStep.sellAsset.assetId)
+
+  // Include requiresBalance protocol fees denominated in the fee asset (e.g. deBridge fixFee)
+  const requiresBalanceProtocolFeeCryptoBaseUnit = useMemo(() => {
+    if (!feeAsset) return '0'
+    const protocolFee = tradeQuoteStep.feeData.protocolFees?.[feeAsset.assetId]
+    if (!protocolFee?.requiresBalance) return '0'
+    return protocolFee.amountCryptoBaseUnit
+  }, [feeAsset, tradeQuoteStep.feeData.protocolFees])
+
   const quoteNetworkFeeCryptoPrecision = useMemo(
     () =>
       BigAmount.fromBaseUnit({
-        value: quoteNetworkFeeCryptoBaseUnit,
+        value: bnOrZero(quoteNetworkFeeCryptoBaseUnit)
+          .plus(requiresBalanceProtocolFeeCryptoBaseUnit)
+          .toString(),
         precision: feeAsset?.precision ?? 0,
       }).toPrecision(),
-    [quoteNetworkFeeCryptoBaseUnit, feeAsset?.precision],
+    [quoteNetworkFeeCryptoBaseUnit, requiresBalanceProtocolFeeCryptoBaseUnit, feeAsset?.precision],
   )
   const feeAssetUserCurrencyRate = useSelectorWithArgs(
     selectMarketDataByAssetIdUserCurrency,
@@ -172,10 +183,17 @@ export const TradeConfirmFooter: FC<TradeConfirmFooterProps> = ({
     if (!networkFeeCryptoBaseUnit) return quoteNetworkFeeCryptoPrecision
 
     return BigAmount.fromBaseUnit({
-      value: networkFeeCryptoBaseUnit,
+      value: bnOrZero(networkFeeCryptoBaseUnit)
+        .plus(requiresBalanceProtocolFeeCryptoBaseUnit)
+        .toString(),
       precision: feeAsset?.precision ?? 0,
     }).toPrecision()
-  }, [networkFeeCryptoBaseUnit, feeAsset?.precision, quoteNetworkFeeCryptoPrecision])
+  }, [
+    networkFeeCryptoBaseUnit,
+    requiresBalanceProtocolFeeCryptoBaseUnit,
+    feeAsset?.precision,
+    quoteNetworkFeeCryptoPrecision,
+  ])
 
   const networkFeeUserCurrency = useMemo(() => {
     return bnOrZero(networkFeeCryptoPrecision)

--- a/src/state/slices/tradeQuoteSlice/helpers.ts
+++ b/src/state/slices/tradeQuoteSlice/helpers.ts
@@ -42,6 +42,35 @@ export const getHopTotalNetworkFeeUserCurrency = (
 }
 
 /**
+ * Computes the user-currency value of protocol fees that require a balance (i.e. paid out-of-pocket
+ * like a network fee, not deducted from the trade output) for a single trade step.
+ */
+export const getRequiresBalanceProtocolFeeUserCurrency = (
+  step: TradeQuoteStep,
+  getUserCurrencyRate: (assetId: AssetId) => string | undefined,
+): BigNumber => {
+  if (!step.feeData.protocolFees) return bn(0)
+
+  return Object.entries(step.feeData.protocolFees).reduce<BigNumber>(
+    (acc, [assetId, protocolFee]) => {
+      if (!protocolFee?.requiresBalance) return acc
+      if (bnOrZero(protocolFee?.amountCryptoBaseUnit).isZero()) return acc
+
+      const rate = getUserCurrencyRate(assetId) ?? '0'
+      const feeUserCurrency = BigAmount.fromBaseUnit({
+        value: protocolFee.amountCryptoBaseUnit,
+        precision: protocolFee.asset.precision,
+      })
+        .times(rate)
+        .toBN()
+
+      return acc.plus(feeUserCurrency)
+    },
+    bn(0),
+  )
+}
+
+/**
  * Computes the total network fee across all hops
  * @param quote The trade quote
  * @param getFeeAsset
@@ -53,8 +82,13 @@ export const getTotalNetworkFeeUserCurrencyPrecision = (
   getFeeAsset: (assetId: AssetId) => Asset,
   getFeeAssetRate: (feeAssetId: AssetId) => string | undefined,
 ): BigNumber | undefined => {
-  // network fee is unknown, which is different than it being akschual 0
-  if (quote.steps.every(step => !step.feeData.networkFeeCryptoBaseUnit)) return
+  const hasAnyNetworkFee = quote.steps.some(step => step.feeData.networkFeeCryptoBaseUnit)
+  const hasAnyRequiresBalanceProtocolFee = quote.steps.some(step =>
+    Object.values(step.feeData.protocolFees ?? {}).some(fee => fee?.requiresBalance),
+  )
+
+  // All fees are unknown - bail early. Note this is different than fees being 0.
+  if (!hasAnyNetworkFee && !hasAnyRequiresBalanceProtocolFee) return
 
   return quote.steps.reduce((acc, step) => {
     const feeAsset = getFeeAsset(step.sellAsset.assetId)
@@ -63,7 +97,11 @@ export const getTotalNetworkFeeUserCurrencyPrecision = (
       feeAsset,
       getFeeAssetRate,
     )
-    return acc.plus(networkFeeFiatPrecision ?? '0')
+    const protocolFeeFiatPrecision = getRequiresBalanceProtocolFeeUserCurrency(
+      step,
+      getFeeAssetRate,
+    )
+    return acc.plus(networkFeeFiatPrecision ?? '0').plus(protocolFeeFiatPrecision)
   }, bn(0))
 }
 

--- a/src/state/slices/tradeQuoteSlice/selectors.ts
+++ b/src/state/slices/tradeQuoteSlice/selectors.ts
@@ -60,6 +60,7 @@ import {
   getActiveQuoteMetaOrDefault,
   getBuyAmountAfterFeesCryptoPrecision,
   getHopTotalNetworkFeeUserCurrency,
+  getRequiresBalanceProtocolFeeUserCurrency,
   getTotalProtocolFeeByAsset,
   sortTradeQuotes,
 } from '@/state/slices/tradeQuoteSlice/helpers'
@@ -365,10 +366,40 @@ export const selectSecondHopSellFeeAsset: Selector<ReduxState, Asset | undefined
   )
 
 export const selectFirstHopNetworkFeeCryptoBaseUnit: Selector<ReduxState, string | undefined> =
-  createSelector(selectFirstHop, firstHop => firstHop?.feeData.networkFeeCryptoBaseUnit)
+  createSelector(selectFirstHop, selectFirstHopSellFeeAsset, (firstHop, feeAsset) => {
+    if (!firstHop) return
+    const base = bnOrZero(firstHop.feeData.networkFeeCryptoBaseUnit)
+    // Include requiresBalance protocol fees denominated in the same fee asset
+    const protocolFeeInFeeAsset = feeAsset
+      ? bnOrZero(
+          firstHop.feeData.protocolFees?.[feeAsset.assetId]?.requiresBalance
+            ? firstHop.feeData.protocolFees[feeAsset.assetId]?.amountCryptoBaseUnit
+            : undefined,
+        )
+      : bn(0)
+    const total = base.plus(protocolFeeInFeeAsset)
+    return firstHop.feeData.networkFeeCryptoBaseUnit !== undefined || total.gt(0)
+      ? total.toString()
+      : undefined
+  })
 
 export const selectSecondHopNetworkFeeCryptoBaseUnit: Selector<ReduxState, string | undefined> =
-  createSelector(selectSecondHop, secondHop => secondHop?.feeData.networkFeeCryptoBaseUnit)
+  createSelector(selectSecondHop, selectSecondHopSellFeeAsset, (secondHop, feeAsset) => {
+    if (!secondHop) return
+    const base = bnOrZero(secondHop.feeData.networkFeeCryptoBaseUnit)
+    // Include requiresBalance protocol fees denominated in the same fee asset
+    const protocolFeeInFeeAsset = feeAsset
+      ? bnOrZero(
+          secondHop.feeData.protocolFees?.[feeAsset.assetId]?.requiresBalance
+            ? secondHop.feeData.protocolFees[feeAsset.assetId]?.amountCryptoBaseUnit
+            : undefined,
+        )
+      : bn(0)
+    const total = base.plus(protocolFeeInFeeAsset)
+    return secondHop.feeData.networkFeeCryptoBaseUnit !== undefined || total.gt(0)
+      ? total.toString()
+      : undefined
+  })
 
 export const selectFirstHopNetworkFeeUserCurrency: Selector<ReduxState, string | undefined> =
   createSelector(
@@ -386,11 +417,22 @@ export const selectFirstHopNetworkFeeUserCurrency: Selector<ReduxState, string |
         return marketData[feeAsset?.assetId ?? '']?.price ?? '0'
       }
 
-      return getHopTotalNetworkFeeUserCurrency(
+      const getUserCurrencyRate = (assetId: AssetId) => marketData[assetId]?.price
+
+      const networkFee = getHopTotalNetworkFeeUserCurrency(
         tradeQuoteStep.feeData.networkFeeCryptoBaseUnit,
         feeAsset,
         getFeeAssetUserCurrencyRate,
-      )?.toString()
+      )
+
+      const protocolFee = getRequiresBalanceProtocolFeeUserCurrency(
+        tradeQuoteStep,
+        getUserCurrencyRate,
+      )
+
+      if (networkFee === undefined) return protocolFee.gt(0) ? protocolFee.toString() : undefined
+
+      return networkFee.plus(protocolFee).toString()
     },
   )
 
@@ -405,15 +447,27 @@ export const selectSecondHopNetworkFeeUserCurrency: Selector<ReduxState, string 
       if (feeAsset === undefined) {
         throw Error(`missing fee asset for assetId ${tradeQuoteStep.sellAsset.assetId}`)
       }
+
       const getFeeAssetUserCurrencyRate = () => {
         return marketData[feeAsset?.assetId ?? '']?.price ?? '0'
       }
 
-      return getHopTotalNetworkFeeUserCurrency(
+      const getUserCurrencyRate = (assetId: AssetId) => marketData[assetId]?.price
+
+      const networkFee = getHopTotalNetworkFeeUserCurrency(
         tradeQuoteStep.feeData.networkFeeCryptoBaseUnit,
         feeAsset,
         getFeeAssetUserCurrencyRate,
-      )?.toString()
+      )
+
+      const protocolFee = getRequiresBalanceProtocolFeeUserCurrency(
+        tradeQuoteStep,
+        getUserCurrencyRate,
+      )
+
+      if (networkFee === undefined) return protocolFee.gt(0) ? protocolFee.toString() : undefined
+
+      return networkFee.plus(protocolFee).toString()
     },
   )
 


### PR DESCRIPTION
## Description

Protocol fees with `requiresBalance: true` (e.g. deBridge fixFee ~0.005 BNB, Jupiter account creation fees) were only validated for sufficient balance but never displayed in the UI. This misrepresented the true cost of routes, making deBridge appear cheaper than it actually is.

Changes:
- Add `getRequiresBalanceProtocolFeeUserCurrency` helper to compute user-currency value of out-of-pocket protocol fees
- Include `requiresBalance` protocol fees in `selectFirstHopNetworkFeeCryptoBaseUnit` / `selectSecondHopNetworkFeeCryptoBaseUnit` selectors (crypto display on Confirm Details)
- Include `requiresBalance` protocol fees in `selectFirstHopNetworkFeeUserCurrency` / `selectSecondHopNetworkFeeUserCurrency` selectors (fiat display + gas icon)
- Fix `TradeConfirmFooter` (Sign & Swap screen) to include protocol fees in Transaction Fee row
- Account for `requiresBalance` fees in quote sorting even when network fee is unknown (disconnected wallet)
- Fix deBridge to use `fixFee` directly instead of `fixFee + prependedOperatingExpenseCost`

## Issue (if applicable)

## Risk

Low-medium. Changes affect fee display and quote sorting across all swappers, but only additive — `requiresBalance: true` protocol fees are added to the existing network fee amounts. Swappers affected in production: deBridge (fixFee in fee asset) and Jupiter (account creation in SOL). CowSwap uses `requiresBalance: false` so is unaffected.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

deBridge and Jupiter fee display. Quote sorting order for all swappers.

## Testing

### Engineering

1. Execute a deBridge cross-chain swap (e.g. USDC on BSC → USDC on Optimism)
2. Verify the gas icon on the trade input screen includes the ~0.005 BNB protocol fee in the fiat amount
3. On Confirm Details, verify the fiat amount next to the rate row includes the protocol fee
4. On Sign & Swap, verify the "Transaction Fee" row shows the combined network + protocol fee in both crypto and fiat
5. Test Jupiter swap with account creation fee — verify SOL account creation fee is included in displayed fees
6. Test a non-affected swapper (e.g. THORChain) — verify no change in behavior
7. Test disconnected wallet state — verify quote sorting still accounts for protocol fees

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Test a deBridge cross-chain swap and verify the Transaction Fee on the Sign & Swap screen now shows ~0.005 BNB + gas instead of just gas.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined protocol fee calculations to correctly identify and track fees requiring balance verification.
  * Enhanced fee aggregation across multi-hop trades for more accurate total fee estimates.
  * Improved trade confirmation displays to properly include all applicable protocol and network fees.
  * Fixed fee computation logic to eliminate overcounting in protocol fee calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->