### PR TITLE
fix(ci): publish-packages workflow options and include hdwallet

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -76,24 +76,25 @@ jobs:
         run: pnpm run build:packages
 
       # `pnpm -r publish` skips packages whose current version is already on the
-      # registry, so this is a safe no-op when no bumps have landed. Filters
-      # exclude the root web package and the hdwallet-* family (versioned by a
-      # separate process). --workspace-concurrency=1 keeps publishes sequential
-      # so workspace:^ deps resolve against just-published versions in order.
+      # registry, so this is a safe no-op when no bumps have landed. Private
+      # packages are skipped automatically by pnpm publish. --workspace-concurrency=1
+      # keeps publishes topologically sequential so the registry sees dependencies
+      # before dependents, preventing a window where end users could install a
+      # dependent whose new dep version isn't yet on npm.
       # Authentication happens via the OIDC token GHA injects from the
       # id-token: write permission above — no env-var token needed.
       - name: Publish
         run: |
-          pnpm -r publish \
-            --access public \
-            --no-git-checks \
+          pnpm -r \
             --workspace-concurrency=1 \
             --filter './packages/*' \
             --filter '!@shapeshiftoss/web' \
-            --filter '!@shapeshiftoss/hdwallet-*'
+            publish \
+            --access public \
+            --no-git-checks
 
-      # Tag HEAD with <name>-v<version> for each public, non-hdwallet package
-      # whose current version is on npm but doesn't yet have a local tag.
+      # Tag HEAD with <name>-v<version> for each public package whose current
+      # version is on npm but doesn't yet have a local tag.
       # Assumes the set of pre-existing versions has been backfilled with tags
       # (one-time bootstrap) — without that, this step would incorrectly tag
       # HEAD for any historically-published version that's missing a tag.
@@ -114,7 +115,6 @@ jobs:
 
             if [ "$private" = "true" ]; then continue; fi
             if [ "$name" = "@shapeshiftoss/web" ]; then continue; fi
-            case "$name" in @shapeshiftoss/hdwallet-*) continue ;; esac
 
             short_name="${name#@shapeshiftoss/}"
             tag="${short_name}-v${version}"


### PR DESCRIPTION
## Description

Two-part fix to the `publish-packages` workflow added in #12371.

### 1. pnpm option position

The first run of the workflow failed with:

```
ERROR  Unknown option: 'workspace-concurrency'
```

`--workspace-concurrency` and `--filter` are recursive options, not `publish` flags. They have to sit between `-r` and the `publish` subcommand; everything after `publish` is parsed as a publish-command flag. Reordered accordingly:

```
pnpm -r \
  --workspace-concurrency=1 \
  --filter './packages/*' \
  --filter '!@shapeshiftoss/web' \
  publish \
  --access public \
  --no-git-checks
```

### 2. Include `hdwallet-*` in this workflow

The original workflow excluded `@shapeshiftoss/hdwallet-*` on the basis that they were "versioned by a separate process". That was true when hdwallet lived in its own repo, but [#11811](https://github.com/shapeshift/web/pull/11811) absorbed it into this monorepo in February — there is no separate publish process anymore.

Concrete consequence today:

- `hdwallet-core@1.62.41` was last published to npm on 2026-01-17, from the old repo.
- Since absorption, ~3 months of changes have landed in `packages/hdwallet-*` (phantom EIP-1474 fix, bebop solana signing, bitcoin wcv2 support, axios bump, etc.) — none are on npm.
- The local `tsc --build` compiles `chain-adapters`/`swapper` `dist/` against the newer hdwallet sources, so consumers installing `chain-adapters@11.3.9` get JS/types that assume APIs paired with `hdwallet-core@^1.62.41` resolving to the **old** January code on npm. Silent breakage waiting to happen.

This PR drops the `!@shapeshiftoss/hdwallet-*` filter from both the publish step and the tagger. Private packages (`hdwallet-integration`, `hdwallet-sandbox`) are still skipped automatically.

### 3. Corrected misleading comment

The `--workspace-concurrency=1` comment claimed it was about `workspace:^` resolution. It isn't — `pnpm publish` always rewrites `workspace:^` from the local `package.json` regardless of order. The real reason for sequential publishing is registry consistency: dependency reaches npm before dependent is published, so users installing during the publish window don't hit a missing dep. Comment updated to match reality.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

CI-only change. No runtime/UI impact in this repo. Downstream consumers of `@shapeshiftoss/*` npm packages will start receiving correct `hdwallet-*` versions once those packages are bumped in a follow-up PR (current `1.62.41` is already on npm, so this PR alone is a no-op for hdwallet).

## Testing

### Engineering

Required follow-ups before this workflow can actually publish hdwallet packages:

- [ ] **Trusted Publisher configs** for all 22 non-private `hdwallet-*` packages on npmjs.com (`org=shapeshift`, `repo=web`, `workflow=publish-packages.yml`). Without these, the first hdwallet publish will fail with `Trusted publisher configuration not found`.
- [x] **Tag bootstrap**: 22 `hdwallet-*-v1.62.41` annotated tags pushed to `origin` at the migration commit `4b625a5278`. Verified via `git ls-remote --tags origin 'refs/tags/hdwallet-*-v1.62.41' | wc -l` → 22. Prevents the tagger from incorrectly tagging `develop` HEAD on first run.
- [ ] **Version bumps**: To actually ship the accumulated changes, a follow-up PR needs to bump `hdwallet-*` versions in lockstep (e.g., `1.62.41` → `1.63.0` across all 22).

Workflow correctness can be sanity-checked locally:

```
pnpm -r --workspace-concurrency=1 --filter './packages/*' --filter '!@shapeshiftoss/web' publish --dry-run --no-git-checks
```

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

CI-only workflow change. End-user impact depends on the follow-up version-bump PR, not this one.

## Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)