### PR TITLE
fix(swapper): classify Relay insufficient funds and Thornode HTTP-error responses

### DIFF
--- a/packages/swapper/src/swappers/RelaySwapper/constant.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/constant.ts
@@ -147,7 +147,7 @@ export const relayErrorCodeToTradeQuoteError: Record<RelayErrorCode, TradeQuoteE
   [RelayErrorCode.ChainDisabled]: TradeQuoteError.TradingHalted,
   [RelayErrorCode.Erc20RouterAddressNotFound]: TradeQuoteError.UnsupportedTradePair,
   [RelayErrorCode.ExtraTransactionsNotSupported]: TradeQuoteError.UnsupportedTradePair,
-  [RelayErrorCode.InsufficientFunds]: TradeQuoteError.SellAmountBelowTradeFee,
+  [RelayErrorCode.InsufficientFunds]: TradeQuoteError.InsufficientFunds,
   [RelayErrorCode.InsufficientLiquidity]: TradeQuoteError.SellAmountBelowTradeFee,
   [RelayErrorCode.InvalidAddress]: TradeQuoteError.UnsupportedTradePair,
   [RelayErrorCode.InvalidExtraTransactions]: TradeQuoteError.UnsupportedTradePair,

--- a/packages/swapper/src/thorchain-utils/getQuote.ts
+++ b/packages/swapper/src/thorchain-utils/getQuote.ts
@@ -4,6 +4,7 @@ import type { Asset } from '@shapeshiftoss/types'
 import { BigAmount, bn } from '@shapeshiftoss/utils'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import type { AxiosError } from 'axios'
 import qs from 'qs'
 
 import type { SwapErrorRight, SwapperDeps, SwapperName } from '../types'
@@ -12,7 +13,11 @@ import { createTradeAmountTooSmallErr, makeSwapErrorRight } from '../utils'
 import { getThresholdedAffiliateBps } from './getThresholdedAffiliateBps/getThresholdedAffiliateBps'
 import { getAffiliate, getDaemonUrl, getNativePrecision, getPoolAssetId } from './index'
 import { thorService } from './service'
