### PR TITLE
feat(public-api): evm validation, on-chain allowance, partner code timeout

### DIFF
--- a/packages/public-api/.env.example
+++ b/packages/public-api/.env.example
@@ -24,9 +24,21 @@ UNCHAINED_BITCOINCASH_HTTP_URL=https://dev-api.bitcoincash.shapeshift.com
 
 # Node URLs
 THORCHAIN_NODE_URL=https://dev-api.thorchain.shapeshift.com/lcd
-MAYACHAIN_NODE_URL=https://api.mayachain.shapeshift.com/lcd
+MAYACHAIN_NODE_URL=https://dev-api.mayachain.shapeshift.com/lcd
 TRON_NODE_URL=https://api.trongrid.io
 SUI_NODE_URL=https://fullnode.mainnet.sui.io
+
+# First-class EVM node URLs (optional — leave unset to use public RPC fallbacks from @shapeshiftoss/contracts)
+# VITE_ prefix is required because @shapeshiftoss/contracts reads process.env.VITE_*_NODE_URL
+# Second-class EVM chains are fallback-only and don't have env vars
+VITE_ETHEREUM_NODE_URL=
+VITE_BNBSMARTCHAIN_NODE_URL=
+VITE_AVALANCHE_NODE_URL=
+VITE_ARBITRUM_NODE_URL=
+VITE_OPTIMISM_NODE_URL=
+VITE_GNOSIS_NODE_URL=
+VITE_POLYGON_NODE_URL=
+VITE_BASE_NODE_URL=
 
 # Midgard URLs
 THORCHAIN_MIDGARD_URL=https://dev-api.thorchain.shapeshift.com/midgard/v2

--- a/packages/public-api/package.json
+++ b/packages/public-api/package.json
@@ -18,6 +18,7 @@
     "@scalar/express-api-reference": "^0.8.30",
     "@shapeshiftoss/caip": "workspace:^",
     "@shapeshiftoss/chain-adapters": "workspace:^",
+    "@shapeshiftoss/contracts": "workspace:^",
     "@shapeshiftoss/swapper": "workspace:^",
     "@shapeshiftoss/types": "workspace:^",
     "@shapeshiftoss/utils": "workspace:^",
@@ -27,6 +28,7 @@
     "express": "^4.21.0",
     "express-rate-limit": "^7.5.0",
     "uuid": "^9.0.0",
+    "viem": "2.43.5",
     "yaml": "^2.8.2",
     "zod": "3.23.8"
   },

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -34,6 +34,18 @@ const envSchema = z.object({
   TRON_NODE_URL: url,
   SUI_NODE_URL: url,
 
+  // First-class EVM node URLs (optional — consumed by @shapeshiftoss/contracts via
+  // process.env.VITE_*_NODE_URL; falls back to public RPCs in PUBLIC_RPC_URLS when unset).
+  // Second-class EVM chains are fallback-only and don't have env vars.
+  VITE_ETHEREUM_NODE_URL: url.optional(),
+  VITE_BNBSMARTCHAIN_NODE_URL: url.optional(),
+  VITE_AVALANCHE_NODE_URL: url.optional(),
+  VITE_ARBITRUM_NODE_URL: url.optional(),
+  VITE_OPTIMISM_NODE_URL: url.optional(),
+  VITE_GNOSIS_NODE_URL: url.optional(),
+  VITE_POLYGON_NODE_URL: url.optional(),
+  VITE_BASE_NODE_URL: url.optional(),
+
   // Midgard URLs
   THORCHAIN_MIDGARD_URL: url,
   MAYACHAIN_MIDGARD_URL: url,

--- a/packages/public-api/src/middleware/auth.ts
+++ b/packages/public-api/src/middleware/auth.ts
@@ -28,7 +28,8 @@ const resolvePartnerCodeFromService = async (
     }
 
     return null
-  } catch {
+  } catch (error) {
+    console.error('Failed to resolve partner code:', error)
     return null
   } finally {
     clearTimeout(timeout)

--- a/packages/public-api/src/middleware/auth.ts
+++ b/packages/public-api/src/middleware/auth.ts
@@ -2,12 +2,18 @@ import type { NextFunction, Request, Response } from 'express'
 
 import { env } from '../env'
 
+const PARTNER_CODE_RESOLUTION_TIMEOUT_MS = 5_000
+
 const resolvePartnerCodeFromService = async (
   code: string,
 ): Promise<{ affiliateAddress: string; bps: string } | null> => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), PARTNER_CODE_RESOLUTION_TIMEOUT_MS)
