### PR TITLE
feat(public-api): real chain adapters in swapperDeps + NearIntents

### DIFF
--- a/packages/public-api/.env.example
+++ b/packages/public-api/.env.example
@@ -22,23 +22,22 @@ UNCHAINED_DOGECOIN_HTTP_URL=https://dev-api.dogecoin.shapeshift.com
 UNCHAINED_LITECOIN_HTTP_URL=https://dev-api.litecoin.shapeshift.com
 UNCHAINED_BITCOINCASH_HTTP_URL=https://dev-api.bitcoincash.shapeshift.com
 
+# First-class EVM node URLs — passed to chain adapter constructors and
+# consumed by @shapeshiftoss/contracts via process.env.VITE_*_NODE_URL.
+VITE_ETHEREUM_NODE_URL=https://dev-api.ethereum.shapeshift.com/api/v1/jsonrpc
+VITE_AVALANCHE_NODE_URL=https://dev-api.avalanche.shapeshift.com/api/v1/jsonrpc
+VITE_OPTIMISM_NODE_URL=https://dev-api.optimism.shapeshift.com/api/v1/jsonrpc
+VITE_BNBSMARTCHAIN_NODE_URL=https://dev-api.bnbsmartchain.shapeshift.com/api/v1/jsonrpc
+VITE_POLYGON_NODE_URL=https://dev-api.polygon.shapeshift.com/api/v1/jsonrpc
+VITE_GNOSIS_NODE_URL=https://dev-api.gnosis.shapeshift.com/api/v1/jsonrpc
+VITE_ARBITRUM_NODE_URL=https://dev-api.arbitrum.shapeshift.com/api/v1/jsonrpc
+VITE_BASE_NODE_URL=https://dev-api.base.shapeshift.com/api/v1/jsonrpc
+
 # Node URLs
 THORCHAIN_NODE_URL=https://dev-api.thorchain.shapeshift.com/lcd
 MAYACHAIN_NODE_URL=https://dev-api.mayachain.shapeshift.com/lcd
 TRON_NODE_URL=https://api.trongrid.io
 SUI_NODE_URL=https://fullnode.mainnet.sui.io
