### PR TITLE
chore: add automated package publishing workflow

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -66,10 +66,11 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # Trusted Publisher OIDC support landed in npm 11.5.1. The Node version
-      # in .nvmrc may ship an older npm; force a recent one for the publish
-      # step. pnpm shells out to this npm for the actual upload.
+      # in .nvmrc may ship an older npm; pin a known-good version here so the
+      # publish behavior stays deterministic across runs. pnpm shells out to
+      # this npm for the actual upload.
       - name: Upgrade npm for trusted publishing
-        run: npm install -g npm@latest
+        run: npm install -g npm@11.5.1
 
       - name: Build Packages
         run: pnpm run build:packages
@@ -105,7 +106,7 @@ jobs:
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
 
-          tagged=0
+          new_tags=()
           for pkg_json in packages/*/package.json; do
             name=$(node -p "require('./$pkg_json').name")
             version=$(node -p "require('./$pkg_json').version")
@@ -128,11 +129,11 @@ jobs:
 
             echo "Tagging $tag at $(git rev-parse --short HEAD)"
             git tag -a "$tag" -m "$tag"
-            tagged=$((tagged + 1))
+            new_tags+=("$tag")
           done
 
-          if [ "$tagged" -gt 0 ]; then
-            git push origin --tags
+          if [ "${#new_tags[@]}" -gt 0 ]; then
+            git push origin "${new_tags[@]}"
           else
             echo "No new tags to push."
           fi

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,138 @@
+name: Publish Packages
+
+# Publishes any public package in packages/* whose version in package.json
+# is not yet on the npm registry. Re-running is a safe no-op when nothing
+# was bumped (pnpm publish skips already-published versions).
+#
+# Bumps are driven by manual PRs that edit packages/<name>/package.json — this
+# workflow only ships what's already been bumped on the main branch.
+#
+# Authentication: npm Trusted Publishers (OIDC). No long-lived NPM_TOKEN
+# needed — npm verifies the GHA OIDC token against a per-package trusted
+# publisher config naming this repo + workflow filename. Provenance is
+# attached automatically by the OIDC publish flow.
+#
+# Prerequisites (one-time, per package, on npmjs.com):
+#   - Each @shapeshiftoss/* package this workflow can publish must have a
+#     Trusted Publisher configured: org=shapeshift, repo=web,
+#     workflow=publish-packages.yml. Without that config a publish will
+#     fail with "Trusted publisher configuration not found".
+#   - If this file is renamed, every package's trusted publisher config
+#     must be updated to match.
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Only one publish run at a time — prevents two pushes racing to publish the
+# same version and one of them failing the registry's "already exists" check.
+concurrency:
+  group: publish-packages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # push per-package git tags
+      id-token: write # mint OIDC token for npm Trusted Publisher auth
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Need full history so we can check whether tags already exist.
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        run: corepack enable && corepack prepare pnpm@10.30.3 --activate
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: ${{ runner.os }}-node-modules-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile
+
+      # Trusted Publisher OIDC support landed in npm 11.5.1. The Node version
+      # in .nvmrc may ship an older npm; force a recent one for the publish
+      # step. pnpm shells out to this npm for the actual upload.
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Build Packages
+        run: pnpm run build:packages
+
+      # `pnpm -r publish` skips packages whose current version is already on the
+      # registry, so this is a safe no-op when no bumps have landed. Filters
+      # exclude the root web package and the hdwallet-* family (versioned by a
+      # separate process). --workspace-concurrency=1 keeps publishes sequential
+      # so workspace:^ deps resolve against just-published versions in order.
+      # Authentication happens via the OIDC token GHA injects from the
+      # id-token: write permission above — no env-var token needed.
+      - name: Publish
+        run: |
+          pnpm -r publish \
+            --access public \
+            --no-git-checks \
+            --workspace-concurrency=1 \
+            --filter './packages/*' \
+            --filter '!@shapeshiftoss/web' \
+            --filter '!@shapeshiftoss/hdwallet-*'
+
+      # Tag HEAD with <name>-v<version> for each public, non-hdwallet package
+      # whose current version is on npm but doesn't yet have a local tag.
+      # Assumes the set of pre-existing versions has been backfilled with tags
+      # (one-time bootstrap) — without that, this step would incorrectly tag
+      # HEAD for any historically-published version that's missing a tag.
+      # Off-CI manual publishes must be tagged manually (see workflow docs).
+      - name: Tag published versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+          tagged=0
+          for pkg_json in packages/*/package.json; do
+            name=$(node -p "require('./$pkg_json').name")
+            version=$(node -p "require('./$pkg_json').version")
+            private=$(node -p "require('./$pkg_json').private === true")
+
+            if [ "$private" = "true" ]; then continue; fi
+            if [ "$name" = "@shapeshiftoss/web" ]; then continue; fi
+            case "$name" in @shapeshiftoss/hdwallet-*) continue ;; esac
+
+            short_name="${name#@shapeshiftoss/}"
+            tag="${short_name}-v${version}"
+
+            if git rev-parse -q --verify "refs/tags/$tag" >/dev/null; then
+              continue
+            fi
+
+            if ! npm view "$name@$version" version >/dev/null 2>&1; then
+              continue
+            fi
+
+            echo "Tagging $tag at $(git rev-parse --short HEAD)"
+            git tag -a "$tag" -m "$tag"
+            tagged=$((tagged + 1))
+          done
+
+          if [ "$tagged" -gt 0 ]; then
+            git push origin --tags
+          else
+            echo "No new tags to push."
+          fi

