### PR TITLE
feat(near-intents): add 20 bps extra fee to cover NEAR Intents protocol base fee

### DIFF
--- a/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
@@ -3,3 +3,6 @@ export const ONE_CLICK_BASE_URL = 'https://1click.chaindefuser.com'
 export const DEFAULT_SLIPPAGE_BPS = 50
 
 export const DEFAULT_QUOTE_DEADLINE_MS = 30 * 60 * 1000
+
+// NEAR Intents charges a protocol base fee on top of the standard affiliate fee
+export const NEAR_INTENTS_EXTRA_BPS = 20

--- a/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
@@ -28,7 +28,11 @@ import {
 } from '../../../utils'
 import { buildAffiliateFee } from '../../utils/affiliateFee'
 import { isNativeEvmAsset } from '../../utils/helpers/helpers'
-import { DEFAULT_QUOTE_DEADLINE_MS, DEFAULT_SLIPPAGE_BPS } from '../constants'
+import {
+  DEFAULT_QUOTE_DEADLINE_MS,
+  DEFAULT_SLIPPAGE_BPS,
+  NEAR_INTENTS_EXTRA_BPS,
+} from '../constants'
 import type { QuoteResponse } from '../types'
 import { QuoteRequest } from '../types'
 import { assetToNearIntentsAsset, calculateAccountCreationCosts } from '../utils/helpers/helpers'
@@ -125,7 +129,7 @@ export const getTradeQuote = async (
       appFees: [
         {
           recipient: DAO_TREASURY_NEAR,
-          fee: Number(affiliateBps),
+          fee: Number(affiliateBps) + NEAR_INTENTS_EXTRA_BPS,
         },
       ],
     }

--- a/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeRate.ts
@@ -31,7 +31,11 @@ import {
 import { simulateWithStateOverrides } from '../../../utils/tenderly'
 import { buildAffiliateFee } from '../../utils/affiliateFee'
 import { isNativeEvmAsset } from '../../utils/helpers/helpers'
-import { DEFAULT_QUOTE_DEADLINE_MS, DEFAULT_SLIPPAGE_BPS } from '../constants'
+import {
+  DEFAULT_QUOTE_DEADLINE_MS,
+  DEFAULT_SLIPPAGE_BPS,
+  NEAR_INTENTS_EXTRA_BPS,
+} from '../constants'
 import type { QuoteResponse } from '../types'
 import { QuoteRequest } from '../types'
 import { assetToNearIntentsAsset, calculateAccountCreationCosts } from '../utils/helpers/helpers'
@@ -106,7 +110,7 @@ export const getTradeRate = async (
       appFees: [
         {
           recipient: DAO_TREASURY_NEAR,
-          fee: Number(affiliateBps),
+          fee: Number(affiliateBps) + NEAR_INTENTS_EXTRA_BPS,
         },
       ],
     }


### PR DESCRIPTION
## Description

NEAR Intents now charges a protocol base fee on swaps. This PR adds \`NEAR_INTENTS_EXTRA_BPS = 20\` on top of the standard 60 bps \`affiliateBps\` in both the quote and rate paths, for an effective 80 bps total fee passed to the NEAR Intents \`appFees\` field.

Pending DFC vote to confirm the 20 bps extra amount.

## Issue (if applicable)

LIN-5648 / closes #12292

## Risk

Low — isolated to the NearIntentsSwapper. Only changes the numeric fee value passed to the NEAR Intents API; no on-chain transaction logic, wallet, or contract interaction is modified.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

NEAR Intents swapper only (\`getTradeQuote\` and \`getTradeRate\`).

## Testing

### Engineering

1. In the app, initiate a NEAR Intents swap (any NEAR-adjacent pair routed through NearIntentsSwapper).
2. Confirm the quote/rate request to \`1click.chaindefuser.com\` includes \`appFees[0].fee = 80\` (60 affiliate + 20 extra).
3. Confirm trade executes and the fee is deducted correctly.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

The fee change is live immediately for all NEAR Intents swaps — no flag. QA should verify a NEAR Intents swap in preview once deployed.

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * NEAR Intents swap fees have been increased by an additional 20 basis points (0.2%). This fee adjustment applies to all NEAR Intents swap transactions on the platform. Users will experience slightly higher costs when executing NEAR Intents swaps. Quote calculations have been updated to reflect these new fee rates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->