### PR TITLE
feat(swap-widget): enable mayachain swapper

### DIFF
--- a/packages/swap-widget/src/constants/swappers.ts
+++ b/packages/swap-widget/src/constants/swappers.ts
@@ -7,7 +7,8 @@ export const SWAPPER_ICONS: Partial<Record<SwapperName, string>> = {
     'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/relay-icon.svg',
   [SwapperName.Thorchain]:
     'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/thorchain-icon.png',
-  //[SwapperName.Mayachain]: 'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/maya_logo.png',
+  [SwapperName.Mayachain]:
+    'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/maya_logo.png',
   //[SwapperName.ArbitrumBridge]: 'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/arbitrum-bridge-icon.png',
   //[SwapperName.Bebop]: 'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/bebop-icon.png',
   //[SwapperName.ButterSwap]: 'https://raw.githubusercontent.com/shapeshift/web/develop/src/components/MultiHopTrade/components/TradeInput/components/SwapperIcon/butterswap.png',
@@ -21,7 +22,7 @@ export const SWAPPER_COLORS: Partial<Record<SwapperName, string>> = {
   [SwapperName.NearIntents]: '#000000',
   [SwapperName.Relay]: '#6366F1',
   [SwapperName.Thorchain]: '#00CCFF',
-  //[SwapperName.Mayachain]: '#4169E1',
+  [SwapperName.Mayachain]: '#4169E1',
   //[SwapperName.ArbitrumBridge]: '#28A0F0',
   //[SwapperName.Bebop]: '#E91E63',
   //[SwapperName.ButterSwap]: '#FFD700',

--- a/packages/swap-widget/src/types/index.ts
+++ b/packages/swap-widget/src/types/index.ts
@@ -38,7 +38,7 @@ export enum SwapperName {
   NearIntents = 'NEAR Intents',
   Relay = 'Relay',
   Thorchain = 'THORChain',
-  //Mayachain = 'MAYAChain',
+  Mayachain = 'MAYAChain',
   //ArbitrumBridge = 'Arbitrum Bridge',
   //Avnu = 'AVNU',
   //Bebop = 'Bebop',


### PR DESCRIPTION
## Description

Enable the MAYAChain swapper in the swap-widget package by uncommenting the `Mayachain` entries in the `SwapperName` enum, `SWAPPER_ICONS`, and `SWAPPER_COLORS` maps.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low risk — swap-widget package only. Surfaces the existing MAYAChain swapper integration in the widget UI; no on-chain transaction logic is added or modified here.

## Testing

### Engineering

- Run the swap-widget locally and verify MAYAChain quotes appear for supported pairs (e.g., CACAO ↔ BTC/ETH).
- Confirm the MAYAChain icon and brand color render correctly in the swapper list / quote rows.
- Verify other swappers (THORChain, Relay, NEAR Intents, etc.) are unaffected.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Mayachain as an available swapper option with proper icon and color display integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/web/pull/12345)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->