### PR TITLE
fix(public-api): near intents erc20 transfers and required swapper api keys

### DIFF
--- a/packages/public-api/.env.example
+++ b/packages/public-api/.env.example
@@ -52,14 +52,14 @@ ACROSS_API_URL=https://app.across.to/api
 DEBRIDGE_API_URL=https://dln.debridge.finance/v1.0
 CHAINFLIP_API_URL=https://chainflip-broker.io
 
-# Swapper API Keys (leave empty if not using)
-CHAINFLIP_API_KEY=
+# Swapper API Keys
+ACROSS_INTEGRATOR_ID=
 BEBOP_API_KEY=
+CHAINFLIP_API_KEY=
 NEAR_INTENTS_API_KEY=
 TENDERLY_API_KEY=
 TENDERLY_ACCOUNT_SLUG=
 TENDERLY_PROJECT_SLUG=
-ACROSS_INTEGRATOR_ID=
 
 # Affiliate
 DEFAULT_AFFILIATE_BPS=60

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -58,14 +58,14 @@ const envSchema = z.object({
   DEBRIDGE_API_URL: url,
   CHAINFLIP_API_URL: url,
 
-  // Swapper API keys (optional)
-  CHAINFLIP_API_KEY: z.string().default(''),
-  BEBOP_API_KEY: z.string().default(''),
-  NEAR_INTENTS_API_KEY: z.string().default(''),
-  TENDERLY_API_KEY: z.string().default(''),
-  TENDERLY_ACCOUNT_SLUG: z.string().default(''),
-  TENDERLY_PROJECT_SLUG: z.string().default(''),
+  // Swapper API keys
   ACROSS_INTEGRATOR_ID: z.string().default(''),
+  BEBOP_API_KEY: z.string(),
+  CHAINFLIP_API_KEY: z.string(),
+  NEAR_INTENTS_API_KEY: z.string(),
+  TENDERLY_API_KEY: z.string(),
+  TENDERLY_ACCOUNT_SLUG: z.string(),
+  TENDERLY_PROJECT_SLUG: z.string(),
 
   // Feature flags
   FEATURE_THORCHAINSWAP_LONGTAIL: flag,

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -60,12 +60,12 @@ const envSchema = z.object({
 
   // Swapper API keys
   ACROSS_INTEGRATOR_ID: z.string().default(''),
-  BEBOP_API_KEY: z.string(),
-  CHAINFLIP_API_KEY: z.string(),
-  NEAR_INTENTS_API_KEY: z.string(),
-  TENDERLY_API_KEY: z.string(),
-  TENDERLY_ACCOUNT_SLUG: z.string(),
-  TENDERLY_PROJECT_SLUG: z.string(),
+  BEBOP_API_KEY: z.string().min(1),
+  CHAINFLIP_API_KEY: z.string().min(1),
+  NEAR_INTENTS_API_KEY: z.string().min(1),
+  TENDERLY_API_KEY: z.string().min(1),
+  TENDERLY_ACCOUNT_SLUG: z.string().min(1),
+  TENDERLY_PROJECT_SLUG: z.string().min(1),
 
   // Feature flags
   FEATURE_THORCHAINSWAP_LONGTAIL: flag,

--- a/packages/public-api/src/routes/quote/extractTransactionData.ts
+++ b/packages/public-api/src/routes/quote/extractTransactionData.ts
@@ -1,5 +1,7 @@
 import { fromChainId } from '@shapeshiftoss/caip'
+import { evm } from '@shapeshiftoss/chain-adapters'
 import type { TradeQuoteStep } from '@shapeshiftoss/swapper'
+import { contractAddressOrUndefined } from '@shapeshiftoss/utils'
 
 import type {
   CosmosTransactionData,
@@ -80,12 +82,26 @@ const extractEvmTransactionData = (step: TradeQuoteStep): EvmTransactionData | u
     }
 
     if (step.nearIntentsSpecific?.depositAddress) {
+      const depositAddress = step.nearIntentsSpecific.depositAddress
+      const value = step.sellAmountIncludingProtocolFeesCryptoBaseUnit
+      const contractAddress = contractAddressOrUndefined(step.sellAsset.assetId)
+
+      if (contractAddress) {
+        return {
+          type: 'evm' as const,
+          chainId,
+          to: contractAddress,
+          data: evm.getErc20Data(depositAddress, value, contractAddress),
+          value: '0',
+        }
+      }
+
       return {
         type: 'evm' as const,
         chainId,
-        to: step.nearIntentsSpecific.depositAddress,
+        to: depositAddress,
         data: '0x',
-        value: step.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        value,
       }
     }
 


### PR DESCRIPTION
## Description

Two fixes to the public-api Near intents flow:

- **ERC20 sell support**: previously ERC20 sells sent the raw token amount as `value` directly to the Near intents deposit address — the deposit never landed and downstream network fee estimation was wrong. Now we build a proper `transfer(depositAddress, value)` calldata against the token contract for ERC20 sell assets; native sells are unchanged.
- **Required swapper API keys**: `BEBOP_API_KEY`, `CHAINFLIP_API_KEY`, `NEAR_INTENTS_API_KEY`, `TENDERLY_API_KEY`, `TENDERLY_ACCOUNT_SLUG`, `TENDERLY_PROJECT_SLUG` were silently defaulting to empty strings. With no Near intents key the 1click upstream couldn't apply the correct affiliate fee split, and missing Tenderly creds meant network fee estimation was running degraded. These are now required env vars so misconfigured deploys fail fast at boot.
- `.env.example` regrouped/sorted to match.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Public-api Near intents quote path only. ERC20 path changes the EVM tx shape we hand back to clients (now an ERC20 transfer to the token contract instead of a value-bearing send to the deposit address). No on-chain contracts changed.

The required env keys are a deploy-side concern — confirm all environments have these set before merging or boot will fail.

## Testing

### Engineering

- Quote a Near intents swap with a native EVM sell (e.g. ETH on mainnet) → tx data unchanged: `to: depositAddress`, `data: '0x'`, `value: amount`
- Quote a Near intents swap with an ERC20 sell (e.g. USDC) → tx data: `to: tokenContract`, `data: transfer(depositAddress, amount)`, `value: '0'`
- Boot the service with one of the required keys missing → expect zod schema failure on startup
- Verify affiliate split appears correctly in the quote response when `NEAR_INTENTS_API_KEY` is set

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed transaction handling for NEAR Intents deposits on EVM networks.

## Chores
* Strengthened validation to require API configuration keys during application startup, ensuring proper setup before operation begins.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/web/pull/12339)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->