### PR TITLE
chore(deps): allow nested @wagmi/core peer for reown adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -394,7 +394,8 @@
         "utf-8-validate": "6.0.6",
         "@ton/core": "0.62.1",
         "eslint": "8.57.1",
-        "@solana/sysvars": "*"
+        "@solana/sysvars": "*",
+        "@wagmi/core": "*"
       },
       "ignoreMissing": [
         "@solana/sysvars"


### PR DESCRIPTION
## Description

`pnpm i` was failing with `ERR_PNPM_PEER_DEP_ISSUES`:

\`\`\`
packages/swap-widget
└─┬ @reown/appkit-adapter-wagmi 1.8.18
  └─┬ @wagmi/connectors 7.2.1
    └── ✕ unmet peer @wagmi/core@3.4.0: found 2.22.1
\`\`\`

`@reown/appkit-adapter-wagmi` ships with an old `@wagmi/connectors@7.2.1` that peer-requires `@wagmi/core@3.4.0`. pnpm already nests `@wagmi/core@3.4.0` under the adapter (verified in `node_modules/@reown/appkit-adapter-wagmi/node_modules/@wagmi/core`), alongside the top-level `@wagmi/core@2.22.1` used by the rest of the workspace. With `strictPeerDependencies: true`, pnpm only checks the visible (top-level) version and refuses to acknowledge the correctly-nested install.

Adding `@wagmi/core: \"*\"` to `pnpm.peerDependencyRules.allowedVersions` silences the strict check. This is **not** a version override — both `@wagmi/core@2.22.1` and `@wagmi/core@3.4.0` remain installed where their respective consumers expect them.

Verified: `pnpm i` now completes with no peer-dep errors.

## Issue (if applicable)

closes #

## Risk

Dev tooling / install only. No code changes, no runtime behavior changes. Both wagmi core versions were already being installed in the same locations before this PR — only the strict peer-check error is silenced.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

- [ ] `pnpm i` from a clean state — confirm no `ERR_PNPM_PEER_DEP_ISSUES`
- [ ] `pnpm dev` and `pnpm build` — confirm wagmi/reown integrations still work in app and swap-widget

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)