-
-# First-class EVM node URLs (optional — leave unset to use public RPC fallbacks from @shapeshiftoss/contracts)
-# VITE_ prefix is required because @shapeshiftoss/contracts reads process.env.VITE_*_NODE_URL
-# Second-class EVM chains are fallback-only and don't have env vars
-VITE_ETHEREUM_NODE_URL=
-VITE_BNBSMARTCHAIN_NODE_URL=
-VITE_AVALANCHE_NODE_URL=
-VITE_ARBITRUM_NODE_URL=
-VITE_OPTIMISM_NODE_URL=
-VITE_GNOSIS_NODE_URL=
-VITE_POLYGON_NODE_URL=
-VITE_BASE_NODE_URL=
 
 # Midgard URLs
 THORCHAIN_MIDGARD_URL=https://dev-api.thorchain.shapeshift.com/midgard/v2

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -28,23 +28,22 @@ const envSchema = z.object({
   UNCHAINED_LITECOIN_HTTP_URL: url,
   UNCHAINED_BITCOINCASH_HTTP_URL: url,
 
+  // First-class EVM node URLs — passed to chain adapter constructors and
+  // consumed by @shapeshiftoss/contracts via process.env.VITE_*_NODE_URL.
+  VITE_ETHEREUM_NODE_URL: url,
+  VITE_BNBSMARTCHAIN_NODE_URL: url,
+  VITE_AVALANCHE_NODE_URL: url,
+  VITE_ARBITRUM_NODE_URL: url,
+  VITE_OPTIMISM_NODE_URL: url,
+  VITE_GNOSIS_NODE_URL: url,
+  VITE_POLYGON_NODE_URL: url,
+  VITE_BASE_NODE_URL: url,
+
   // Node URLs
   THORCHAIN_NODE_URL: url,
   MAYACHAIN_NODE_URL: url,
   TRON_NODE_URL: url,
   SUI_NODE_URL: url,
-
-  // First-class EVM node URLs (optional — consumed by @shapeshiftoss/contracts via
-  // process.env.VITE_*_NODE_URL; falls back to public RPCs in PUBLIC_RPC_URLS when unset).
-  // Second-class EVM chains are fallback-only and don't have env vars.
-  VITE_ETHEREUM_NODE_URL: url.optional(),
-  VITE_BNBSMARTCHAIN_NODE_URL: url.optional(),
-  VITE_AVALANCHE_NODE_URL: url.optional(),
-  VITE_ARBITRUM_NODE_URL: url.optional(),
-  VITE_OPTIMISM_NODE_URL: url.optional(),
-  VITE_GNOSIS_NODE_URL: url.optional(),
-  VITE_POLYGON_NODE_URL: url.optional(),
-  VITE_BASE_NODE_URL: url.optional(),
 
   // Midgard URLs
   THORCHAIN_MIDGARD_URL: url,

--- a/packages/public-api/src/index.ts
+++ b/packages/public-api/src/index.ts
@@ -3,7 +3,7 @@ import './setupZod'
 import cors from 'cors'
 import express from 'express'
 
-import { getAssetsById, initAssets } from './assets'
+import { initAssets } from './assets'
 import { env } from './env'
 import { quoteStore } from './lib/quoteStore'
 import { resolvePartnerCode } from './middleware/auth'
@@ -30,11 +30,9 @@ import { getChainCount, getChains } from './routes/chains'
 import { getQuote } from './routes/quote'
 import { getRates } from './routes/rates'
 import { getSwapStatus } from './routes/status'
-import { initSwapperDeps } from './swapperDeps'
 
 const startServer = async () => {
   await initAssets()
-  initSwapperDeps(getAssetsById())
 
   const app = express()
 

--- a/packages/public-api/src/routes/rates/getRates.ts
+++ b/packages/public-api/src/routes/rates/getRates.ts
@@ -12,15 +12,16 @@ import type { ApiRate, RateResponse } from './types'
 import { RateResponseSchema, RatesRequestSchema } from './types'
 
 const ENABLED_SWAPPER_NAMES = [
-  'THORChain',
-  'MAYAChain',
-  '0x',
-  'CoW Swap',
-  'Portals',
-  'Chainflip',
-  'Relay',
-  'ButterSwap',
-  'Bebop',
+  SwapperName.Bebop,
+  SwapperName.ButterSwap,
+  SwapperName.Chainflip,
+  SwapperName.CowSwap,
+  SwapperName.Mayachain,
+  SwapperName.NearIntents,
+  SwapperName.Portals,
+  SwapperName.Relay,
+  SwapperName.Thorchain,
+  SwapperName.Zrx,
 ] as const
 
 // Rate timeout per swapper (10 seconds)

--- a/packages/public-api/src/routes/rates/getRates.ts
+++ b/packages/public-api/src/routes/rates/getRates.ts
@@ -99,12 +99,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
       chainId: sellAsset.chainId,
     }
 
-    const enabledSwappers = ENABLED_SWAPPER_NAMES.map(name => {
-      const swapperName = Object.values(SwapperName).find(v => v === name)
-      return swapperName
-    }).filter((name): name is (typeof SwapperName)[keyof typeof SwapperName] => name !== undefined)
-
-    const ratePromises = enabledSwappers.map(async (swapperName): Promise<ApiRate | null> => {
+    const ratePromises = ENABLED_SWAPPER_NAMES.map(async (swapperName): Promise<ApiRate | null> => {
       try {
         const swapper = swappers[swapperName]
         if (!swapper) return null

--- a/packages/public-api/src/swapperDeps.ts
+++ b/packages/public-api/src/swapperDeps.ts
@@ -1,278 +1,186 @@
 import type { ChainId } from '@shapeshiftoss/caip'
-import type {
-  ChainAdapter,
-  CosmosSdkChainAdapter,
-  EvmChainAdapter,
-  near,
-  solana,
-  starknet,
-  sui,
-  ton,
-  tron,
-  UtxoChainAdapter,
-} from '@shapeshiftoss/chain-adapters'
+import * as adapters from '@shapeshiftoss/chain-adapters'
 import type { SwapperDeps } from '@shapeshiftoss/swapper'
-import type { AssetsByIdPartial } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
+import * as unchained from '@shapeshiftoss/unchained-client'
 
+import { getAssetsById } from './assets'
 import { getServerConfig } from './config'
 import { env } from './env'
 
-type GasFeeData = {
-  gasPrice: string
-  maxFeePerGas?: string
-  maxPriorityFeePerGas?: string
-}
+// ws is required by chain-adapter constructors but the public-api never
+// subscribes to txs, so the URL is never dialed.
+const wsPlaceholderUrl = 'ws://localhost'
 
-type GasFeeDataEstimate = {
-  fast: GasFeeData
-  average: GasFeeData
-  slow: GasFeeData
-}
-
-type UtxoNetworkFees = {
-  fast: { satsPerKiloByte: number }
-  average: { satsPerKiloByte: number }
-  slow: { satsPerKiloByte: number }
-}
-
-const getEvmUnchainedUrls = (): Record<string, string> => ({
-  [KnownChainIds.EthereumMainnet]: env.UNCHAINED_ETHEREUM_HTTP_URL,
-  [KnownChainIds.ArbitrumMainnet]: env.UNCHAINED_ARBITRUM_HTTP_URL,
-  [KnownChainIds.OptimismMainnet]: env.UNCHAINED_OPTIMISM_HTTP_URL,
-  [KnownChainIds.PolygonMainnet]: env.UNCHAINED_POLYGON_HTTP_URL,
-  [KnownChainIds.GnosisMainnet]: env.UNCHAINED_GNOSIS_HTTP_URL,
-  [KnownChainIds.AvalancheMainnet]: env.UNCHAINED_AVALANCHE_HTTP_URL,
-  [KnownChainIds.BnbSmartChainMainnet]: env.UNCHAINED_BNBSMARTCHAIN_HTTP_URL,
-  [KnownChainIds.BaseMainnet]: env.UNCHAINED_BASE_HTTP_URL,
-})
-
-const getUtxoUnchainedUrls = (): Record<string, string> => ({
-  [KnownChainIds.BitcoinMainnet]: env.UNCHAINED_BITCOIN_HTTP_URL,
-  [KnownChainIds.DogecoinMainnet]: env.UNCHAINED_DOGECOIN_HTTP_URL,
-  [KnownChainIds.LitecoinMainnet]: env.UNCHAINED_LITECOIN_HTTP_URL,
-  [KnownChainIds.BitcoinCashMainnet]: env.UNCHAINED_BITCOINCASH_HTTP_URL,
-})
-
-const GAS_FEES_TIMEOUT_MS = 10_000
-
-const fetchGasFees = async (unchainedUrl: string): Promise<GasFeeDataEstimate> => {
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), GAS_FEES_TIMEOUT_MS)
-
-  try {
-    const response = await fetch(`${unchainedUrl}/api/v1/gas/fees`, {
-      signal: controller.signal,
-    })
-    if (!response.ok) {
-      throw new Error(`Failed to fetch gas fees: ${response.statusText}`)
-    }
-    const data = (await response.json()) as GasFeeDataEstimate
-    return {
-      fast: {
-        gasPrice: data.fast.gasPrice,
-        maxFeePerGas: data.fast.maxFeePerGas,
-        maxPriorityFeePerGas: data.fast.maxPriorityFeePerGas,
-      },
-      average: {
-        gasPrice: data.average.gasPrice,
-        maxFeePerGas: data.average.maxFeePerGas,
-        maxPriorityFeePerGas: data.average.maxPriorityFeePerGas,
-      },
-      slow: {
-        gasPrice: data.slow.gasPrice,
-        maxFeePerGas: data.slow.maxFeePerGas,
-        maxPriorityFeePerGas: data.slow.maxPriorityFeePerGas,
-      },
-    }
-  } finally {
-    clearTimeout(timeout)
-  }
-}
-
-const createMinimalEvmAdapter = (chainId: ChainId) => {
-  const evmUnchainedUrls = getEvmUnchainedUrls()
-  const unchainedUrl = evmUnchainedUrls[chainId]
-  if (!unchainedUrl) {
-    throw new Error(`No Unchained URL configured for chain ${chainId}`)
-  }
-
-  return {
-    getChainId: () => chainId,
-    getGasFeeData: () => fetchGasFees(unchainedUrl),
-    getFeeAssetId: () => {
-      switch (chainId) {
-        case KnownChainIds.EthereumMainnet:
-          return 'eip155:1/slip44:60'
-        case KnownChainIds.ArbitrumMainnet:
-          return 'eip155:42161/slip44:60'
-        case KnownChainIds.OptimismMainnet:
-          return 'eip155:10/slip44:60'
-        case KnownChainIds.PolygonMainnet:
-          return 'eip155:137/slip44:966'
-        case KnownChainIds.GnosisMainnet:
-          return 'eip155:100/slip44:700'
-        case KnownChainIds.AvalancheMainnet:
-          return 'eip155:43114/slip44:9005'
-        case KnownChainIds.BnbSmartChainMainnet:
-          return 'eip155:56/slip44:714'
-        case KnownChainIds.BaseMainnet:
-          return 'eip155:8453/slip44:60'
-        default:
-          return `${chainId}/slip44:60`
-      }
+const evmAdapters: Record<ChainId, adapters.EvmChainAdapter> = {
+  [KnownChainIds.EthereumMainnet]: new adapters.ethereum.ChainAdapter({
+    providers: {
+      http: new unchained.ethereum.V1Api(
+        new unchained.ethereum.Configuration({ basePath: env.UNCHAINED_ETHEREUM_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.ethereum.Tx>(wsPlaceholderUrl),
     },
-    getDisplayName: () => chainId,
-  }
-}
-
-const createMinimalUtxoAdapter = (chainId: ChainId) => {
-  const utxoUnchainedUrls = getUtxoUnchainedUrls()
-  const unchainedUrl = utxoUnchainedUrls[chainId]
-  if (!unchainedUrl) {
-    throw new Error(`No Unchained URL configured for UTXO chain ${chainId}`)
-  }
-
-  const getFeeAssetId = () => {
-    switch (chainId) {
-      case KnownChainIds.BitcoinMainnet:
-        return 'bip122:000000000019d6689c085ae165831e93/slip44:0'
-      case KnownChainIds.DogecoinMainnet:
-        return 'bip122:00000000001a91e3dace36e2be3bf030/slip44:3'
-      case KnownChainIds.LitecoinMainnet:
-        return 'bip122:12a765e31ffd4059bada1e25190f6e98/slip44:2'
-      case KnownChainIds.BitcoinCashMainnet:
-        return 'bip122:000000000000000000651ef99cb9fcbe/slip44:145'
-      default:
-        throw new Error(`Unknown UTXO chain ${chainId}`)
-    }
-  }
-
-  const getDisplayName = () => {
-    switch (chainId) {
-      case KnownChainIds.BitcoinMainnet:
-        return 'Bitcoin'
-      case KnownChainIds.DogecoinMainnet:
-        return 'Dogecoin'
-      case KnownChainIds.LitecoinMainnet:
-        return 'Litecoin'
-      case KnownChainIds.BitcoinCashMainnet:
-        return 'Bitcoin Cash'
-      default:
-        return chainId
-    }
-  }
-
-  return {
-    getChainId: () => chainId,
-    getFeeAssetId,
-    getDisplayName,
-    getFeeData: async (_input: {
-      to: string
-      value: string
-      chainSpecific: { pubkey: string; opReturnData?: string }
-    }) => {
-      const response = await fetch(`${unchainedUrl}/api/v1/fees`)
-      if (!response.ok) {
-        throw new Error(`Failed to fetch UTXO fees: ${response.statusText}`)
-      }
-      const networkFees = (await response.json()) as UtxoNetworkFees
-
-      const fastPerByte = String(Math.round(networkFees.fast.satsPerKiloByte / 1000))
-      const averagePerByte = String(Math.round(networkFees.average.satsPerKiloByte / 1000))
-      const slowPerByte = String(Math.round(networkFees.slow.satsPerKiloByte / 1000))
-
-      const ESTIMATED_TX_SIZE = 250
-      const fastFee = String(parseInt(fastPerByte) * ESTIMATED_TX_SIZE)
-      const averageFee = String(parseInt(averagePerByte) * ESTIMATED_TX_SIZE)
-      const slowFee = String(parseInt(slowPerByte) * ESTIMATED_TX_SIZE)
-
-      return {
-        fast: {
-          txFee: fastFee,
-          chainSpecific: { satoshiPerByte: fastPerByte },
-        },
-        average: {
-          txFee: averageFee,
-          chainSpecific: { satoshiPerByte: averagePerByte },
-        },
-        slow: {
-          txFee: slowFee,
-          chainSpecific: { satoshiPerByte: slowPerByte },
-        },
-      }
+    rpcUrl: env.VITE_ETHEREUM_NODE_URL,
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+    mayaMidgardUrl: env.MAYACHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.AvalancheMainnet]: new adapters.avalanche.ChainAdapter({
+    providers: {
+      http: new unchained.avalanche.V1Api(
+        new unchained.avalanche.Configuration({ basePath: env.UNCHAINED_AVALANCHE_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.avalanche.Tx>(wsPlaceholderUrl),
     },
-  }
+    rpcUrl: env.VITE_AVALANCHE_NODE_URL,
+    midgardUrl: env.THORCHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.OptimismMainnet]: new adapters.optimism.ChainAdapter({
+    providers: {
+      http: new unchained.optimism.V1Api(
+        new unchained.optimism.Configuration({ basePath: env.UNCHAINED_OPTIMISM_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.optimism.Tx>(wsPlaceholderUrl),
+    },
+    rpcUrl: env.VITE_OPTIMISM_NODE_URL,
+  }),
+  [KnownChainIds.BnbSmartChainMainnet]: new adapters.bnbsmartchain.ChainAdapter({
+    providers: {
+      http: new unchained.bnbsmartchain.V1Api(
+        new unchained.bnbsmartchain.Configuration({
+          basePath: env.UNCHAINED_BNBSMARTCHAIN_HTTP_URL,
+        }),
+      ),
+      ws: new unchained.ws.Client<unchained.bnbsmartchain.Tx>(wsPlaceholderUrl),
+    },
+    rpcUrl: env.VITE_BNBSMARTCHAIN_NODE_URL,
+    midgardUrl: env.THORCHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.PolygonMainnet]: new adapters.polygon.ChainAdapter({
+    providers: {
+      http: new unchained.polygon.V1Api(
+        new unchained.polygon.Configuration({ basePath: env.UNCHAINED_POLYGON_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.polygon.Tx>(wsPlaceholderUrl),
+    },
+    rpcUrl: env.VITE_POLYGON_NODE_URL,
+  }),
+  [KnownChainIds.GnosisMainnet]: new adapters.gnosis.ChainAdapter({
+    providers: {
+      http: new unchained.gnosis.V1Api(
+        new unchained.gnosis.Configuration({ basePath: env.UNCHAINED_GNOSIS_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.gnosis.Tx>(wsPlaceholderUrl),
+    },
+    rpcUrl: env.VITE_GNOSIS_NODE_URL,
+  }),
+  [KnownChainIds.ArbitrumMainnet]: new adapters.arbitrum.ChainAdapter({
+    providers: {
+      http: new unchained.arbitrum.V1Api(
+        new unchained.arbitrum.Configuration({ basePath: env.UNCHAINED_ARBITRUM_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.arbitrum.Tx>(wsPlaceholderUrl),
+    },
+    rpcUrl: env.VITE_ARBITRUM_NODE_URL,
+    mayaMidgardUrl: env.MAYACHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.BaseMainnet]: new adapters.base.ChainAdapter({
+    providers: {
+      http: new unchained.base.V1Api(
+        new unchained.base.Configuration({ basePath: env.UNCHAINED_BASE_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.base.Tx>(wsPlaceholderUrl),
+    },
+    rpcUrl: env.VITE_BASE_NODE_URL,
+  }),
 }
 
-const createStubAdapter = (type: string) => {
-  return () => {
-    throw new Error(
-      `Chain adapter ${type} not implemented in public API. ` +
-        `This swapper requires chain adapter functionality that is not yet available.`,
-    )
-  }
+const utxoAdapters: Record<ChainId, adapters.UtxoChainAdapter> = {
+  [KnownChainIds.BitcoinMainnet]: new adapters.bitcoin.ChainAdapter({
+    providers: {
+      http: new unchained.bitcoin.V1Api(
+        new unchained.bitcoin.Configuration({ basePath: env.UNCHAINED_BITCOIN_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.bitcoin.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Bitcoin',
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+    mayaMidgardUrl: env.MAYACHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.DogecoinMainnet]: new adapters.dogecoin.ChainAdapter({
+    providers: {
+      http: new unchained.dogecoin.V1Api(
+        new unchained.dogecoin.Configuration({ basePath: env.UNCHAINED_DOGECOIN_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.dogecoin.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Dogecoin',
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.LitecoinMainnet]: new adapters.litecoin.ChainAdapter({
+    providers: {
+      http: new unchained.litecoin.V1Api(
+        new unchained.litecoin.Configuration({ basePath: env.UNCHAINED_LITECOIN_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.litecoin.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Litecoin',
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.BitcoinCashMainnet]: new adapters.bitcoincash.ChainAdapter({
+    providers: {
+      http: new unchained.bitcoincash.V1Api(
+        new unchained.bitcoincash.Configuration({ basePath: env.UNCHAINED_BITCOINCASH_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.bitcoincash.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'BitcoinCash',
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+  }),
 }
 
-const createServerSwapperDeps = (assetsById: AssetsByIdPartial): SwapperDeps => ({
-  assetsById,
+const notImplemented = (type: string) => () => {
+  throw new Error(`Chain adapter ${type} not implemented in public API`)
+}
+
+export const getSwapperDeps = (): SwapperDeps => ({
+  assetsById: getAssetsById(),
   config: getServerConfig(),
   mixPanel: undefined,
-
-  assertGetChainAdapter: createStubAdapter('generic') as unknown as (
+  assertGetChainAdapter: (chainId: ChainId) => {
+    const adapter = evmAdapters[chainId] ?? utxoAdapters[chainId]
+    if (!adapter) throw new Error(`No chain adapter registered for ${chainId}`)
+    return adapter as unknown as adapters.ChainAdapter<KnownChainIds>
+  },
+  assertGetEvmChainAdapter: (chainId: ChainId) => {
+    const adapter = evmAdapters[chainId]
+    if (!adapter) throw new Error(`No EVM chain adapter registered for ${chainId}`)
+    return adapter
+  },
+  assertGetUtxoChainAdapter: (chainId: ChainId) => {
+    const adapter = utxoAdapters[chainId]
+    if (!adapter) throw new Error(`No UTXO chain adapter registered for ${chainId}`)
+    return adapter
+  },
+  assertGetCosmosSdkChainAdapter: notImplemented('CosmosSdk') as unknown as (
     chainId: ChainId,
-  ) => ChainAdapter<KnownChainIds>,
-
-  assertGetEvmChainAdapter: ((chainId: ChainId) => {
-    const evmUnchainedUrls = getEvmUnchainedUrls()
-    const unchainedUrl = evmUnchainedUrls[chainId]
-    if (unchainedUrl) {
-      return createMinimalEvmAdapter(chainId)
-    }
-    throw new Error(`Chain adapter EVM for ${chainId} not implemented in public API.`)
-  }) as unknown as (chainId: ChainId) => EvmChainAdapter,
-
-  assertGetUtxoChainAdapter: ((chainId: ChainId) => {
-    const utxoUnchainedUrls = getUtxoUnchainedUrls()
-    const unchainedUrl = utxoUnchainedUrls[chainId]
-    if (unchainedUrl) {
-      return createMinimalUtxoAdapter(chainId)
-    }
-    throw new Error(`Chain adapter UTXO for ${chainId} not implemented in public API.`)
-  }) as unknown as (chainId: ChainId) => UtxoChainAdapter,
-
-  assertGetCosmosSdkChainAdapter: createStubAdapter('CosmosSdk') as unknown as (
+  ) => adapters.CosmosSdkChainAdapter,
+  assertGetSolanaChainAdapter: notImplemented('Solana') as unknown as (
     chainId: ChainId,
-  ) => CosmosSdkChainAdapter,
-  assertGetSolanaChainAdapter: createStubAdapter('Solana') as unknown as (
+  ) => adapters.solana.ChainAdapter,
+  assertGetTronChainAdapter: notImplemented('Tron') as unknown as (
     chainId: ChainId,
-  ) => solana.ChainAdapter,
-  assertGetTronChainAdapter: createStubAdapter('Tron') as unknown as (
+  ) => adapters.tron.ChainAdapter,
+  assertGetSuiChainAdapter: notImplemented('Sui') as unknown as (
     chainId: ChainId,
-  ) => tron.ChainAdapter,
-  assertGetSuiChainAdapter: createStubAdapter('Sui') as unknown as (
+  ) => adapters.sui.ChainAdapter,
+  assertGetNearChainAdapter: notImplemented('Near') as unknown as (
     chainId: ChainId,
-  ) => sui.ChainAdapter,
-  assertGetNearChainAdapter: createStubAdapter('Near') as unknown as (
+  ) => adapters.near.ChainAdapter,
+  assertGetStarknetChainAdapter: notImplemented('Starknet') as unknown as (
     chainId: ChainId,
-  ) => near.ChainAdapter,
-  assertGetStarknetChainAdapter: createStubAdapter('Starknet') as unknown as (
+  ) => adapters.starknet.ChainAdapter,
+  assertGetTonChainAdapter: notImplemented('Ton') as unknown as (
     chainId: ChainId,
-  ) => starknet.ChainAdapter,
-  assertGetTonChainAdapter: createStubAdapter('Ton') as unknown as (
-    chainId: ChainId,
-  ) => ton.ChainAdapter,
-
+  ) => adapters.ton.ChainAdapter,
   fetchIsSmartContractAddressQuery: () => Promise.resolve(false),
 })
-
-let swapperDeps: SwapperDeps | null = null
-
-export const initSwapperDeps = (assetsById: AssetsByIdPartial): void => {
-  swapperDeps = createServerSwapperDeps(assetsById)
-}
-
-export const getSwapperDeps = (): SwapperDeps => {
-  if (!swapperDeps) throw new Error('SwapperDeps not initialized')
-  return swapperDeps
-}

--- a/packages/swap-widget/src/constants/swappers.ts
+++ b/packages/swap-widget/src/constants/swappers.ts
@@ -1,39 +1,42 @@
 import { SwapperName } from '../types'
 
 export const SWAPPER_ICONS: Partial<Record<SwapperName, string>> = {
-  [SwapperName.Thorchain]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/thorchain-icon.png',
-  [SwapperName.Mayachain]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/maya_logo.png',
-  [SwapperName.CowSwap]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/cow-icon.png',
-  [SwapperName.Zrx]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/0x-icon.png',
-  [SwapperName.Portals]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/portals-icon.png',
-  [SwapperName.Chainflip]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/chainflip-icon.png',
-  [SwapperName.Relay]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/relay-icon.svg',
+  [SwapperName.ArbitrumBridge]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/arbitrum-bridge-icon.png',
   [SwapperName.Bebop]:
     'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/bebop-icon.png',
   [SwapperName.ButterSwap]:
     'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/butterswap.png',
-  [SwapperName.ArbitrumBridge]:
-    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/arbitrum-bridge-icon.png',
+  [SwapperName.Chainflip]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/chainflip-icon.png',
+  [SwapperName.CowSwap]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/cow-icon.png',
+  [SwapperName.Mayachain]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/maya_logo.png',
+  [SwapperName.NearIntents]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/near-intents-icon.png',
+  [SwapperName.Portals]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/portals-icon.png',
+  [SwapperName.Relay]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/relay-icon.svg',
+  [SwapperName.Thorchain]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/thorchain-icon.png',
+  [SwapperName.Zrx]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/0x-icon.png',
 }
 
 export const SWAPPER_COLORS: Partial<Record<SwapperName, string>> = {
-  [SwapperName.Thorchain]: '#00CCFF',
-  [SwapperName.Mayachain]: '#4169E1',
-  [SwapperName.CowSwap]: '#012d73',
-  [SwapperName.Zrx]: '#000000',
-  [SwapperName.Portals]: '#8B5CF6',
-  [SwapperName.Chainflip]: '#FF4081',
-  [SwapperName.Relay]: '#6366F1',
+  [SwapperName.ArbitrumBridge]: '#28A0F0',
   [SwapperName.Bebop]: '#E91E63',
   [SwapperName.ButterSwap]: '#FFD700',
-  [SwapperName.ArbitrumBridge]: '#28A0F0',
+  [SwapperName.Chainflip]: '#FF4081',
+  [SwapperName.CowSwap]: '#012d73',
+  [SwapperName.Mayachain]: '#4169E1',
+  [SwapperName.NearIntents]: '#000000',
+  [SwapperName.Portals]: '#8B5CF6',
+  [SwapperName.Relay]: '#6366F1',
+  [SwapperName.Thorchain]: '#00CCFF',
+  [SwapperName.Zrx]: '#000000',
 }
 
 export const getSwapperIcon = (swapperName: SwapperName): string | undefined => {


### PR DESCRIPTION
## Description

Replaces the hand-rolled minimal EVM/UTXO adapter stubs in `packages/public-api/src/swapperDeps.ts` with real chain adapters from `@shapeshiftoss/chain-adapters`, wired to Unchained HTTP endpoints and `VITE_*_NODE_URL` RPCs. The previous stubs only implemented `getGasFeeData` / `getFeeData` / `getFeeAssetId` / `getDisplayName`, which limited what swappers could call through `SwapperDeps`. Real adapters expose the full surface and align public-api behavior with the web app.

Side effects:
- `VITE_*_NODE_URL` for first-class EVM chains are now **required** in the env schema (previously optional with public-RPC fallback). `.env.example` is updated to point at `dev-api.*.shapeshift.com` JSON-RPC endpoints.
- `initSwapperDeps(getAssetsById())` is removed from server bootstrap; `getSwapperDeps()` now reads `getAssetsById()` directly each call.
- `ENABLED_SWAPPER_NAMES` in `routes/rates/getRates.ts` switched from string literals to the `SwapperName` enum. NearIntents added to the enabled set; mirrored in the swap-widget icon/color tables.
- `ws` providers use a `ws://localhost` placeholder URL — required by adapter constructors but never dialed since public-api doesn't subscribe to txs.

WebSocket placeholder caveat: chain-adapter constructors require a `ws.Client` instance; public-api never subscribes, so the URL is never opened. If a future adapter eagerly connects, this will surface immediately at boot.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Server-side only (public-api). All EVM and UTXO swapper paths that previously hit the minimal stubs now route through real chain adapters — fee estimation, address validation, and any other adapter methods now use the same code paths as the web app. NearIntents becomes selectable in the rates API. No on-chain transaction logic changes; `assertGetSolana/Tron/Sui/Near/Starknet/Ton/CosmosSdkChainAdapter` still throw \"not implemented\".

## Testing

### Engineering

1. Set `VITE_*_NODE_URL` env vars per the new `.env.example` (any unset value will now fail boot with a Zod error — previously it was optional).
2. \`pnpm --filter @shapeshiftoss/public-api dev\`
3. Hit \`GET /v1/rates\` with an EVM and a UTXO pair and verify quotes still come back, including a NearIntents quote when applicable.
4. Hit \`GET /v1/quote\` end-to-end for an EVM swap to confirm gas estimation flows through the new adapter.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

(public-api is not yet user-facing.)

## Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)