### PR TITLE
feat: add modal display mode to swap widget demo

### DIFF
--- a/packages/swap-widget/src/demo/App.css
+++ b/packages/swap-widget/src/demo/App.css
@@ -460,6 +460,117 @@ body,
   justify-content: center;
 }
 
+.demo-widget-container.demo-widget-container-modal {
+  align-self: stretch;
+  align-items: center;
+}
+
+.demo-launch {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 420px;
+  max-width: 100%;
+  min-height: 320px;
+  padding: 24px;
+}
+
+.demo-launch-btn {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 16px 32px;
+  border: none;
+  border-radius: 14px;
+  background: var(--demo-accent);
+  color: #ffffff;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  box-shadow: 0 8px 24px color-mix(in srgb, var(--demo-accent), transparent 65%);
+}
+
+.demo-launch-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 28px color-mix(in srgb, var(--demo-accent), transparent 55%);
+}
+
+.demo-launch-btn:active {
+  transform: scale(0.98);
+}
+
+.demo-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  overflow-y: auto;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(6px);
+  animation: demo-modal-fade-in 0.15s ease;
+}
+
+.demo-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  border: none;
+  padding: 0;
+  background: transparent;
+  cursor: default;
+}
+
+.demo-modal {
+  position: relative;
+  margin: auto;
+  animation: demo-modal-pop-in 0.2s ease;
+}
+
+.demo-modal-close {
+  position: absolute;
+  top: -40px;
+  right: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.12);
+  color: #ffffff;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.demo-modal-close:hover {
+  background: rgba(255, 255, 255, 0.24);
+}
+
+@keyframes demo-modal-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes demo-modal-pop-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 .demo-footer {
   padding: 20px;
   text-align: center;

--- a/packages/swap-widget/src/demo/DemoCustomizer.tsx
+++ b/packages/swap-widget/src/demo/DemoCustomizer.tsx
@@ -68,11 +68,14 @@ const DEFAULT_LIGHT: ThemeColors = { bg: '#f8f9fc', card: '#ffffff', accent: '#3
 
 const STORAGE_KEY = 'ssw-demo-config'
 
+export type DisplayMode = 'inline' | 'modal'
+
 type StoredConfig = {
   partnerCode?: string
   darkColors?: ThemeColors
   lightColors?: ThemeColors
   selectedPreset?: string | null
+  displayMode?: DisplayMode
 }
 
 const loadConfig = (): StoredConfig => {
@@ -90,17 +93,18 @@ export const useDemoTheme = (theme: 'light' | 'dark') => {
   const [darkColors, setDarkColors] = useState<ThemeColors>(stored.darkColors ?? DEFAULT_DARK)
   const [lightColors, setLightColors] = useState<ThemeColors>(stored.lightColors ?? DEFAULT_LIGHT)
   const [selectedPreset, setSelectedPreset] = useState<string | null>(stored.selectedPreset ?? null)
+  const [displayMode, setDisplayMode] = useState<DisplayMode>(stored.displayMode ?? 'inline')
 
   useEffect(() => {
     try {
       localStorage.setItem(
         STORAGE_KEY,
-        JSON.stringify({ partnerCode, darkColors, lightColors, selectedPreset }),
+        JSON.stringify({ partnerCode, darkColors, lightColors, selectedPreset, displayMode }),
       )
     } catch {
       // ignore write failures (e.g. storage unavailable)
     }
-  }, [partnerCode, darkColors, lightColors, selectedPreset])
+  }, [partnerCode, darkColors, lightColors, selectedPreset, displayMode])
 
   const currentColors = theme === 'dark' ? darkColors : lightColors
 
@@ -135,6 +139,8 @@ export const useDemoTheme = (theme: 'light' | 'dark') => {
     setLightColors,
     selectedPreset,
     setSelectedPreset,
+    displayMode,
+    setDisplayMode,
     themeConfig,
     demoStyle,
   }
@@ -158,6 +164,8 @@ export const DemoCustomizer = ({ theme, setTheme, state }: DemoCustomizerProps) 
     setLightColors,
     selectedPreset,
     setSelectedPreset,
+    displayMode,
+    setDisplayMode,
   } = state
 
   const currentColors = theme === 'dark' ? darkColors : lightColors
@@ -306,6 +314,48 @@ ${formatColors(lightColors, 'light')}
               <path d='M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z' />
             </svg>
             Dark
+          </button>
+        </div>
+      </div>
+
+      <div className='demo-customizer-section'>
+        <span className='demo-customizer-label'>Display</span>
+        <div className='demo-theme-toggle'>
+          <button
+            className={`demo-theme-btn ${displayMode === 'inline' ? 'active' : ''}`}
+            onClick={() => setDisplayMode('inline')}
+            type='button'
+          >
+            <svg
+              width='16'
+              height='16'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+            >
+              <rect x='3' y='3' width='18' height='18' rx='2' />
+              <rect x='8' y='8' width='8' height='8' rx='1' />
+            </svg>
+            Inline
+          </button>
+          <button
+            className={`demo-theme-btn ${displayMode === 'modal' ? 'active' : ''}`}
+            onClick={() => setDisplayMode('modal')}
+            type='button'
+          >
+            <svg
+              width='16'
+              height='16'
+              viewBox='0 0 24 24'
+              fill='none'
+              stroke='currentColor'
+              strokeWidth='2'
+            >
+              <rect x='3' y='3' width='18' height='18' rx='2' opacity='0.4' />
+              <rect x='7' y='9' width='10' height='8' rx='1' />
+            </svg>
+            Modal
           </button>
         </div>
       </div>

--- a/packages/swap-widget/src/demo/ExternalWalletApp.tsx
+++ b/packages/swap-widget/src/demo/ExternalWalletApp.tsx
@@ -1,7 +1,7 @@
 import './App.css'
 
 import { useAppKit, useAppKitAccount } from '@reown/appkit/react'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { SwapWidget } from '../components/SwapWidget'
 import { initializeAppKit } from '../config/appkit'
@@ -78,15 +78,18 @@ const ExternalDemoBody = ({ theme, setTheme }: ExternalDemoBodyProps) => {
     console.error('Swap failed:', error)
   }, [])
 
