### PR TITLE
fix(swapper): correct maya non-cacao outbound fee precision

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "17.7.2",
+  "version": "17.7.3",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swapper/src/thorchain-utils/checkTradeStatus.ts
+++ b/packages/swapper/src/thorchain-utils/checkTradeStatus.ts
@@ -95,7 +95,12 @@ export const checkTradeStatus = async ({
 
     return { buyTxHash, status: TxStatus.Pending, message }
   } catch (e) {
-    console.error(e)
+    const message = (() => {
+      if (axios.isAxiosError(e)) return e.response?.data?.message ?? e.message
+      if (e instanceof Error) return e.message
+      return String(e)
+    })()
+    console.error(`checkTradeStatus(${nativeChain}, ${txHash}): ${message}`)
     return { buyTxHash: undefined, status: TxStatus.Unknown, message: undefined }
   }
 }

--- a/packages/swapper/src/thorchain-utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.test.ts
+++ b/packages/swapper/src/thorchain-utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.test.ts
@@ -10,8 +10,8 @@ import { SwapperName } from '../../types'
 import { thorService } from '../service'
 import type { MidgardPoolResponse } from '../types'
 import {
-  getExpectedAffiliateFeeSellAssetThorUnit,
-  getOutboundFeeInSellAssetThorBaseUnit,
+  getExpectedAffiliateFeeSellAssetThorBaseUnit,
+  getOutboundFeeSellAssetThorBaseUnit,
   getThresholdedAffiliateBps,
 } from './getThresholdedAffiliateBps'
 
@@ -37,24 +37,41 @@ vi.mock('../service', () => {
   }
 })
 
