### PR TITLE
chore: drop vite-plugin-checker and tidy vite config types

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,7 +321,6 @@
     "typescript": "~5.2.2",
     "vite": "6.4.1",
     "vite-bundle-analyzer": "^0.18.1",
-    "vite-plugin-checker": "^0.9.1",
     "vite-plugin-node-polyfills": "^0.23.0",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "3.0.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -790,9 +790,6 @@ importers:
       vite-bundle-analyzer:
         specifier: ^0.18.1
         version: 0.18.1
-      vite-plugin-checker:
-        specifier: ^0.9.1
-        version: 0.9.3(eslint@8.57.1)(optionator@0.9.4)(typescript@5.2.2)(vite@6.4.1(@types/node@22.19.13)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       vite-plugin-node-polyfills:
         specifier: ^0.23.0
         version: 0.23.0(rollup@4.59.0)(vite@6.4.1(@types/node@22.19.13)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -13466,10 +13463,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@6.0.0:
-    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
-    engines: {node: '>=18'}
-
   number-to-bn@1.7.0:
     resolution: {integrity: sha512-wsJ9gfSz1/s4ZsJN01lyonwuxA1tml6X1yBDnfpMglypcBRFZZkus26EdPSlqS5GJfYddVZa22p3VNb3z5m5Ig==}
     engines: {node: '>=6.5.0', npm: '>=3'}
@@ -13792,10 +13785,6 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -16000,10 +15989,6 @@ packages:
     resolution: {integrity: sha512-hpbDzxUY9BFwX+UeBnxv3Sh1q7HFxj48DTmXchNgRa46lO8uj3/1iEn3MiNUYTg1g9ctIqXCCERn8gYZhHC5lQ==}
     engines: {node: '>=4'}
 
-  unicorn-magic@0.3.0:
-    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
-    engines: {node: '>=18'}
-
   unidragger@3.0.1:
     resolution: {integrity: sha512-RngbGSwBFmqGBWjkaH+yB677uzR95blSQyxq6hYbrQCejH3Mx1nm8DVOuh3M9k2fQyTstWUG5qlgCnNqV/9jVw==}
 
@@ -16405,40 +16390,6 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite-plugin-checker@0.9.3:
-    resolution: {integrity: sha512-Tf7QBjeBtG7q11zG0lvoF38/2AVUzzhMNu+Wk+mcsJ00Rk/FpJ4rmUviVJpzWkagbU13cGXvKpt7CMiqtxVTbQ==}
-    engines: {node: '>=14.16'}
-    peerDependencies:
-      '@biomejs/biome': '>=1.7'
-      eslint: '>=7'
-      meow: ^13.2.0
-      optionator: ^0.9.4
-      stylelint: '>=16'
-      typescript: '*'
-      vite: '>=2.0.0'
-      vls: '*'
-      vti: '*'
-      vue-tsc: ~2.2.10
-    peerDependenciesMeta:
-      '@biomejs/biome':
-        optional: true
-      eslint:
-        optional: true
-      meow:
-        optional: true
-      optionator:
-        optional: true
-      stylelint:
-        optional: true
-      typescript:
-        optional: true
-      vls:
-        optional: true
-      vti:
-        optional: true
-      vue-tsc:
-        optional: true
-
   vite-plugin-node-polyfills@0.23.0:
     resolution: {integrity: sha512-4n+Ys+2bKHQohPBKigFlndwWQ5fFKwaGY6muNDMTb0fSQLyBzS+jjUNRZG9sKF0S/Go4ApG6LFnUGopjkILg3w==}
     peerDependencies:
@@ -16590,9 +16541,6 @@ packages:
 
   vm-browserify@1.1.2:
     resolution: {integrity: sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==}
-
-  vscode-uri@3.1.0:
-    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   w3c-xmlserializer@5.0.0:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
@@ -39229,11 +39177,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@6.0.0:
-    dependencies:
-      path-key: 4.0.0
-      unicorn-magic: 0.3.0
-
   number-to-bn@1.7.0:
     dependencies:
       bn.js: 4.11.6
@@ -39744,8 +39687,6 @@ snapshots:
   path-key@2.0.1: {}
 
   path-key@3.1.1: {}
-
-  path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
 
@@ -42341,8 +42282,6 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.2.0: {}
 
-  unicorn-magic@0.3.0: {}
-
   unidragger@3.0.1:
     dependencies:
       ev-emitter: 2.1.2
@@ -42836,23 +42775,6 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-checker@0.9.3(eslint@8.57.1)(optionator@0.9.4)(typescript@5.2.2)(vite@6.4.1(@types/node@22.19.13)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
-    dependencies:
-      '@babel/code-frame': 7.29.0
-      chokidar: 4.0.3
-      npm-run-path: 6.0.0
-      picocolors: 1.1.1
-      picomatch: 4.0.3
-      strip-ansi: 7.2.0
-      tiny-invariant: 1.3.3
-      tinyglobby: 0.2.15
-      vite: 6.4.1(@types/node@22.19.13)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vscode-uri: 3.1.0
-    optionalDependencies:
-      eslint: 8.57.1
-      optionator: 0.9.4
-      typescript: 5.2.2
-
   vite-plugin-node-polyfills@0.23.0(rollup@4.59.0)(vite@5.4.21(@types/node@22.19.13)(terser@5.46.0)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.59.0)
@@ -43057,8 +42979,6 @@ snapshots:
   vlq@2.0.4: {}
 
   vm-browserify@1.1.2: {}
-
-  vscode-uri@3.1.0: {}
 
   w3c-xmlserializer@5.0.0:
     dependencies:

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,7 +1,10 @@
 import react from '@vitejs/plugin-react'
 import * as fs from 'fs'
+// @ts-expect-error multiformats package.json exports omit types
 import { CID } from 'multiformats/cid'
+// @ts-expect-error multiformats package.json exports omit types
 import * as raw from 'multiformats/codecs/raw'
+// @ts-expect-error multiformats package.json exports omit types
 import { sha256 } from 'multiformats/hashes/sha2'
 import * as path from 'path'
 import { dirname, resolve } from 'path'
@@ -10,7 +13,6 @@ import { fileURLToPath } from 'url'
 import type { PluginOption } from 'vite'
 import { defineConfig, loadEnv } from 'vite'
 import { analyzer } from 'vite-bundle-analyzer'
-import checker from 'vite-plugin-checker'
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
@@ -21,7 +23,7 @@ const __dirname = dirname(__filename)
 
 const VITE_CSP_META = serializeCsp(cspMeta)
 
-const publicFilesEnvVars = {
+const publicFilesEnvVars: Record<string, string> = {
   VITE_CSP_META: JSON.stringify(VITE_CSP_META),
 }
 
@@ -57,7 +59,7 @@ for (const dirent of fs.readdirSync(publicPath, { withFileTypes: true })) {
 const resolveEthersV5ForHdwallet: PluginOption = {
   name: 'resolve-ethers-v5-hdwallet',
   enforce: 'pre',
-  async resolveId(source, importer) {
+  resolveId(source, importer) {
     if (source === 'ethers' && importer && /\/packages\/hdwallet-/.test(importer)) {
       return this.resolve('ethers5', importer, { skipSelf: true })
     }
@@ -72,7 +74,7 @@ const resolveEthersV5ForHdwallet: PluginOption = {
 const resolveBech32V1ForHdwallet: PluginOption = {
   name: 'resolve-bech32-v1-hdwallet',
   enforce: 'pre',
-  async resolveId(source, importer) {
+  resolveId(source, importer) {
     if (source === 'bech32' && importer && /\/packages\/hdwallet-/.test(importer)) {
       return this.resolve('bech32-v1', importer, { skipSelf: true })
     }
@@ -218,12 +220,6 @@ export default defineConfig(({ mode }) => {
         },
       }),
       tsconfigPaths(),
-      checker({
-        typescript: {
-          typescriptPath: path.join(__dirname, './node_modules/typescript/lib/tsc.js'),
-        },
-        overlay: true,
-      }),
       process.env.ANALYZE === 'true' &&
         analyzer({
           analyzerMode: 'server',
@@ -283,8 +279,14 @@ export default defineConfig(({ mode }) => {
         'ethers/lib/utils': 'ethers5/lib/utils.js',
         'ethers/lib/utils.js': 'ethers5/lib/utils.js',
         'dayjs/locale': resolve(__dirname, 'node_modules/dayjs/locale'),
-        '@shapeshiftoss/hdwallet-native/nativeEvents': resolve(__dirname, './packages/hdwallet-native/src/nativeEvents.ts'),
-        '@shapeshiftoss/hdwallet-native/crypto/revocable': resolve(__dirname, './packages/hdwallet-native/src/crypto/isolation/engines/default/revocable.ts'),
+        '@shapeshiftoss/hdwallet-native/nativeEvents': resolve(
+          __dirname,
+          './packages/hdwallet-native/src/nativeEvents.ts',
+        ),
+        '@shapeshiftoss/hdwallet-native/crypto/revocable': resolve(
+          __dirname,
+          './packages/hdwallet-native/src/crypto/isolation/engines/default/revocable.ts',
+        ),
         '@shapeshiftoss/hdwallet-core': resolve(__dirname, './packages/hdwallet-core/src'),
         '@shapeshiftoss/caip': resolve(__dirname, './packages/caip/src'),
         '@shapeshiftoss/types': resolve(__dirname, './packages/types/src'),
@@ -307,7 +309,8 @@ export default defineConfig(({ mode }) => {
               // buffer polyfill must be in its own chunk to avoid circular deps between ui↔sdk in pnpm
               // Matches: node_modules/buffer/, node_modules/base64-js/, node_modules/ieee754/,
               // and also vite-plugin-node-polyfills/shims/buffer/ and safe-buffer
-              if (/\/node_modules\/(buffer|base64-js|ieee754|safe-buffer)\//.test(id)) return 'polyfills'
+              if (/\/node_modules\/(buffer|base64-js|ieee754|safe-buffer)\//.test(id))
+                return 'polyfills'
               if (/vite-plugin-node-polyfills\/shims\/buffer\//.test(id)) return 'polyfills'
               if (id.match(/(framer-motion|@visx|@coral-xyz)/)) return 'ui'
               if (id.match(/(react-icons|@react-spring|react-datepicker|react-dom)/)) return 'react'


### PR DESCRIPTION
## Description

- Remove `vite-plugin-checker` from the dev pipeline (and dependency). It was the dominant local dev perf bottleneck; CI and editor LSP already surface TypeScript errors.
- Type `publicFilesEnvVars` as `Record<string, string>` so the dynamic `VITE_SRI_*` / `VITE_CID_*` keys built from the `public/` directory type-check.
- Suppress `multiformats/cid|codecs/raw|hashes/sha2` imports with `@ts-expect-error`. multiformats v9 ships types but excludes them from its package `exports`, so TS can't resolve them. The package is only used at build time for SRI/CID computation, so suppressing inline is cleaner than declaring ambient modules.

## Issue (if applicable)

closes #

## Risk

Build/dev tooling only; no runtime app code changes. Dev type errors will no longer block via overlay — they still surface in editor and CI.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

- [ ] `pnpm install` then `pnpm dev` — confirm dev server starts and is noticeably faster on cold/warm boot
- [ ] `pnpm build` — confirm production build still succeeds and emits SRI/CID env vars correctly
- [ ] `pnpm type-check` — confirm no new TS errors

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed development dependency from the project
  * Updated build configuration and plugin settings
  * Enhanced TypeScript type checking with suppression annotations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->