-  const widget = (
-    <SwapWidget
-      partnerCode={partnerCode || undefined}
-      theme={themeConfig}
-      onSwapSuccess={handleSwapSuccess}
-      onSwapError={handleSwapError}
-      showPoweredBy={true}
-      showConnectButton={false}
-    />
+  const widget = useMemo(
+    () => (
+      <SwapWidget
+        partnerCode={partnerCode || undefined}
+        theme={themeConfig}
+        onSwapSuccess={handleSwapSuccess}
+        onSwapError={handleSwapError}
+        showPoweredBy={true}
+        showConnectButton={false}
+      />
+    ),
+    [partnerCode, themeConfig, handleSwapSuccess, handleSwapError],
   )
 
   return (

--- a/packages/swap-widget/src/demo/ExternalWalletApp.tsx
+++ b/packages/swap-widget/src/demo/ExternalWalletApp.tsx
@@ -7,6 +7,7 @@ import { SwapWidget } from '../components/SwapWidget'
 import { initializeAppKit } from '../config/appkit'
 import { truncateAddress } from '../types'
 import { DemoCustomizer, useDemoTheme } from './DemoCustomizer'
+import { WidgetModal } from './WidgetModal'
 
 const PROJECT_ID = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID
 
@@ -67,7 +68,7 @@ const ExternalDemoBody = ({ theme, setTheme }: ExternalDemoBodyProps) => {
   const [showCustomizer, setShowCustomizer] = useState(true)
 
   const themeState = useDemoTheme(theme)
-  const { themeConfig, partnerCode, demoStyle } = themeState
+  const { themeConfig, partnerCode, demoStyle, displayMode } = themeState
 
   const handleSwapSuccess = useCallback((txHash: string) => {
     console.log('Swap successful:', txHash)
@@ -76,6 +77,17 @@ const ExternalDemoBody = ({ theme, setTheme }: ExternalDemoBodyProps) => {
   const handleSwapError = useCallback((error: Error) => {
     console.error('Swap failed:', error)
   }, [])
+
+  const widget = (
+    <SwapWidget
+      partnerCode={partnerCode || undefined}
+      theme={themeConfig}
+      onSwapSuccess={handleSwapSuccess}
+      onSwapError={handleSwapError}
+      showPoweredBy={true}
+      showConnectButton={false}
+    />
+  )
 
   return (
     <div className={`demo-app ${theme}`} style={demoStyle}>
@@ -141,15 +153,12 @@ const ExternalDemoBody = ({ theme, setTheme }: ExternalDemoBodyProps) => {
               <DemoCustomizer theme={theme} setTheme={setTheme} state={themeState} />
             )}
 
-            <div className='demo-widget-container'>
-              <SwapWidget
-                partnerCode={partnerCode || undefined}
-                theme={themeConfig}
-                onSwapSuccess={handleSwapSuccess}
-                onSwapError={handleSwapError}
-                showPoweredBy={true}
-                showConnectButton={false}
-              />
+            <div
+              className={`demo-widget-container${
+                displayMode === 'modal' ? ' demo-widget-container-modal' : ''
+              }`}
+            >
+              {displayMode === 'modal' ? <WidgetModal>{widget}</WidgetModal> : widget}
             </div>
           </div>
         </div>

--- a/packages/swap-widget/src/demo/InternalWalletApp.tsx
+++ b/packages/swap-widget/src/demo/InternalWalletApp.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { SwapWidget } from '../components/SwapWidget'
 import { DemoCustomizer, useDemoTheme } from './DemoCustomizer'
+import { WidgetModal } from './WidgetModal'
 
 const PROJECT_ID = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID
 
@@ -18,7 +19,7 @@ const InternalDemoBody = ({ theme, setTheme }: InternalDemoBodyProps) => {
   const [showCustomizer, setShowCustomizer] = useState(true)
 
   const themeState = useDemoTheme(theme)
-  const { themeConfig, partnerCode, demoStyle } = themeState
+  const { themeConfig, partnerCode, demoStyle, displayMode } = themeState
 
   const handleSwapSuccess = useCallback((txHash: string) => {
     console.log('Swap successful:', txHash)
@@ -27,6 +28,18 @@ const InternalDemoBody = ({ theme, setTheme }: InternalDemoBodyProps) => {
   const handleSwapError = useCallback((error: Error) => {
     console.error('Swap failed:', error)
   }, [])
+
+  const widget = (
+    <SwapWidget
+      partnerCode={partnerCode || undefined}
+      theme={themeConfig}
+      onSwapSuccess={handleSwapSuccess}
+      onSwapError={handleSwapError}
+      showPoweredBy={true}
+      showConnectButton={true}
+      walletConnectProjectId={PROJECT_ID}
+    />
+  )
 
   return (
     <div className={`demo-app ${theme}`} style={demoStyle}>
@@ -94,16 +107,12 @@ const InternalDemoBody = ({ theme, setTheme }: InternalDemoBodyProps) => {
               <DemoCustomizer theme={theme} setTheme={setTheme} state={themeState} />
             )}
 
-            <div className='demo-widget-container'>
-              <SwapWidget
-                partnerCode={partnerCode || undefined}
-                theme={themeConfig}
-                onSwapSuccess={handleSwapSuccess}
-                onSwapError={handleSwapError}
-                showPoweredBy={true}
-                showConnectButton={true}
-                walletConnectProjectId={PROJECT_ID}
-              />
+            <div
+              className={`demo-widget-container${
+                displayMode === 'modal' ? ' demo-widget-container-modal' : ''
+              }`}
+            >
+              {displayMode === 'modal' ? <WidgetModal>{widget}</WidgetModal> : widget}
             </div>
           </div>
         </div>

--- a/packages/swap-widget/src/demo/InternalWalletApp.tsx
+++ b/packages/swap-widget/src/demo/InternalWalletApp.tsx
@@ -1,6 +1,6 @@
 import './App.css'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { SwapWidget } from '../components/SwapWidget'
 import { DemoCustomizer, useDemoTheme } from './DemoCustomizer'
@@ -29,16 +29,19 @@ const InternalDemoBody = ({ theme, setTheme }: InternalDemoBodyProps) => {
     console.error('Swap failed:', error)
   }, [])
 
-  const widget = (
-    <SwapWidget
-      partnerCode={partnerCode || undefined}
-      theme={themeConfig}
-      onSwapSuccess={handleSwapSuccess}
-      onSwapError={handleSwapError}
-      showPoweredBy={true}
-      showConnectButton={true}
-      walletConnectProjectId={PROJECT_ID}
-    />
+  const widget = useMemo(
+    () => (
+      <SwapWidget
+        partnerCode={partnerCode || undefined}
+        theme={themeConfig}
+        onSwapSuccess={handleSwapSuccess}
+        onSwapError={handleSwapError}
+        showPoweredBy={true}
+        showConnectButton={true}
+        walletConnectProjectId={PROJECT_ID}
+      />
+    ),
+    [partnerCode, themeConfig, handleSwapSuccess, handleSwapError],
   )
 
   return (

--- a/packages/swap-widget/src/demo/WidgetModal.tsx
+++ b/packages/swap-widget/src/demo/WidgetModal.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+
+type WidgetModalProps = {
+  children: ReactNode
+}
+
+export const WidgetModal = ({ children }: WidgetModalProps) => {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    if (!isOpen) return
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false)
+    }
+    window.addEventListener('keydown', onKeyDown)
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = ''
+    }
+  }, [isOpen])
+
+  return (
+    <>
+      <div className='demo-launch'>
+        <button className='demo-launch-btn' onClick={open} type='button'>
+          <svg
+            width='18'
+            height='18'
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+          >
+            <path d='M17 1l4 4-4 4' />
+            <path d='M3 11V9a4 4 0 0 1 4-4h14' />
+            <path d='M7 23l-4-4 4-4' />
+            <path d='M21 13v2a4 4 0 0 1-4 4H3' />
+          </svg>
+          Swap crypto
+        </button>
+      </div>
+
+      {isOpen && (
+        <div className='demo-modal-overlay'>
+          <button
+            className='demo-modal-backdrop'
+            onClick={close}
+            type='button'
+            aria-label='Close'
+          />
+          <div className='demo-modal' role='dialog' aria-modal='true' aria-label='Swap'>
+            <button className='demo-modal-close' onClick={close} type='button' aria-label='Close'>
+              <svg
+                width='16'
+                height='16'
+                viewBox='0 0 24 24'
+                fill='none'
+                stroke='currentColor'
+                strokeWidth='2'
+              >
+                <path d='M18 6L6 18M6 6l12 12' />
+              </svg>
+            </button>
+            {children}
+          </div>
+        </div>
+      )}
+    </>
+  )
+}

--- a/packages/swap-widget/src/demo/WidgetModal.tsx
+++ b/packages/swap-widget/src/demo/WidgetModal.tsx
@@ -14,7 +14,7 @@ export const WidgetModal = ({ children }: WidgetModalProps) => {
   useEffect(() => {
     if (!isOpen) return
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false)
+      if (e.key === 'Escape') close()
     }
     window.addEventListener('keydown', onKeyDown)
     document.body.style.overflow = 'hidden'
@@ -22,7 +22,7 @@ export const WidgetModal = ({ children }: WidgetModalProps) => {
       window.removeEventListener('keydown', onKeyDown)
       document.body.style.overflow = ''
     }
-  }, [isOpen])
+  }, [isOpen, close])
 
   return (
     <>


### PR DESCRIPTION
## Description

Adds an **Inline / Modal** display toggle to the swap widget demo app's customizer to better demonstrate how a client would integrate the widget behind a button.

- New `WidgetModal` demo component: a host-style "Swap crypto" CTA (themed via the demo's accent color) that opens the widget in a centered overlay with blurred backdrop. Dismissable via backdrop click, Escape, or close button; body scroll is locked while open.
- The toggle lives in the demo customizer and persists alongside the existing demo config in localStorage. Works on both the internal and external (host-owned AppKit) wallet demo pages.
- In modal mode the CTA column stretches to the customizer's height and centers the button, mirroring the inline widget's 420px footprint.

Demo-only change: nothing under `src/demo/` is part of the published SDK (`dist` is built from `src/index.ts` via tsup; verified the built `index.css`/`index.js` contain no demo code or styles).

## Issue (if applicable)

closes #

## Risk

Near zero — isolated to the swap widget demo app. No widget, SDK, or web app code paths affected. No on-chain transaction changes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

1. `cd packages/swap-widget && pnpm dev`
2. In the customizer, switch **Display** to **Modal** — the widget is replaced by a "Swap crypto" button
3. Click it: the widget opens in a centered overlay; verify backdrop click, Escape, and the × button all close it
4. Verify the toggle persists across reloads and works on both the Internal and External demo pages
5. `pnpm run build` and confirm `dist/index.css` contains no `demo-` classes

### Operations

- [x] :checkered_flag: Demo app only — not user-facing in the web app and not part of the published SDK

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Demo now lets you switch between inline and modal display modes from the customizer, with the choice persisted.
  * Modal view adds a centered launch panel/button, fixed overlay, close control, Escape-to-close keyboard support, and prevents background scrolling.
  * Modal appearance includes fade/scale/pop animations and polished backdrop styling for a smoother experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->