-describe('getOutboundFeeInSellAssetThorBaseUnit', () => {
+describe('getOutboundFeeSellAssetThorBaseUnit', () => {
   it('should return 0.02 rune denominated in the target asset, in thor units', () => {
     const assetPricePrecision = '4.00000' // 1 token is 4x as valuable as 1 rune
     expect(
-      getOutboundFeeInSellAssetThorBaseUnit(assetPricePrecision, SwapperName.Thorchain).toNumber(),
+      getOutboundFeeSellAssetThorBaseUnit(
+        assetPricePrecision,
+        ETH.assetId,
+        SwapperName.Thorchain,
+      ).toNumber(),
     ).toEqual(
       Number(thorchain.NATIVE_FEE) / 4, // .005 of the sell asset in THOR base unit
     )
   })
+
+  it('should scale CACAO 10-dec native fee down to non-CACAO 8-dec sell asset precision on MAYA', () => {
+    // 1 eth = 100 cacao, NATIVE_FEE = 2e9 (10-dec CACAO = 0.2 CACAO)
+    // 0.2 CACAO / 100 (CACAO/ETH) = 0.002 ETH = 200_000 at 8-dec ETH
+    const assetPrice = '100'
+    expect(
+      getOutboundFeeSellAssetThorBaseUnit(
+        assetPrice,
+        ETH.assetId,
+        SwapperName.Mayachain,
+      ).toNumber(),
+    ).toEqual(200_000)
+  })
 })
 
-describe('getExpectedAffiliateFeeSellAssetThorUnit', () => {
+describe('getExpectedAffiliateFeeSellAssetThorBaseUnit', () => {
   it('should return the correct affiliate fee in thor base units', () => {
     const sellAmountCryptoBaseUnit = '1000000000000000000' // 1 eth
     const affiliateBps = '35'
     const sellAsset = ETH
 
-    const result = getExpectedAffiliateFeeSellAssetThorUnit(
+    const result = getExpectedAffiliateFeeSellAssetThorBaseUnit(
       sellAmountCryptoBaseUnit,
       sellAsset,
       affiliateBps,
@@ -71,7 +88,7 @@ describe('getExpectedAffiliateFeeSellAssetThorUnit', () => {
     const affiliateBps = '0'
     const sellAsset = ETH
 
-    const result = getExpectedAffiliateFeeSellAssetThorUnit(
+    const result = getExpectedAffiliateFeeSellAssetThorBaseUnit(
       sellAmountCryptoBaseUnit,
       sellAsset,
       affiliateBps,

--- a/packages/swapper/src/thorchain-utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
+++ b/packages/swapper/src/thorchain-utils/getThresholdedAffiliateBps/getThresholdedAffiliateBps.ts
@@ -1,5 +1,6 @@
+import type { AssetId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
-import { bn, convertBasisPointsToDecimalPercentage, convertPrecision } from '@shapeshiftoss/utils'
+import { convertBasisPointsToDecimalPercentage, convertPrecision } from '@shapeshiftoss/utils'
 
 import type { SwapperConfig, SwapperName } from '../../types'
 import type { MidgardPoolResponse } from '../index'
@@ -8,24 +9,33 @@ import {
   getNativeFee,
   getNativePrecision,
   getPoolAssetId,
+  getSwapperNativeAssetId,
   isNativeAsset,
   thorService,
 } from '../index'
 
-export const getOutboundFeeInSellAssetThorBaseUnit = (
+// Convert native fee to sell asset's native precision before dividing by `assetPrice`.
+// MAYA's CACAO is 10-dec but pool assets are 8-dec — skip this and the result is 100x off.
+export const getOutboundFeeSellAssetThorBaseUnit = (
   runePerAsset: string,
+  sellAssetId: AssetId,
   swapperName: SwapperName,
 ) => {
-  return bn(getNativeFee(swapperName)).dividedBy(runePerAsset)
+  const nativeFeeSellAssetThorBaseUnit = convertPrecision({
+    value: getNativeFee(swapperName),
+    inputExponent: getNativePrecision(getSwapperNativeAssetId(swapperName), swapperName),
+    outputExponent: getNativePrecision(sellAssetId, swapperName),
+  })
+  return nativeFeeSellAssetThorBaseUnit.dividedBy(runePerAsset)
 }
 
-export const getExpectedAffiliateFeeSellAssetThorUnit = (
+export const getExpectedAffiliateFeeSellAssetThorBaseUnit = (
   sellAmountCryptoBaseUnit: string,
   sellAsset: Asset,
   affiliateBps: string,
   swapperName: SwapperName,
 ) => {
-  const sellAmountThorUnit = convertPrecision({
+  const sellAmountThorBaseUnit = convertPrecision({
     value: sellAmountCryptoBaseUnit,
     inputExponent: sellAsset.precision,
     outputExponent: getNativePrecision(sellAsset.assetId, swapperName),
@@ -33,7 +43,7 @@ export const getExpectedAffiliateFeeSellAssetThorUnit = (
 
   const affiliatePercent = convertBasisPointsToDecimalPercentage(affiliateBps)
 
-  return sellAmountThorUnit.times(affiliatePercent)
+  return sellAmountThorBaseUnit.times(affiliatePercent)
 }
 
 // don't apply an affiliate fee if it's below the outbound fee for the inbound pool
@@ -52,7 +62,7 @@ export const getThresholdedAffiliateBps = async ({
 }) => {
   const midgardUrl = getMidgardUrl(config, swapperName)
 
-  const outboundFeeSellAssetThorUnit = await (async () => {
+  const outboundFeeSellAssetThorBaseUnit = await (async () => {
     if (isNativeAsset(sellAsset.assetId, swapperName)) return getNativeFee(swapperName)
 
     const sellPoolId = getPoolAssetId({ assetId: sellAsset.assetId, swapperName })
@@ -63,20 +73,20 @@ export const getThresholdedAffiliateBps = async ({
 
     const pool = res.unwrap().data
 
-    // calculate the rune outbound fee denominated in the sell asset, in native units
-    return getOutboundFeeInSellAssetThorBaseUnit(pool.assetPrice, swapperName)
+    // calculate the rune outbound fee denominated in the sell asset, in thor base units
+    return getOutboundFeeSellAssetThorBaseUnit(pool.assetPrice, sellAsset.assetId, swapperName)
   })()
 
-  // calculate the expected affiliate fee, in native units
-  const expectedAffiliateFeeSellAssetThorUnit = getExpectedAffiliateFeeSellAssetThorUnit(
+  // calculate the expected affiliate fee, in thor base units
+  const expectedAffiliateFeeSellAssetThorBaseUnit = getExpectedAffiliateFeeSellAssetThorBaseUnit(
     sellAmountCryptoBaseUnit,
     sellAsset,
     affiliateBps,
     swapperName,
   )
 
-  const isAffiliateFeeBelowOutboundFee = expectedAffiliateFeeSellAssetThorUnit.lte(
-    outboundFeeSellAssetThorUnit,
+  const isAffiliateFeeBelowOutboundFee = expectedAffiliateFeeSellAssetThorBaseUnit.lte(
+    outboundFeeSellAssetThorBaseUnit,
   )
 
   return isAffiliateFeeBelowOutboundFee ? '0' : affiliateBps

--- a/packages/swapper/src/thorchain-utils/index.ts
+++ b/packages/swapper/src/thorchain-utils/index.ts
@@ -1,5 +1,10 @@
 import type { AssetId } from '@shapeshiftoss/caip'
-import { mayachainAssetId, mayachainChainId, thorchainChainId } from '@shapeshiftoss/caip'
+import {
+  mayachainAssetId,
+  mayachainChainId,
+  thorchainAssetId,
+  thorchainChainId,
+} from '@shapeshiftoss/caip'
 import * as adapters from '@shapeshiftoss/chain-adapters'
 
 import {
@@ -95,6 +100,17 @@ export const getNativePrecision = (assetId: AssetId, swapperName: SwapperName) =
       return THORCHAIN_PRECISION
     case SwapperName.Mayachain:
       return assetId === mayachainAssetId ? CACAO_PRECISION : MAYACHAIN_PRECISION
+    default:
+      throw new Error(`Invalid swapper: ${swapperName}`)
+  }
+}
+
+export const getSwapperNativeAssetId = (swapperName: SwapperName): AssetId => {
+  switch (swapperName) {
+    case SwapperName.Thorchain:
+      return thorchainAssetId
+    case SwapperName.Mayachain:
+      return mayachainAssetId
     default:
       throw new Error(`Invalid swapper: ${swapperName}`)
   }


### PR DESCRIPTION
## Description

Fixes a precision bug in `getThresholdedAffiliateBps` for MAYA non-CACAO swaps. Midgard's `assetPrice` is a precision-normalized decimal ratio (native asset per sell asset), but the previous implementation divided the raw native fee by it without first reconciling that MAYA's CACAO is 10-dec while pool assets are 8-dec.

Result: the outbound-fee threshold was 100x too large on MAYA non-CACAO pairs, silently zeroing out legitimate affiliate fees.

Also included:
- Unified naming on `*SellAssetThorBaseUnit` (was mixed `ThorUnit` / `ThorBaseUnit` / `InSellAsset` / `SellAsset`).
- Distilled the precision comment to two lines.
- `checkTradeStatus` no longer dumps the full axios error object; logs `checkTradeStatus(<chain>, <txHash>): <message>` with the response body when present.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

THORChain and Mayachain L1 swap quotes. Behavior is unchanged for THOR (8→8 precision conversion is a no-op) and for native sell assets (RUNE/CACAO, gated upstream). Only MAYA non-CACAO sell assets see a change: outbound fee comparison value is now 100x smaller, matching reality.

## Testing

### Engineering

- Added unit test covering MAYA non-CACAO precision scaling (CACAO 10-dec native fee → 8-dec sell asset).
- Existing THOR test continues to pass; the precision conversion is a no-op there.
- `pnpm vitest run packages/swapper/src/thorchain-utils/getThresholdedAffiliateBps`

Math walkthrough for the new test:
- MAYA `NATIVE_FEE = 2_000_000_000` (0.2 CACAO @ 10-dec)
- `assetPrice = 100` (1 ETH = 100 CACAO)
- `convertPrecision(2_000_000_000, 10, 8) = 20_000_000`
- `20_000_000 / 100 = 200_000` (0.002 ETH @ 8-dec) ✓

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not behind a flag, but the change only affects MAYA non-CACAO affiliate fee calculations server-side — no UI changes. Smoke a MAYA non-CACAO swap (e.g. ETH→BTC) and verify quotes still return normally; expectation is that more swaps now correctly carry the configured affiliate BPS instead of `0`.

## Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)