-import type { ThornodeQuoteResponse, ThornodeQuoteResponseSuccess } from './types'
+import type {
+  ThornodeQuoteResponse,
+  ThornodeQuoteResponseSuccess,
+  ThornodeResponseError,
+} from './types'
 
 type GetQuoteArgs = {
   sellAsset: Asset
@@ -91,35 +96,45 @@ export const getQuote = async (
 
   const daemonUrl = getDaemonUrl(deps.config, swapperName)
   const res = await thorService.get<ThornodeQuoteResponse>(`${daemonUrl}/quote/swap?${queryString}`)
-  if (res.isErr()) return Err(res.unwrapErr())
 
-  const { data } = res.unwrap()
-  const isError = 'error' in data
+  // Thornode returns errors as `{ error: string }` in both the 2xx body and the 4xx body.
+  // On 4xx axios rejects, so the body lands on `cause.response.data` instead of in the success data.
+  const errorMessage: string | undefined = (() => {
+    if (res.isErr()) {
+      const cause = res.unwrapErr().cause as AxiosError<ThornodeResponseError> | undefined
+      return cause?.response?.data?.error
+    }
+    const { data } = res.unwrap()
+    return 'error' in data ? data.error : undefined
+  })()
 
-  const notEnoughFeeError = isError && /not enough fee/i.test(data.error)
-  const notEnoughToPayTxFeeError = isError && /not enough to pay transaction fee/i.test(data.error)
-  const tradingIsHaltedError = isError && /trading is halted/.test(data.error)
+  if (errorMessage) {
+    if (
+      /not enough fee/i.test(errorMessage) ||
+      /not enough to pay transaction fee/i.test(errorMessage)
+    ) {
+      return Err(createTradeAmountTooSmallErr())
+    }
 
-  if (notEnoughFeeError || notEnoughToPayTxFeeError) return Err(createTradeAmountTooSmallErr())
+    if (/trading is halted/i.test(errorMessage)) {
+      return Err(
+        makeSwapErrorRight({
+          message: `[getQuote]: Trading is halted, cannot process swap`,
+          code: TradeQuoteError.TradingHalted,
+          details: { sellAssetId: sellAsset.assetId, buyAssetId },
+        }),
+      )
+    }
 
-  if (tradingIsHaltedError) {
     return Err(
       makeSwapErrorRight({
-        message: `[getQuote]: Trading is halted, cannot process swap`,
-        code: TradeQuoteError.TradingHalted,
-        details: { sellAssetId: sellAsset.assetId, buyAssetId },
-      }),
-    )
-  }
-
-  if (isError) {
-    return Err(
-      makeSwapErrorRight({
-        message: data.error,
+        message: errorMessage,
         code: TradeQuoteError.UnknownError,
       }),
     )
   }
 
-  return Ok(data)
+  if (res.isErr()) return Err(res.unwrapErr())
+
+  return Ok(res.unwrap().data as ThornodeQuoteResponseSuccess)
 }

--- a/packages/swapper/src/thorchain-utils/types.ts
+++ b/packages/swapper/src/thorchain-utils/types.ts
@@ -78,7 +78,7 @@ export type ThornodeQuoteResponseSuccess = {
   warning: string
 }
 
-type ThornodeResponseError = { error: string }
+export type ThornodeResponseError = { error: string }
 export type ThornodeQuoteResponse = ThornodeQuoteResponseSuccess | ThornodeResponseError
 
 type MidgardCoins = {

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -151,6 +151,8 @@ export enum TradeQuoteError {
   Timeout = 'Timeout',
   // catch-all for unknown issues
   UnknownError = 'UnknownError',
+  // the swapper performed on chain balance checks and determined the user didn't have the funds to perform the swap
+  InsufficientFunds = 'InsufficientFunds',
 }
 
 export type UtxoFeeData = {

--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
@@ -25,6 +25,7 @@ export const getQuoteErrorTranslation = (
       case SwapperTradeQuoteError.SellAmountBelowTradeFee:
         return 'trade.errors.sellAmountDoesNotCoverFee'
       case TradeQuoteValidationError.InsufficientFirstHopAssetBalance:
+      case SwapperTradeQuoteError.InsufficientFunds:
         return 'common.insufficientFundsForTrade'
       case TradeQuoteValidationError.InsufficientFirstHopFeeAssetBalance:
         return 'common.insufficientAmountForGas'

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -84,6 +84,7 @@ export const validateTradeQuote = (
         case SwapperTradeQuoteError.RateLimitExceeded:
         case SwapperTradeQuoteError.Timeout:
         case SwapperTradeQuoteError.InvalidResponse:
+        case SwapperTradeQuoteError.InsufficientFunds:
           // no metadata associated with this error
           return { error: errorCode }
         case SwapperTradeQuoteError.FinalQuoteMaxSlippageExceeded:

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -49,6 +49,7 @@ export const initialState: TradeQuoteSliceState = {
 export const SWAPPER_USER_ERRORS = [
   TradeQuoteError.SellAmountBelowTradeFee,
   TradeQuoteError.SellAmountBelowMinimum,
+  TradeQuoteError.InsufficientFunds,
   TradeQuoteValidationError.SellAmountBelowTradeFee,
   TradeQuoteValidationError.InsufficientFirstHopAssetBalance,
   TradeQuoteValidationError.InsufficientFirstHopFeeAssetBalance,


### PR DESCRIPTION
## Description

Two swapper error-classification fixes so users see useful messages instead of "An error occurred getting a quote":

- **Relay `InsufficientFunds`** previously mapped to `SellAmountBelowTradeFee`, surfacing "sell amount does not cover fee" when the wallet simply didn't have the funds. Adds a new `TradeQuoteError.InsufficientFunds`, routes Relay's error code to it, handles it in `validateTradeQuote`'s switch (which otherwise hits `assertUnreachable` and throws), adds it to `SWAPPER_USER_ERRORS` so the quote stays in the *available* list, and maps it to `common.insufficientFundsForTrade`.
- **Thornode 4xx responses** were lost because `getQuote` only inspected the success-shape `{ error }` body. The 4xx body uses the same `{ error: string }` shape but lands on `cause.response.data` after axios rejects, so we now read it from there (typed via `AxiosError<ThornodeResponseError>`) and run the same pattern matching. "trading is halted" now surfaces as `TradeQuoteError.TradingHalted`. Any unmapped Thornode error message is forwarded as `UnknownError` instead of falling through to the generic `QueryFailed`.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low. Touches error-classification paths only — no changes to quote pricing, transaction construction, or signing. Affected swappers: Relay (one error mapping), Thornode/Mayachain (error-message extraction in shared `getQuote` helper). Unmatched errors still fall through to the previous behavior.

## Testing

### Engineering

- Relay path: trigger a Relay quote with insufficient sell-asset balance (e.g. select an amount above wallet balance for a Relay-supported pair). Quote should appear in the available list with "Insufficient funds for trade" instead of disappearing or showing the fee message.
- Thornode path: hit any Thornode pair whose pool is currently halted. The 400 response body looks like `{"error":"{\"code\":3,\"message\":\"... trading is halted ...\"}"}`. The quote should surface as "Trading is not currently active" instead of "An error occurred getting a quote".
- Regression: existing 2xx-with-`{ error }` Thornode error paths (e.g. "not enough fee", "not enough to pay transaction fee") should continue to map to `createTradeAmountTooSmallErr`.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

User-facing impact is limited to two error-message strings becoming more accurate. Regression check: confirm normal Relay and Thornode quotes still load and execute.

## Screenshots (if applicable)

<img width="478" height="226" alt="insufficientfunds" src="https://github.com/user-attachments/assets/0c66527d-1ef9-4ead-b843-b2e87df50271" />

<img width="556" height="212" alt="image" src="https://github.com/user-attachments/assets/2cbae03b-2c71-4e1b-9d7a-af1b85695147" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)