### PR TITLE
fix: use sellAsset chainId for deBridge affiliate fee recipient

### DIFF
--- a/packages/swapper/src/swappers/DebridgeSwapper/utils/getTrade.ts
+++ b/packages/swapper/src/swappers/DebridgeSwapper/utils/getTrade.ts
@@ -103,7 +103,7 @@ export async function getTrade<T extends 'quote' | 'rate'>({
   })()
 
   const affiliateFeePercent = (() => {
-    if (!isTreasuryChainId(buyAsset.chainId)) return undefined
+    if (!isTreasuryChainId(sellAsset.chainId)) return undefined
     const bps = bnOrZero(affiliateBps)
     if (!bps.isFinite() || bps.lte(0)) return undefined
     return bps.div(100).toFixed()
@@ -112,10 +112,10 @@ export async function getTrade<T extends 'quote' | 'rate'>({
   const affiliateFeeRecipient = (() => {
     if (affiliateFeePercent === undefined) return undefined
     try {
-      return getTreasuryAddressFromChainId(buyAsset.chainId).toLowerCase()
+      return getTreasuryAddressFromChainId(sellAsset.chainId).toLowerCase()
     } catch (e) {
       console.error(
-        `[getTrade] Failed to get treasury address for chainId ${buyAsset.chainId}, affiliate fee will not be applied`,
+        `[getTrade] Failed to get treasury address for chainId ${sellAsset.chainId}, affiliate fee will not be applied`,
         e,
       )
       return undefined


### PR DESCRIPTION
## Description

The deBridge affiliate fee recipient treasury address was being derived from `buyAsset.chainId` (destination chain) instead of `sellAsset.chainId` (source chain). Since the affiliate fee is collected on the source chain, the treasury address must correspond to the sell asset's chain.

## Risk

Low - isolated fix to affiliate fee address lookup in deBridge swapper.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

deBridge swaps where sell and buy chains differ. Previously the affiliate fee may have been sent to an address on the wrong chain (or failed silently if no treasury address existed for the buy chain).

## Testing

### Engineering

1. Execute a cross-chain deBridge swap
2. Verify the affiliate fee recipient in the transaction matches the treasury address for the **sell** chain

### Operations

- [ ] Test a cross-chain swap using deBridge and confirm it completes successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed affiliate fee recipient and eligibility logic to reference the selling asset's chain, ensuring affiliate fees are calculated and routed to the correct treasury address.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->