### PR TITLE
fix(swapper): nearIntents allowance contract and btc omni migration

### DIFF
--- a/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
@@ -3,3 +3,4 @@ export const ONE_CLICK_BASE_URL = 'https://1click.chaindefuser.com'
 export const DEFAULT_SLIPPAGE_BPS = 50
 
 export const DEFAULT_QUOTE_DEADLINE_MS = 30 * 60 * 1000
+export const BTC_QUOTE_DEADLINE_MS = 60 * 60 * 1000

--- a/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
@@ -111,7 +111,9 @@ export const getTradeQuote = async (
     }
 
     const quoteDeadline =
-      sellAsset.chainId === btcChainId ? BTC_QUOTE_DEADLINE_MS : DEFAULT_QUOTE_DEADLINE_MS
+      sellAsset.chainId === btcChainId || buyAsset.chainId === btcChainId
+        ? BTC_QUOTE_DEADLINE_MS
+        : DEFAULT_QUOTE_DEADLINE_MS
 
     const quoteRequest: QuoteRequest = {
       dry: false,

--- a/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
@@ -1,4 +1,4 @@
-import { CHAIN_NAMESPACE, fromAssetId, nearChainId } from '@shapeshiftoss/caip'
+import { btcChainId, CHAIN_NAMESPACE, fromAssetId, nearChainId } from '@shapeshiftoss/caip'
 import { evm } from '@shapeshiftoss/chain-adapters'
 import {
   bn,
@@ -28,7 +28,11 @@ import {
 } from '../../../utils'
 import { buildAffiliateFee } from '../../utils/affiliateFee'
 import { isNativeEvmAsset } from '../../utils/helpers/helpers'
-import { DEFAULT_QUOTE_DEADLINE_MS, DEFAULT_SLIPPAGE_BPS } from '../constants'
+import {
+  BTC_QUOTE_DEADLINE_MS,
+  DEFAULT_QUOTE_DEADLINE_MS,
+  DEFAULT_SLIPPAGE_BPS,
+} from '../constants'
 import type { QuoteResponse } from '../types'
 import { QuoteRequest } from '../types'
 import { assetToNearIntentsAsset, calculateAccountCreationCosts } from '../utils/helpers/helpers'
@@ -106,6 +110,9 @@ export const getTradeQuote = async (
       )
     }
 
+    const quoteDeadline =
+      sellAsset.chainId === btcChainId ? BTC_QUOTE_DEADLINE_MS : DEFAULT_QUOTE_DEADLINE_MS
+
     const quoteRequest: QuoteRequest = {
       dry: false,
       swapType: QuoteRequest.swapType.EXACT_INPUT,
@@ -120,7 +127,7 @@ export const getTradeQuote = async (
       refundType: QuoteRequest.refundType.ORIGIN_CHAIN,
       recipient: receiveAddress,
       recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
-      deadline: new Date(Date.now() + DEFAULT_QUOTE_DEADLINE_MS).toISOString(),
+      deadline: new Date(Date.now() + quoteDeadline).toISOString(),
       referral: 'shapeshift',
       appFees: [
         {
@@ -350,7 +357,7 @@ export const getTradeQuote = async (
       steps: [
         {
           accountNumber,
-          allowanceContract: quote.depositAddress,
+          allowanceContract: '',
           buyAmountBeforeFeesCryptoBaseUnit: quote.amountOut,
           buyAmountAfterFeesCryptoBaseUnit: quote.amountOut,
           buyAsset,

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers/helpers.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers/helpers.ts
@@ -64,6 +64,7 @@ export const getNearIntentsAsset = ({
 const NEP245_CHAINS = ['bsc', 'pol', 'avax', 'op', 'tron', 'monad', 'plasma'] as const
 const TOKEN_LOOKUP_CHAINS = ['sui', 'starknet', 'ton'] as const
 const NEAR_CHAIN = 'near' as const
+const BTC_CHAIN = 'btc' as const
 const WNEAR_CONTRACT_ADDRESS = 'wrap.near' as const
 
 type Nep245Chain = (typeof NEP245_CHAINS)[number]
@@ -82,6 +83,9 @@ export const assetToNearIntentsAsset = async (asset: Asset): Promise<string | nu
     chainIdToNearIntentsChain[asset.chainId as keyof typeof chainIdToNearIntentsChain]
 
   if (!nearNetwork) return null
+
+  // https://partners.near-intents.org/omni-migration#partners
+  if (nearNetwork === BTC_CHAIN) return `1cs_v1:btc:native:coin`
 
   // NEAR chain requires special handling
   // Native NEAR maps to wNEAR (wrap.near)
@@ -127,7 +131,7 @@ export const assetToNearIntentsAsset = async (asset: Asset): Promise<string | nu
     return match.assetId
   }
 
-  // NEP-141 chains (ETH, ARB, BASE, GNOSIS, BTC, DOGE): use predictable format
+  // NEP-141 chains (ETH, ARB, BASE, GNOSIS, DOGE): use predictable format
   const contractAddress = isToken(asset.assetId)
     ? fromAssetId(asset.assetId).assetReference
     : zeroAddress


### PR DESCRIPTION
## Description

Three small fixes to the NearIntents swapper:

- **Allowance contract**: clear `allowanceContract` on the quote step. The `depositAddress` is not an ERC20 allowance contract and shouldn't be returned as such.
- **BTC omni migration**: map BTC to `1cs_v1:btc:native:coin` per the [omni migration partners doc](https://partners.near-intents.org/omni-migration#partners). Removed BTC from the NEP-141 fallback comment since it now takes the omni path.
- **BTC quote deadline**: use a 60-min quote deadline when either side of the trade is BTC (vs. the default 30 min), to accommodate slower BTC confirmations.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

NearIntents swapper only. No new on-chain transaction types — `allowanceContract` was already unused for Near intents flows (deposits, not approvals).

## Testing

### Engineering

- Get a quote with BTC as sell asset → verify deadline is ~60 min out and asset id resolves to `1cs_v1:btc:native:coin`
- Get a quote with BTC as buy asset → verify deadline is ~60 min out
- Get a quote with neither side BTC → verify deadline remains ~30 min
- Verify `allowanceContract` is empty string on the returned trade quote step

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented enhanced Bitcoin (BTC) swap handling with a dedicated one-hour quote validity window to better support BTC settlement requirements.
  * Added specialized asset mapping for Bitcoin trades on the NEAR Intents protocol.

* **Bug Fixes**
  * Corrected allowance contract field in swap quote processing for improved transaction configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/web/pull/12338)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->