### PR TITLE
feat(agenticChat): soften border radii across primary surfaces (SS-5650)

### DIFF
--- a/src/features/agenticChat/components/AgenticChatWindow.tsx
+++ b/src/features/agenticChat/components/AgenticChatWindow.tsx
@@ -86,7 +86,7 @@ export const AgenticChatWindow = ({ isOpen, onClose }: AgenticChatWindowProps) =
         width='400px'
         height='600px'
         bg={bg}
-        borderRadius='xl'
+        borderRadius='2xl'
         boxShadow='2xl'
         border='1px solid'
         borderColor={borderColor}

--- a/src/features/agenticChat/components/Chat.tsx
+++ b/src/features/agenticChat/components/Chat.tsx
@@ -45,7 +45,7 @@ const MessageItem = memo(({ message, userBg }: MessageItemProps) => {
         bg: userBg,
         px: 3,
         py: 2,
-        borderRadius: 'lg',
+        borderRadius: 'xl',
       }
     : {}
 

--- a/src/features/agenticChat/components/Composer.tsx
+++ b/src/features/agenticChat/components/Composer.tsx
@@ -35,7 +35,7 @@ export const Composer = ({ chat }: ComposerProps) => {
   return (
     <Box
       bg={composerBg}
-      borderRadius='xl'
+      borderRadius='2xl'
       border='1px solid'
       borderColor={borderColor}
       p={2}

--- a/src/features/agenticChat/components/DrawerChatButton.tsx
+++ b/src/features/agenticChat/components/DrawerChatButton.tsx
@@ -22,7 +22,7 @@ export const DrawerChatButton = memo(() => {
   if (!isEnabled) return null
 
   return (
-    <Button flex='1' height='80px' borderRadius='xl' alignItems='center' onClick={handleClick}>
+    <Button flex='1' height='80px' borderRadius='2xl' alignItems='center' onClick={handleClick}>
       <VStack spacing={2} justify='center' align='center'>
         {chatIcon}
         <Text fontSize='sm' fontWeight='medium' color='text.subtle'>

--- a/src/features/agenticChat/components/DrawerChatHistory.tsx
+++ b/src/features/agenticChat/components/DrawerChatHistory.tsx
@@ -138,7 +138,7 @@ export const DrawerChatHistory = memo(() => {
               type='text'
               placeholder={translate('agenticChat.searchChats')}
               variant='filled'
-              borderRadius='lg'
+              borderRadius='xl'
             />
           </InputGroup>
         </Box>
@@ -158,8 +158,8 @@ export const DrawerChatHistory = memo(() => {
                 <Box key={conversation.id}>
                   <Flex
                     bg={conversation.id === activeConversationId ? activeBg : 'transparent'}
-                    borderTopRadius={index === 0 ? 'md' : 0}
-                    borderBottomRadius={index === filteredConversations.length - 1 ? 'md' : 0}
+                    borderTopRadius={index === 0 ? 'lg' : 0}
+                    borderBottomRadius={index === filteredConversations.length - 1 ? 'lg' : 0}
                     p={3}
                     cursor='pointer'
                     onClick={() => handleSelectConversation(conversation.id)}

--- a/src/features/agenticChat/components/Markdown.tsx
+++ b/src/features/agenticChat/components/Markdown.tsx
@@ -102,7 +102,7 @@ export const Markdown = ({ children }: MarkdownProps) => {
           width='100%'
           borderWidth='1px'
           borderColor={tableBorderColor}
-          borderRadius='md'
+          borderRadius='lg'
           overflow='hidden'
         >
           {children}
@@ -140,7 +140,7 @@ export const Markdown = ({ children }: MarkdownProps) => {
           bg={codeBlockBg}
           color={codeBlockText}
           p={4}
-          borderRadius='md'
+          borderRadius='lg'
           overflowX='auto'
           my={4}
         >

--- a/src/features/agenticChat/components/tools/DisplayToolCard.tsx
+++ b/src/features/agenticChat/components/tools/DisplayToolCard.tsx
@@ -10,7 +10,7 @@ const DisplayToolCardRoot = ({ children }: DisplayToolCardRootProps) => {
   const bgColor = useColorModeValue('white', 'gray.800')
 
   return (
-    <Box w='full' borderRadius='lg' borderWidth={1} borderColor={borderColor} bg={bgColor} mt={2}>
+    <Box w='full' borderRadius='xl' borderWidth={1} borderColor={borderColor} bg={bgColor} mt={2}>
       {children}
     </Box>
   )

--- a/src/features/agenticChat/components/tools/ReceiveUI.tsx
+++ b/src/features/agenticChat/components/tools/ReceiveUI.tsx
@@ -71,7 +71,7 @@ export const ReceiveUI = ({ toolPart }: ToolUIProps<'receiveTool'>) => {
         <Flex direction='column' gap={4} alignItems='center'>
           <LogoQRCode text={address} asset={asset} size={256} />
 
-          <Flex direction='column' gap={2} w='full' bg={bgColor} p={3} borderRadius='md'>
+          <Flex direction='column' gap={2} w='full' bg={bgColor} p={3} borderRadius='lg'>
             <Text fontSize='xs' color={mutedColor} textAlign='center' fontWeight='medium'>
               {translate('agenticChat.agenticChatTools.receive.copyAddress')}
             </Text>
@@ -98,7 +98,7 @@ export const ReceiveUI = ({ toolPart }: ToolUIProps<'receiveTool'>) => {
             </Flex>
           </Flex>
 
-          <Box w='full' bg={warningBg} p={3} borderRadius='md'>
+          <Box w='full' bg={warningBg} p={3} borderRadius='lg'>
             <Text fontSize='xs' color={warningColor} textAlign='center'>
               {translate('agenticChat.agenticChatTools.receive.warning', {
                 network: chainName ?? network,

--- a/src/features/agenticChat/components/tools/TxStepCard/TxStepCard.tsx
+++ b/src/features/agenticChat/components/tools/TxStepCard/TxStepCard.tsx
@@ -19,7 +19,7 @@ const TxStepCardRoot = ({ children }: TxStepCardRootProps) => {
     <Box
       borderWidth={1}
       borderColor={borderColor}
-      borderRadius='lg'
+      borderRadius='xl'
       bg={bgColor}
       maxW='512px'
       w='full'
@@ -169,7 +169,7 @@ const TxStepCardStep = ({
       position='relative'
       h={10}
       alignItems='center'
-      borderRadius='md'
+      borderRadius='lg'
       px={2}
       mx={-2}
       bg={status === StepStatus.IN_PROGRESS ? inProgressBg : 'transparent'}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Softens border radii throughout the agentic chat UI to make surfaces feel cohesive and less sharp. Applies a two-tier bump:

- **Prominent surfaces** (Composer prompt box, chat window, drawer chat button): `xl` → `2xl`
- **Secondary surfaces** (tool cards, user message bubbles, search input): `lg` → `xl`
- **Minor/internal surfaces** (conversation list highlights, code blocks, table borders, inner containers): `md` → `lg`

### Files changed

| File | Change |
|---|---|
| `Composer.tsx` | `xl` → `2xl` — main prompt box is now the most visually soft element |
| `AgenticChatWindow.tsx` | `xl` → `2xl` — floating chat window container |
| `DrawerChatButton.tsx` | `xl` → `2xl` — AI Chat entry button |
| `Chat.tsx` | `lg` → `xl` — user message bubbles |
| `DrawerChatHistory.tsx` | search input `lg` → `xl`; conversation item highlights `md` → `lg` |
| `DisplayToolCard.tsx` | `lg` → `xl` — tool result cards |
| `TxStepCard.tsx` | root `lg` → `xl`; step row `md` → `lg` |
| `ReceiveUI.tsx` | inner containers `md` → `lg` |
| `Markdown.tsx` | tables and code blocks `md` → `lg` |

## Issue (if applicable)

closes SS-5650

## Risk

Low — pure visual styling changes. No logic, state, or API interactions affected. All changes are within the `agenticChat` feature which is behind the `AgenticChat` feature flag.

## Testing

### Engineering

Enable the `AgenticChat` feature flag locally and visually verify:
- Composer (prompt input box) has visibly softer/rounder corners
- Floating chat window has rounder corners
- Tool result cards (swap, send, receive, tx steps) have rounder corners
- User message bubbles are rounder
- Chat history search input and conversation list highlights are rounder
- Markdown tables and code blocks are slightly rounder

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Visual QA: open the AI Chat drawer/window, send a message, inspect the Composer box, New Chat button, Connect Wallet button, tool cards, and conversation list — all should feel cohesively softer with no hard edges or clipping artifacts.

## Screenshots (if applicable)

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SS-5650](https://linear.app/shapeshift-dao/issue/SS-5650/soften-border-radii-across-primary-surfaces)

<div><a href="https://cursor.com/agents/bc-c52f59eb-7361-43ff-8e56-84cdd1aad75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c52f59eb-7361-43ff-8e56-84cdd1aad75b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

