### PR TITLE
fix(phantom): normalize EIP-1474 hex quantities so yields approvals don't reject

### DIFF
--- a/packages/hdwallet-coinbase/src/coinbase.test.ts
+++ b/packages/hdwallet-coinbase/src/coinbase.test.ts
@@ -127,6 +127,7 @@ describe('CoinbaseHDWallet', () => {
       nonce: '0xDEADBEEF',
       gasLimit: '0xDEADBEEF',
       maxFeePerGas: '0xDEADBEEF',
+      maxPriorityFeePerGas: '0xDEADBEEF',
       to: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
       value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
       data: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',

--- a/packages/hdwallet-core/src/ethereum.ts
+++ b/packages/hdwallet-core/src/ethereum.ts
@@ -75,9 +75,9 @@ export type ETHSignTx = {
   | {
       gasPrice?: never
       /** EIP-1559 - The maximum total fee per gas the sender is willing to pay. <=256 bit unsigned big endian (in wei) */
-      maxFeePerGas?: Hex
+      maxFeePerGas: Hex
       /** EIP-1559 - Maximum fee per gas the sender is willing to pay to miners. <=256 bit unsigned big endian (in wei) */
-      maxPriorityFeePerGas?: Hex
+      maxPriorityFeePerGas: Hex
     }
 )
 

--- a/packages/hdwallet-metamask-multichain/src/shapeshift-multichain.test.ts
+++ b/packages/hdwallet-metamask-multichain/src/shapeshift-multichain.test.ts
@@ -132,6 +132,7 @@ describe('MetaMaskMultiChainHDWallet', () => {
       nonce: '0xDEADBEEF',
       gasLimit: '0xDEADBEEF',
       maxFeePerGas: '0xDEADBEEF',
+      maxPriorityFeePerGas: '0xDEADBEEF',
       to: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
       value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
       data: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',

--- a/packages/hdwallet-phantom/src/ethereum.ts
+++ b/packages/hdwallet-phantom/src/ethereum.ts
@@ -1,6 +1,6 @@
 import type { ETHSignedMessage } from '@shapeshiftoss/hdwallet-core'
 import * as core from '@shapeshiftoss/hdwallet-core'
-import { isHexString } from 'ethers/lib/utils'
+import { hexValue, isHexString } from 'ethers/lib/utils'
 
 import type { PhantomEvmProvider } from './types'
 
@@ -26,19 +26,19 @@ export async function ethSendTx(
     const utxBase = {
       from,
       to: msg.to,
-      value: msg.value,
-      chainId: msg.chainId,
+      value: hexValue(msg.value),
       data: msg.data,
-      gasLimit: msg.gasLimit,
+      gasLimit: hexValue(msg.gasLimit),
     }
 
-    const utx = msg.maxFeePerGas
-      ? {
-          ...utxBase,
-          maxFeePerGas: msg.maxFeePerGas,
-          maxPriorityFeePerGas: msg.maxPriorityFeePerGas,
-        }
-      : { ...utxBase, gasPrice: msg.gasPrice }
+    const utx =
+      msg.maxFeePerGas && msg.maxPriorityFeePerGas
+        ? {
+            ...utxBase,
+            maxFeePerGas: hexValue(msg.maxFeePerGas),
+            maxPriorityFeePerGas: hexValue(msg.maxPriorityFeePerGas),
+          }
+        : { ...utxBase, gasPrice: hexValue(msg.gasPrice) }
 
     const signedTx = await phantom.request?.({
       method: 'eth_sendTransaction',

--- a/packages/hdwallet-phantom/src/phantom.test.ts
+++ b/packages/hdwallet-phantom/src/phantom.test.ts
@@ -81,6 +81,7 @@ describe('PhantomHDWallet', () => {
         nonce: '0xDEADBEEF',
         gasLimit: '0xDEADBEEF',
         maxFeePerGas: '0xDEADBEEF',
+        maxPriorityFeePerGas: '0xDEADBEEF',
         to: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
         value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
         data: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',

--- a/packages/hdwallet-vultisig/src/vultisig.test.ts
+++ b/packages/hdwallet-vultisig/src/vultisig.test.ts
@@ -74,6 +74,7 @@ describe('VultisigHDWallet', () => {
         nonce: '0xDEADBEEF',
         gasLimit: '0xDEADBEEF',
         maxFeePerGas: '0xDEADBEEF',
+        maxPriorityFeePerGas: '0xDEADBEEF',
         to: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
         value: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
         data: '0xDEADBEEFDEADBEEFDEADBEEFDEADBEEF',

--- a/src/lib/yieldxyz/executeTransaction.test.ts
+++ b/src/lib/yieldxyz/executeTransaction.test.ts
@@ -64,8 +64,14 @@ describe('toHexOrDefault', () => {
     expect(toHexOrDefault('', '0x0')).toBe('0x0')
   })
 
-  it('should return hex value as-is when already hex', () => {
+  it('should preserve already-compact hex', () => {
     expect(toHexOrDefault('0x30d40', '0x0')).toBe('0x30d40')
+  })
+
+  it('should strip leading zeros from hex to satisfy EIP-1474', () => {
+    expect(toHexOrDefault('0x054e0840', '0x0')).toBe('0x54e0840')
+    expect(toHexOrDefault('0x036bd6', '0x0')).toBe('0x36bd6')
+    expect(toHexOrDefault('0x00', '0x0')).toBe('0x0')
   })
 
   it('should convert number to hex', () => {
@@ -141,7 +147,9 @@ describe('EVM transaction parsing - ETH rETH liquid staking', () => {
 
   it('should produce valid hex values from tx fields', () => {
     const parsed = JSON.parse(ETH_RETH_UNSIGNED_TX)
-    expect(toHexOrDefault(parsed.gasLimit, '0x0')).toBe('0x036bd6')
+    expect(toHexOrDefault(parsed.gasLimit, '0x0')).toBe('0x36bd6')
+    expect(toHexOrDefault(parsed.maxFeePerGas, '0x0')).toBe('0xa21fe80')
+    expect(toHexOrDefault(parsed.maxPriorityFeePerGas, '0x0')).toBe('0x54e0840')
     expect(toHexOrDefault(parsed.value, '0x0')).toBe('0xde78bc6ce42d1a')
     expect(toHexData(parsed.data)).toBe('0x5bcb2fc6')
   })
@@ -159,7 +167,7 @@ describe('EVM transaction parsing - AVAX sAVAX liquid staking', () => {
     const parsed = JSON.parse(AVAX_SAVAX_UNSIGNED_TX)
     expect(toHexOrDefault(parsed.gasLimit, '0x0')).toBe('0xde93')
     expect(toHexOrDefault(parsed.maxFeePerGas, '0x0')).toBe('0xcaa808')
-    expect(toHexOrDefault(parsed.maxPriorityFeePerGas, '0x0')).toBe('0x03e8')
+    expect(toHexOrDefault(parsed.maxPriorityFeePerGas, '0x0')).toBe('0x3e8')
     expect(toHexOrDefault(parsed.value, '0x0')).toBe('0xde78bc6ce42d1a')
   })
 })

--- a/src/lib/yieldxyz/executeTransaction.ts
+++ b/src/lib/yieldxyz/executeTransaction.ts
@@ -141,10 +141,12 @@ type ExecuteEvmTransactionInput = {
   bip44Params?: { purpose: number; coinType: number; accountNumber: number }
 }
 
+// Always normalizes through BigInt so the output is EIP-1474 compact hex (no leading zeros, except
+// 0x0 itself). yield.xyz returns padded hex like 0x054e0840 that Phantom rejects as invalid; viem's
+// isHex would short-circuit and pass that through unchanged.
 export const toHexOrDefault = (value: string | number | undefined, fallback: Hex): Hex => {
   if (value === undefined || value === null || value === '') return fallback
   if (typeof value === 'number') return toHex(value)
-  if (isHex(value)) return value as Hex
   try {
     return toHex(BigInt(value))
   } catch {


### PR DESCRIPTION
## Description

Phantom strictly enforces EIP-1474 hex QUANTITY encoding — no leading zeros except `0x0` itself — and rejects non-compact hex with a generic `Missing or invalid parameters` error (code -32000). MetaMask silently normalizes, which is why yields approvals worked there but not on Phantom: yield.xyz returns padded hex like `0x054e0840` and the client was passing it through unchanged.

**Changes:**

- `packages/hdwallet-phantom/src/ethereum.ts` — normalize all hex QUANTITY fields (`value`, `gasLimit`, `maxFeePerGas`, `maxPriorityFeePerGas`, `gasPrice`) via ethers v5's `hexValue` before invoking `phantom.request({ method: 'eth_sendTransaction' })`.
- `src/lib/yieldxyz/executeTransaction.ts` — `toHexOrDefault` was short-circuiting on `isHex` and preserving non-compact input verbatim. Always re-encode through `BigInt`/`toHex` so the output is EIP-1474 compact.
- `packages/hdwallet-core/src/ethereum.ts` — tighten the EIP-1559 variant of `ETHSignTx` to require both `maxFeePerGas` and `maxPriorityFeePerGas` (matches the existing `NetworkFees` discriminator). Enables proper discriminated-union narrowing at callsites.
- Added missing `maxPriorityFeePerGas` to the EIP-1559 ethSendTx tests in `coinbase`, `metamask-multichain`, `vultisig`, and `phantom` adapters — surfaced by the tighter type.
- Updated `executeTransaction.test.ts` expectations that codified the buggy non-compact output; added a regression test for the leading-zero case.

## Issue (if applicable)

closes #12350

[SS-5675](https://linear.app/shapeshift-dao/issue/SS-5675/approvals-for-evm-deposits-on-yeilds-failing-on-phantom-wallet)

## Risk

> High Risk PRs Require 2 approvals

**High risk.** Touches `hdwallet-core` (the `ETHSignTx` type) and the EVM transaction send path in `hdwallet-phantom`. Type tightening surfaced three previously-incorrect adapter tests but does not change runtime behavior for any production construction site (all already pair both EIP-1559 fields). yield.xyz EVM execute path is also touched (`toHexOrDefault` semantics).

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- **Wallets:** Phantom (EVM) — behavior changed (now compliant). MetaMask / Ledger / KeepKey / Coinbase / Vultisig / WalletConnect / Native — no runtime change.
- **Transaction types:** all EIP-1559 transactions through `hdwallet-phantom`, all EVM transactions originating from yield.xyz flows.
- **Contract interactions:** any approval / deposit via the Yields feature on EVM chains.

## Testing

### Engineering

Repro (without this fix): connect Phantom on Ethereum mainnet, attempt a yields deposit on USDC (Aave V3 or similar). Approval popup never appears, console shows `error signing & broadcasting tx` originating from `ethereum.ts:50` → Phantom's bundle throws `Missing or invalid parameters` on `maxPriorityFeePerGas`.

With this fix:

- Yields approval + deposit on Phantom for USDC on Ethereum, USDC on Polygon, USDT on Ethereum (the chains/tokens called out in the ticket).
- Regression: yields approval + deposit on MetaMask (and any other EVM wallet you have handy) to confirm the `toHexOrDefault` change didn't break paths that previously worked.
- Regression: a normal swap on Phantom (the swapper path uses a different fee-construction route — confirm still works).
- Unit tests: `pnpm --filter @shapeshiftoss/hdwallet-phantom test`, `pnpm --filter @shapeshiftoss/hdwallet-core test`, and the yieldxyz tests in the web app.

Build order if testing locally: `pnpm --filter @shapeshiftoss/hdwallet-core build` then `pnpm --filter @shapeshiftoss/hdwallet-phantom build` (both packages resolve via `dist/`).

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

QA on a preview build:

1. Open the app on a preview deployment with Phantom installed.
2. Connect Phantom, switch to Ethereum mainnet.
3. Navigate to Yields, find a USDC opportunity (e.g. Aave V3).
4. Attempt a small deposit (~5 USDC). The Phantom popup should appear for the approval step, then the deposit step.
5. Repeat on Polygon (USDC) and Ethereum (USDT).
6. As a regression check, also test a normal swap on Phantom on one EVM chain to confirm no regression at the wallet layer.

## Screenshots (if applicable)

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ethereum transaction processing with enhanced validation of transaction fee parameters
  * Refined hexadecimal value formatting for better wallet compatibility and transaction reliability
  * Enhanced transaction handling across wallet implementations to prevent incomplete fee submissions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/web/pull/12360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->