+
   try {
     const response = await fetch(
       `${env.SWAP_SERVICE_BASE_URL}/v1/partner/${encodeURIComponent(code)}`,
+      { signal: controller.signal },
     )
 
     if (response.ok) {
@@ -24,6 +30,8 @@ const resolvePartnerCodeFromService = async (
     return null
   } catch {
     return null
+  } finally {
+    clearTimeout(timeout)
   }
 }
 
@@ -45,7 +53,6 @@ export const resolvePartnerCode = async (
       next()
       return
     }
-    // Partner code not found — continue without affiliate info
   }
 
   // No partner code provided — use default BPS for unattributed swaps

--- a/packages/public-api/src/routes/quote/getQuote.ts
+++ b/packages/public-api/src/routes/quote/getQuote.ts
@@ -1,3 +1,5 @@
+import { fromChainId } from '@shapeshiftoss/caip'
+import { viemClientByChainId } from '@shapeshiftoss/contracts'
 import type { GetTradeQuoteInputWithWallet } from '@shapeshiftoss/swapper'
 import {
   getDefaultSlippageDecimalPercentageForSwapper,
@@ -9,6 +11,7 @@ import type { Request, Response } from 'express'
 import { v4 as uuidv4 } from 'uuid'
 
 import { getAsset } from '../../assets'
+import { env } from '../../env'
 import { QuoteStore, quoteStore } from '../../lib/quoteStore'
 import { registry } from '../../registry'
 import { getSwapperDeps } from '../../swapperDeps'
@@ -95,6 +98,23 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       return
     }
 
