### PR TITLE
fix(chain-adapters): prevent UTXO sats/byte rounding to zero

### DIFF
--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -481,10 +481,11 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
         assetId: this.assetId,
       }
 
-      // We have to round because coinselect library uses sats per byte which cant be decimals
-      const fastPerByte = String(Math.round(data.fast.satsPerKiloByte / 1000))
-      const averagePerByte = String(Math.round(data.average.satsPerKiloByte / 1000))
-      const slowPerByte = String(Math.round(data.slow.satsPerKiloByte / 1000))
+      // We have to round because coinselect library uses sats per byte which cant be decimals.
+      // Use ceil with a 1 sat/byte floor so sub-1000 sats/kB rates don't collapse to 0.
+      const fastPerByte = String(Math.max(1, Math.ceil(data.fast.satsPerKiloByte / 1000)))
+      const averagePerByte = String(Math.max(1, Math.ceil(data.average.satsPerKiloByte / 1000)))
+      const slowPerByte = String(Math.max(1, Math.ceil(data.slow.satsPerKiloByte / 1000)))
 
       const { fee: fastFee } = utxoSelect({ ...utxoSelectInput, satoshiPerByte: fastPerByte })
       const { fee: averageFee } = utxoSelect({ ...utxoSelectInput, satoshiPerByte: averagePerByte })

--- a/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoin/BitcoinChainAdapter.test.ts
@@ -130,15 +130,15 @@ const getTransactionMockResponse = {
 const getNetworkFeesMockedResponse = {
   fast: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   average: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   slow: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
 }
 

--- a/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/bitcoincash/BitcoinCashChainAdapter.test.ts
@@ -118,15 +118,15 @@ const getTransactionMockResponse = {
 const getNetworkFeesMockedResponse = {
   fast: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   average: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   slow: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
 }
 

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.test.ts
@@ -104,15 +104,15 @@ const getTransactionMockResponse = {
 const getNetworkFeesMockedResponse = {
   fast: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   average: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   slow: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
 }
 

--- a/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
+++ b/packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts
@@ -92,10 +92,11 @@ export class ChainAdapter extends UtxoBaseAdapter<KnownChainIds.DogecoinMainnet>
 
     const utxoSelectInput = { from, to, value, opReturnData, utxos, sendMax, assetId: this.assetId }
 
-    // We have to round because coinselect library uses sats per byte which cant be decimals
-    const fastPerByte = String(Math.round(fast.satsPerKiloByte / 1000))
-    const averagePerByte = String(Math.round(average.satsPerKiloByte / 1000))
-    const slowPerByte = String(Math.round(slow.satsPerKiloByte / 1000))
+    // We have to round because coinselect library uses sats per byte which cant be decimals.
+    // Use ceil with a 1 sat/byte floor so sub-1000 sats/kB rates don't collapse to 0.
+    const fastPerByte = String(Math.max(1, Math.ceil(fast.satsPerKiloByte / 1000)))
+    const averagePerByte = String(Math.max(1, Math.ceil(average.satsPerKiloByte / 1000)))
+    const slowPerByte = String(Math.max(1, Math.ceil(slow.satsPerKiloByte / 1000)))
 
     const { fee: fastFee } = utxoSelect({ ...utxoSelectInput, satoshiPerByte: fastPerByte })
     const { fee: averageFee } = utxoSelect({ ...utxoSelectInput, satoshiPerByte: averagePerByte })

--- a/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
+++ b/packages/chain-adapters/src/utxo/litecoin/LitecoinChainAdapter.test.ts
@@ -107,15 +107,15 @@ const getTransactionMockResponse = {
 const getNetworkFeesMockedResponse = {
   fast: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   average: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
   slow: {
     blocksUntilConfirmation: 1,
-    satsPerKiloByte: 1024,
+    satsPerKiloByte: 1000,
   },
 }
 


### PR DESCRIPTION
## Description

UTXO fee estimation converts `satsPerKiloByte` (returned by unchained) into the per-byte rate that the `coinselect` library requires. The conversion used `Math.round(satsPerKiloByte / 1000)`, which collapses any rate below ~500 sats/kB to `0`.

This is a real condition during low-fee periods. For example, a recent observation:

```
slow:    { satsPerKiloByte: 291,  blocksUntilConfirmation: 10 }
average: { satsPerKiloByte: 302,  blocksUntilConfirmation: 5  }
fast:    { satsPerKiloByte: 2227, blocksUntilConfirmation: 2  }
```

`Math.round(291/1000) = 0` and `Math.round(302/1000) = 0`, so slow/average tiers come back with a `0` per-byte rate. Downstream, `buildSendApiTransaction` rejects this via `if (!satoshiPerByte) throw new Error('satoshiPerByte is required')`, breaking the lower-fee tiers entirely.

Fix: use `Math.ceil` with a 1 sat/byte floor. `Math.max(1, Math.ceil(x / 1000))` guarantees a valid positive rate for any non-negative input, and rounding up biases slightly toward inclusion rather than under-paying.

Applied at both UTXO conversion sites:
- `packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts` (BTC, BCH, LTC, ZEC)
- `packages/chain-adapters/src/utxo/dogecoin/DogecoinChainAdapter.ts` (DOGE)

The Dogecoin adapter already had a `<=0` guard with high default minimums, so it was less likely to trip in practice — but the same math issue applied for any small positive upstream value, and consistency matters.

## Issue (if applicable)

closes #

## Risk

> High Risk PRs Require 2 approvals

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

UTXO chains: BTC, BCH, LTC, ZEC, DOGE. Affects only `getFeeData` output (slow/average/fast per-byte rates and resulting `txFee`). No change to signing or broadcasting paths.

The output rate may now be slightly higher than before for the *same* upstream value (ceil vs round) — by at most ~0.5 sat/byte at the boundary — but this only matters when the upstream rate sits exactly on a half-byte boundary, which is rare.

## Testing

### Engineering

- [ ] Send BTC during a low-fee window (or stub `getNetworkFees` to return e.g. `{ slow: 291, average: 302, fast: 2227 }`); confirm slow/average/fast tiers all yield positive `satoshiPerByte` and a valid `txFee`.
- [ ] Send BTC during a normal-fee window; confirm fees are within the same ballpark as before.
- [ ] Send DOGE; confirm no regression (per-byte rates remain in expected range).
- [ ] Repeat for BCH, LTC, ZEC.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

n/a