--- a/packages/affiliate-dashboard/package.json
+++ b/packages/affiliate-dashboard/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shapeshiftoss/affiliate-dashboard",
   "version": "1.0.0",
+  "private": true,
   "type": "module",
   "scripts": {
     "clean": "rm -rf dist node_modules",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/contracts",
-  "version": "1.0.5-coderabbit-fix.2",
+  "version": "1.0.6",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/public-api/package.json
+++ b/packages/public-api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@shapeshiftoss/public-api",
   "version": "0.1.0",
+  "private": true,
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swap-widget/package.json
+++ b/packages/swap-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swap-widget",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Embeddable swap widget using ShapeShift API",
   "type": "module",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Description

Adds a new GitHub Actions workflow that publishes ShapeShift's public packages to npm automatically, removing the need for manual `pnpm publish` runs from a maintainer's laptop.

### What's in this PR

**New workflow: `.github/workflows/publish-packages.yml`**

- Triggers on `push` to `main` and on `workflow_dispatch`
- Builds packages, then runs `pnpm -r publish` filtered to `packages/*` excluding `@shapeshiftoss/web` and `@shapeshiftoss/hdwallet-*`
- `pnpm publish` skips any version already on the registry, so re-running with no bumps is a clean no-op
- After publish, pushes per-package git tags `<name>-v<version>` for anything that actually shipped
- Authenticates via **npm Trusted Publishers** (OIDC) - no `NPM_TOKEN` secret needed; each package is configured on npmjs.com to trust this repo + workflow filename

**Package cleanups bundled in**

- `@shapeshiftoss/affiliate-dashboard` and `@shapeshiftoss/public-api` marked `private: true` — they're service/app packages, not libraries; they shouldn't be on npm
- `@shapeshiftoss/contracts` version cleaned from `1.0.5-coderabbit-fix.2` to `1.0.6` (matches what's already on npm; first workflow run no-ops for contracts)
- `@shapeshiftoss/swap-widget` bumped from `0.1.0` to `0.2.0` (real publish; first workflow run will ship this)

### Authoring flow going forward

Bump the version in `packages/<name>/package.json` as part of any normal PR. When the change reaches `main`, the workflow ships it. For urgent publishes that can't wait for the next web release, trigger the `Publish Packages` workflow manually from the Actions tab.

### One-time setup tasks (done out-of-band)

- Trusted Publisher configured on npmjs.com for each publishable package (`caip`, `chain-adapters`, `contracts`, `errors`, `swapper`, `swap-widget`, `types`, `unchained-client`, `utils`) — pointing at `shapeshift/web` + `publish-packages.yml`
- Existing-version git tags backfilled (`caip-v8.16.7`, `chain-adapters-v11.3.9`, `errors-v1.1.6`, `swapper-v17.7.3`, `swap-widget-v0.1.0`, `types-v8.6.7`, `unchained-client-v10.14.10`, `utils-v1.0.5`)

## Issue (if applicable)

closes #

## Risk

Low. The workflow only runs on `push: main` and `workflow_dispatch`, so it doesn't affect PR or develop CI. Failures are isolated to the workflow itself (won't block the web app deploy, which lives in a separate workflow). Worst case if something is misconfigured: `pnpm publish` errors loudly with `Trusted publisher configuration not found` or similar — no silent partial state.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

Hard to dry-run without merging, since the workflow only triggers on `main`. Two natural verification points after merge:

1. **First push to main without a new bump** — should run, snapshot zero pending publishes, no-op cleanly, no new tags
2. **First push to main with the bundled `swap-widget` 0.2.0 bump (this PR)** — should publish `@shapeshiftoss/swap-widget@0.2.0` to npm and push `swap-widget-v0.2.0` tag; `contracts@1.0.6` is already on npm and will skip cleanly

If the workflow fails for any package, the error message will name the package + reason; fix in a follow-up.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

No user-facing changes. Affects internal release tooling only.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated GitHub Actions workflow to publish workspace packages from main with safe concurrency and tag synchronization
  * Marked affiliate-dashboard and public-api packages as private
  * Updated package versions: contracts → 1.0.6 and swap-widget → 0.2.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shapeshift/web/pull/12371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->