### PR TITLE
chore: update rfox ipfs hash

### DIFF
--- a/src/pages/RFOX/constants.ts
+++ b/src/pages/RFOX/constants.ts
@@ -11,7 +11,7 @@ export const unstakeEvent = getAbiItem({ abi: RFOX_ABI, name: 'Unstake' })
 
 export const IPFS_GATEWAY = 'https://gateway.pinata.cloud/ipfs'
 
-export const CURRENT_EPOCH_IPFS_HASH = 'bafkreidxwaaxp72lpoqdyto7tyl4kcouokli26kabglcshx34eg3b5md6y'
+export const CURRENT_EPOCH_IPFS_HASH = 'bafkreigjewqmwnpou2udax2dq23bvkg6cfx4o4ke456oadjob2ikknii2u'
 export const STUB_RUNE_ADDRESS = 'thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqn8p0r8'
 export const RFOX_V3_UPGRADE_EPOCH = 18
 


### PR DESCRIPTION
## Description

Bumps `CURRENT_EPOCH_IPFS_HASH` in `src/pages/RFOX/constants.ts` to the latest pinned epoch.

## Issue (if applicable)

closes #

## Risk

> High Risk PRs Require 2 approvals

Low. Single-constant update pointing the UI at the latest pinned RFOX epoch on IPFS. Identical shape to prior hash bumps (e.g. #12251, #12090, #11590, #11291).

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

RFOX UI only. No transaction-construction or wallet changes.

## Testing

### Engineering

- Load the RFOX page and confirm the current epoch data fetches successfully from `https://gateway.pinata.cloud/ipfs/<new hash>`.
- Confirm rewards/distribution UI populates without errors.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

QA: open RFOX, verify current epoch + rewards render as expected with no fetch errors in console.

## Screenshots (if applicable)

n/a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data reference identifier for RFOX page content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/web/pull/12361?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->