### PR TITLE
chore: update treasury addresses

### DIFF
--- a/packages/utils/src/treasury.ts
+++ b/packages/utils/src/treasury.ts
@@ -36,9 +36,9 @@ export const DAO_TREASURY_BSC = '0x8b92b1698b57bEDF2142297e9397875ADBb2297E'
 export const DAO_TREASURY_ARBITRUM = '0x38276553F8fbf2A027D901F8be45f00373d8Dd48'
 export const DAO_TREASURY_BASE = '0x9c9aA90363630d4ab1D9dbF416cc3BBC8d3Ed502'
 
-export const DAO_TREASURY_BITCOIN = 'bc1qr2whxtd0gvqnctcxlynwejp6fvntv0mtxkv0dlv02vyale8h69ysm6l32n'
+export const DAO_TREASURY_BITCOIN = 'bc1q9xrjfet2a05r3jvsxx66rru7pysevk5dvqasdw9eeea3rfqlk33qr4hghh'
 export const DAO_TREASURY_NEAR = 'shapeshifttokenomics.sputnik-dao.near'
-export const DAO_TREASURY_SOLANA = 'DAis9ukYi5g77fWAiXrDWwek94ndP6LXUD5Vs4CUG34p'
+export const DAO_TREASURY_SOLANA = 'FxXyPB5RH4uHLPPJR5H89zGwZp19juBetmRwrxfsLj2j'
 
 export const DAO_TREASURY_MONAD = '0xF5AA59151bE6515C4Ca68A0282CF68B3eA4846fC'
 export const DAO_TREASURY_HYPEREVM = '0xF5AA59151bE6515C4Ca68A0282CF68B3eA4846fC'


### PR DESCRIPTION
## Description

Updates DAO treasury addresses for Bitcoin and Solana.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low — constants-only change. Affects affiliate fee/treasury routing on BTC and Solana only.

## Testing

### Engineering

- [ ] Verify `DAO_TREASURY_BITCOIN` and `DAO_TREASURY_SOLANA` resolve to the expected addresses where consumed.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

n/a