+    const isEvmSell = fromChainId(sellAsset.chainId).chainNamespace === 'eip155'
+    if (isEvmSell && !sendAddress) {
+      res.status(400).json({
+        error: 'sendAddress is required for EVM sell assets',
+        code: 'MISSING_SEND_ADDRESS',
+      } satisfies ErrorResponse)
+      return
+    }
+
+    if (isEvmSell && !viemClientByChainId[sellAsset.chainId]) {
+      res.status(400).json({
+        error: `Unsupported EVM chain: ${sellAsset.chainId}`,
+        code: 'UNSUPPORTED_CHAIN',
+      } satisfies ErrorResponse)
+      return
+    }
+
     const deps = getSwapperDeps()
 
     const slippage = (() => {
@@ -111,8 +131,7 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       sellAsset,
       buyAsset,
       sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      affiliateBps: req.affiliateInfo?.affiliateBps!,
+      affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
       allowMultiHop,
       slippageTolerancePercentageDecimal: slippage,
       receiveAddress,
@@ -169,8 +188,7 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       sellAmountCryptoBaseUnit: firstStep.sellAmountIncludingProtocolFeesCryptoBaseUnit,
       buyAmountAfterFeesCryptoBaseUnit: lastStep.buyAmountAfterFeesCryptoBaseUnit,
       affiliateAddress: req.affiliateInfo?.affiliateAddress,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      affiliateBps: req.affiliateInfo?.affiliateBps!,
+      affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
       sellChainId: sellAsset.chainId,
       receiveAddress,
       sendAddress,
@@ -204,14 +222,15 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       sellAmountCryptoBaseUnit: firstStep.sellAmountIncludingProtocolFeesCryptoBaseUnit,
       buyAmountBeforeFeesCryptoBaseUnit: lastStep.buyAmountBeforeFeesCryptoBaseUnit,
       buyAmountAfterFeesCryptoBaseUnit: lastStep.buyAmountAfterFeesCryptoBaseUnit,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      affiliateBps: req.affiliateInfo?.affiliateBps!,
+      affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
       slippageTolerancePercentageDecimal: quote.slippageTolerancePercentageDecimal,
       networkFeeCryptoBaseUnit: firstStep.feeData.networkFeeCryptoBaseUnit,
       steps: quote.steps.map((step, index) =>
         transformQuoteStep(step, index === 0 ? depositContext : {}),
       ),
-      approval: buildApprovalInfo(firstStep),
+      approval: sendAddress
+        ? await buildApprovalInfo(firstStep, sendAddress)
+        : { isRequired: false, spender: '' },
       expiresAt: now + 60_000,
       affiliateAddress: req.affiliateInfo?.affiliateAddress,
     }

--- a/packages/public-api/src/routes/quote/utils.ts
+++ b/packages/public-api/src/routes/quote/utils.ts
@@ -1,10 +1,9 @@
-import { fromChainId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, fromAssetId, fromChainId } from '@shapeshiftoss/caip'
+import { viemClientByChainId } from '@shapeshiftoss/contracts'
 import type { SwapperName, TradeQuote, TradeQuoteStep } from '@shapeshiftoss/swapper'
-import {
-  getDaemonUrl,
-  getInboundAddressDataForChain,
-  isNativeEvmAsset,
-} from '@shapeshiftoss/swapper'
+import { getDaemonUrl, getInboundAddressDataForChain } from '@shapeshiftoss/swapper'
+import { isToken } from '@shapeshiftoss/utils'
+import { erc20Abi, getAddress } from 'viem'
 
 import { getServerConfig } from '../../config'
 import { extractTransactionData } from './extractTransactionData'
@@ -41,25 +40,32 @@ export const getEvmChainIdNumber = (chainId: string): number => {
   return parseInt(chainReference, 10)
 }
 
-export const buildApprovalInfo = (step: TradeQuoteStep): ApprovalInfo => {
+export const buildApprovalInfo = async (
+  step: TradeQuoteStep,
+  owner: string,
+): Promise<ApprovalInfo> => {
   const { chainNamespace } = fromChainId(step.sellAsset.chainId)
 
-  if (chainNamespace !== 'eip155') {
-    return { isRequired: false, spender: '' }
-  }
+  const needsAllowanceCheck =
+    chainNamespace === CHAIN_NAMESPACE.Evm &&
+    isToken(step.sellAsset.assetId) &&
+    Boolean(step.allowanceContract)
 
-  if (isNativeEvmAsset(step.sellAsset.assetId)) {
-    return { isRequired: false, spender: '' }
-  }
+  if (!needsAllowanceCheck) return { isRequired: false, spender: '' }
 
-  if (step.allowanceContract) {
-    return {
-      isRequired: true,
-      spender: step.allowanceContract,
-    }
-  }
+  const spender = step.allowanceContract
+  const client = viemClientByChainId[step.sellAsset.chainId]
 
-  return { isRequired: false, spender: '' }
+  const allowance = await client.readContract({
+    address: getAddress(fromAssetId(step.sellAsset.assetId).assetReference),
+    abi: erc20Abi,
+    functionName: 'allowance',
+    args: [getAddress(owner), getAddress(spender)],
+  })
+
+  const requiredAmount = BigInt(step.sellAmountIncludingProtocolFeesCryptoBaseUnit)
+
+  return { isRequired: allowance < requiredAmount, spender }
 }
 
 // Transform quote step to API format

--- a/packages/public-api/src/routes/rates/getRates.ts
+++ b/packages/public-api/src/routes/rates/getRates.ts
@@ -3,6 +3,7 @@ import { getTradeRates, SwapperName, swappers, TradeQuoteError } from '@shapeshi
 import type { Request, Response } from 'express'
 
 import { getAsset } from '../../assets'
+import { env } from '../../env'
 import { registry } from '../../registry'
 import { getSwapperDeps } from '../../swapperDeps'
 import type { ErrorResponse } from '../../types'
@@ -87,8 +88,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
       sellAsset,
       buyAsset,
       sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      affiliateBps: req.affiliateInfo?.affiliateBps!,
+      affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
       allowMultiHop,
       slippageTolerancePercentageDecimal,
       receiveAddress: undefined,
@@ -127,8 +127,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
             steps: 0,
             estimatedExecutionTimeMs: undefined,
             priceImpactPercentageDecimal: undefined,
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            affiliateBps: req.affiliateInfo?.affiliateBps!,
+            affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
             networkFeeCryptoBaseUnit: undefined,
             error: {
               code: error.code ?? TradeQuoteError.UnknownError,
@@ -152,8 +151,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
           steps: rate.steps.length,
           estimatedExecutionTimeMs: firstStep.estimatedExecutionTimeMs,
           priceImpactPercentageDecimal: rate.priceImpactPercentageDecimal,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          affiliateBps: req.affiliateInfo?.affiliateBps!,
+          affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
           networkFeeCryptoBaseUnit: firstStep.feeData.networkFeeCryptoBaseUnit,
         }
       } catch (error) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1955,6 +1955,9 @@ importers:
       '@shapeshiftoss/chain-adapters':
         specifier: workspace:^
         version: link:../chain-adapters
+      '@shapeshiftoss/contracts':
+        specifier: workspace:^
+        version: link:../contracts
       '@shapeshiftoss/swapper':
         specifier: workspace:^
         version: link:../swapper
@@ -1982,6 +1985,9 @@ importers:
       uuid:
         specifier: ^9.0.0
         version: 9.0.1
+      viem:
+        specifier: 2.43.5
+        version: 2.43.5(bufferutil@4.1.0)(typescript@5.2.2)(utf-8-validate@6.0.6)(zod@3.25.76)
       yaml:
         specifier: ^2.8.2
         version: 2.8.2


### PR DESCRIPTION
## Description

Several independent improvements to `public-api`'s quote/rates flow. Split into three commits:

1. **`fix(public-api): timeout partner code resolution after 5s`** — add an `AbortController` with a 5s timeout to the partner-code lookup against `swap-service`, so slow/hung responses can't stall every incoming request.

2. **`feat(public-api): support optional EVM node URL env vars`** — add optional `VITE_<CHAIN>_NODE_URL` env vars for first-class EVM chains (ETH, BSC, AVAX, ARB, OP, GNO, POLY, BASE). These are consumed by `@shapeshiftoss/contracts` viem clients via `process.env.VITE_*_NODE_URL`. When unset, the clients fall back to the public RPCs bundled in `@shapeshiftoss/contracts`. Adds `@shapeshiftoss/contracts` and `viem` as workspace deps so we can reuse the client factory instead of reimplementing it.

3. **`feat(public-api): validate EVM inputs and check on-chain allowance`** —
   - Reject EVM sell requests without a `sendAddress` (400 `MISSING_SEND_ADDRESS`) or on unsupported chains (400 `UNSUPPORTED_CHAIN`) instead of crashing downstream.
   - `buildApprovalInfo` now reads the ERC-20 allowance on-chain via the viem client and only flags approval as required when `allowance < sellAmount`. Previously we returned `isRequired: true` for every ERC-20 quote regardless of existing allowance, forcing the widget to always prompt for approval even when one was already in place.
   - Replace the `affiliateBps!` non-null assertions with a `DEFAULT_AFFILIATE_BPS` fallback so unattributed swaps don't explode at runtime.

### Why

- Slow `swap-service` partner lookups were propagating into request latency with no bound.
- `public-api` needs its own transport to sell assets that aren't hitting a SwapServer private RPC; exposing the bundled public RPCs via `@shapeshiftoss/contracts` keeps env-var overhead minimal and gives us working clients out of the box for all supported EVM chains.
- The prior approval-required logic was purely structural (\"is this an ERC-20? → require approval\") and forced unnecessary approvals in the widget when allowance already existed.

## Issue (if applicable)

closes #

## Risk

Medium — changes the contract of `/quote` for EVM sells (now requires `sendAddress`), adds a network call per ERC-20 quote (on-chain allowance read), and introduces a new transport path (public RPCs) when private node URLs are unset.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

All EVM swaps routed through `public-api`. Non-EVM chains are unaffected.

## Testing

### Engineering

- [ ] `pnpm run type-check` passes
- [ ] `pnpm run lint` passes
- [ ] `/quote` with EVM sell + no `sendAddress` → 400 `MISSING_SEND_ADDRESS`
- [ ] `/quote` with an unsupported EVM chain → 400 `UNSUPPORTED_CHAIN`
- [ ] `/quote` with an ERC-20 sell where allowance is already sufficient → `approval.isRequired: false`
- [ ] `/quote` with an ERC-20 sell where allowance is insufficient → `approval.isRequired: true`, correct `spender`
- [ ] `/quote` with native EVM sell → `approval.isRequired: false`
- [ ] Slow/unreachable `swap-service` partner endpoint does not stall requests past ~5s
- [ ] Missing `VITE_<CHAIN>_NODE_URL` → viem client still works via public RPC fallback

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended support for configurable node endpoints across multiple EVM networks (Ethereum, BNB Smart Chain, Avalanche, Arbitrum, Optimism, Gnosis, Polygon, and Base).
  * Enhanced approval handling with on-chain allowance verification.

* **Bug Fixes**
  * Added timeout protection for partner code resolution requests.
  * Improved chain validation for quote requests with better error handling.
  * Enhanced fallback logic for affiliate fee calculations.

* **Chores**
  * Added external dependencies to support EVM network integration.
  * Updated environment configuration templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->