### PR TITLE
fix(swapper): omit sender for BobGateway UTXO sells

### DIFF
--- a/packages/swapper/src/swappers/BobGatewaySwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/endpoints.ts
@@ -38,7 +38,7 @@ export const bobGatewayApi: SwapperApi = {
     const adapter = assertGetUtxoChainAdapter(sellAsset.chainId)
 
     if (!bobSpecific?.utxoTx) throw new Error('[BobGateway] invalid utxo transaction')
-    const { depositAddress, opReturnData, sender } = bobSpecific.utxoTx
+    const { depositAddress, opReturnData } = bobSpecific.utxoTx
 
     return adapter.buildSendApiTransaction({
       value: step.sellAmountIncludingProtocolFeesCryptoBaseUnit,
@@ -47,7 +47,6 @@ export const bobGatewayApi: SwapperApi = {
       accountNumber: step.accountNumber,
       skipToAddressValidation: true,
       chainSpecific: {
-        from: sender,
         accountType,
         opReturnData,
         satoshiPerByte: (step.feeData.chainSpecific as UtxoFeeData).satsPerByte,
@@ -65,12 +64,12 @@ export const bobGatewayApi: SwapperApi = {
     const adapter = assertGetUtxoChainAdapter(sellAsset.chainId)
 
     if (!bobSpecific?.utxoTx) throw new Error('[BobGateway] invalid utxo transaction')
-    const { depositAddress, opReturnData, sender } = bobSpecific.utxoTx
+    const { depositAddress, opReturnData } = bobSpecific.utxoTx
 
     const { fast } = await adapter.getFeeData({
       to: depositAddress,
       value: step.sellAmountIncludingProtocolFeesCryptoBaseUnit,
-      chainSpecific: { pubkey: xpub, opReturnData, from: sender },
+      chainSpecific: { pubkey: xpub, opReturnData },
       sendMax: false,
     })
 

--- a/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeQuote.ts
@@ -1,3 +1,4 @@
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { v4 as uuid } from 'uuid'
@@ -5,7 +6,6 @@ import { v4 as uuid } from 'uuid'
 import type {
   CommonTradeQuoteInput,
   GetTradeQuoteInput,
-  GetUtxoTradeQuoteInput,
   SwapErrorRight,
   SwapperDeps,
   TradeQuote,
@@ -18,7 +18,6 @@ import {
   getBobGatewayAllowanceContract,
   getBobGatewayQuote,
   getBobGatewayQuoteFeeData,
-  getBobGatewaySender,
   parseBobGatewayQuote,
 } from '../utils/helpers'
 
@@ -62,16 +61,9 @@ export const getBobGatewayTradeQuote = async (
 
   const { sellChainName, buyChainName } = assertion.unwrap()
 
-  const maybeSender = await getBobGatewaySender({
-    sellAsset,
-    sellAmount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-    sendAddress,
-    xpub: (input as GetUtxoTradeQuoteInput).xpub,
-    deps,
-  })
-
-  if (maybeSender.isErr()) return Err(maybeSender.unwrapErr())
-  const sender = maybeSender.unwrap()
+  // omit the sender for utxo sells so order creation does not enforce a per-address confirmed
+  // funds check (deposits are matched via op_return, not the sending address)
+  const sender = isEvmChainId(sellAsset.chainId) ? sendAddress : undefined
 
   const maybeQuote = await getBobGatewayQuote({
     config,
@@ -89,7 +81,7 @@ export const getBobGatewayTradeQuote = async (
   if (maybeQuote.isErr()) return Err(maybeQuote.unwrapErr())
   const quote = maybeQuote.unwrap()
 
-  const maybeOrderMetadata = await createBobGatewayOrderMetadata(config, quote, sender)
+  const maybeOrderMetadata = await createBobGatewayOrderMetadata(config, quote)
   if (maybeOrderMetadata.isErr()) return Err(maybeOrderMetadata.unwrapErr())
 
   const orderMetadata = maybeOrderMetadata.unwrap()

--- a/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeRate.ts
@@ -38,7 +38,7 @@ export const getBobGatewayTradeRate = async (
 
   const recipient =
     receiveAddress ?? (buyAsset.chainId === btcChainId ? DUMMY_BTC_ADDRESS : DUMMY_EVM_ADDRESS)
-  const sender = sellAsset.chainId === btcChainId ? DUMMY_BTC_ADDRESS : DUMMY_EVM_ADDRESS
+  const sender = sellAsset.chainId === btcChainId ? undefined : DUMMY_EVM_ADDRESS
 
   const maybeQuote = await getBobGatewayQuote({
     config,

--- a/packages/swapper/src/swappers/BobGatewaySwapper/types.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/types.ts
@@ -8,7 +8,6 @@ type BobGatewayEvmTxMetadata = {
 type BobGatewayUtxoTxMetadata = {
   depositAddress: string
   opReturnData?: string
-  sender: string
 }
 
 export type BobGatewayMetadata = { orderId: string } & (

--- a/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
@@ -6,18 +6,10 @@ import type {
 } from '@gobob/bob-sdk'
 import { GatewayErrorCode, GatewaySDK, isGatewayError } from '@gobob/bob-sdk'
 import type { AssetId } from '@shapeshiftoss/caip'
-import {
-  ASSET_NAMESPACE,
-  CHAIN_NAMESPACE,
-  ethChainId,
-  fromAssetId,
-  fromChainId,
-  toAssetId,
-} from '@shapeshiftoss/caip'
+import { ASSET_NAMESPACE, ethChainId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
 import { evm, isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { Asset, AssetsByIdPartial } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import type { BN } from '@shapeshiftoss/utils'
 import {
   bnOrZero,
   chainIdToFeeAssetId,
@@ -70,77 +62,6 @@ export const getBobGatewayAffiliates = (affiliateBps: string): GetQuoteParams['a
   return [{ address: getAddress(affiliateAddress), bps: bps.toNumber() }]
 }
 
-export const getBobGatewaySender = async ({
-  sellAsset,
-  sellAmount,
-  sendAddress,
-  xpub,
-  deps: { assertGetUtxoChainAdapter },
-}: {
-  sellAsset: Asset
-  sellAmount: string
-  sendAddress: string
-  xpub?: string
-  deps: SwapperDeps
-}): Promise<Result<string, SwapErrorRight>> => {
-  if (fromChainId(sellAsset.chainId).chainNamespace === CHAIN_NAMESPACE.Evm) {
-    return Ok(sendAddress)
-  }
-
-  if (!xpub) {
-    return Err(
-      makeSwapErrorRight({
-        message: '[BobGateway] xpub is required for quote',
-        code: TradeQuoteError.UnknownError,
-      }),
-    )
-  }
-
-  try {
-    const adapter = assertGetUtxoChainAdapter(sellAsset.chainId)
-    const utxos = await adapter.getUtxos({ pubkey: xpub })
-
-    const balanceByAddress = utxos.reduce<Record<string, BN>>((acc, utxo) => {
-      if (!utxo.address) return acc
-      acc[utxo.address] = bnOrZero(acc[utxo.address]).plus(utxo.value)
-      return acc
-    }, {})
-
-    // the richest address is the one best able to fund the send
-    const [sender, balance] = Object.entries(balanceByAddress).sort(
-      ([, a], [, b]) => b.comparedTo(a) ?? 0,
-    )[0] ?? [sendAddress, bnOrZero(0)]
-
-    // real coinselect fee for the send constrained to the sender address (the deposit address is
-    // not known pre-order, but the to address does not meaningfully affect the fee estimate)
-    const { fast } = await adapter.getFeeData({
-      to: sender,
-      value: sellAmount,
-      chainSpecific: { pubkey: xpub, from: sender },
-      sendMax: false,
-    })
-
-    if (balance.lt(bnOrZero(sellAmount).plus(fast.txFee))) {
-      return Err(
-        makeSwapErrorRight({
-          message: '[BobGateway] no single address holds enough funds to cover the trade',
-          code: TradeQuoteError.FundsFragmented,
-        }),
-      )
-    }
-
-    return Ok(sender)
-  } catch (err) {
-    return Err(
-      makeSwapErrorRight({
-        message: '[BobGateway] failed to select sender address',
-        code: TradeQuoteError.QueryFailed,
-        cause: err,
-      }),
-    )
-  }
-}
-
 export const getBobGatewayQuote = async ({
   config,
   sellAsset,
@@ -158,7 +79,7 @@ export const getBobGatewayQuote = async ({
   buyAsset: Asset
   sellChainName: BobGatewayChainName
   buyChainName: BobGatewayChainName
-  sender: string
+  sender: string | undefined
   recipient: string
   amount: string
   affiliateBps: string
@@ -235,7 +156,6 @@ export const getBobGatewayQuote = async ({
 export const createBobGatewayOrderMetadata = async (
   config: SwapperConfig,
   gatewayQuote: GatewayQuoteV2,
-  sender: string,
 ): Promise<Result<BobGatewayMetadata, SwapErrorRight>> => {
   try {
     const orderResponse = await getBobGatewayClient(config).api.createOrderV2({
@@ -249,7 +169,6 @@ export const createBobGatewayOrderMetadata = async (
         utxoTx: {
           depositAddress: orderResponse.onramp.address,
           opReturnData: orderResponse.onramp.opReturnData ?? undefined,
-          sender,
         },
       })
     }
@@ -326,12 +245,12 @@ export const getBobGatewayQuoteFeeData = async (
 
   try {
     if (orderMetadata.utxoTx && 'xpub' in input) {
-      const { depositAddress, opReturnData, sender } = orderMetadata.utxoTx
+      const { depositAddress, opReturnData } = orderMetadata.utxoTx
 
       const { fast } = await assertGetUtxoChainAdapter(sellAsset.chainId).getFeeData({
         to: depositAddress,
         value: sellAmountIncludingProtocolFeesCryptoBaseUnit,
-        chainSpecific: { pubkey: input.xpub, opReturnData, from: sender },
+        chainSpecific: { pubkey: input.xpub, opReturnData },
         sendMax: false,
       })
 

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -158,8 +158,6 @@ export enum TradeQuoteError {
   InsufficientFunds = 'InsufficientFunds',
   // the user's confirmed balance is insufficient — funds may exist but are still confirming on chain (e.g. unconfirmed UTXO deposits)
   InsufficientFundsUnconfirmed = 'InsufficientFundsUnconfirmed',
-  // the account has enough total balance, but no single address holds enough to fund the trade (utxo fragmentation)
-  FundsFragmented = 'FundsFragmented',
 }
 
 export type UtxoFeeData = {

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1035,7 +1035,6 @@
       "sellAmountDoesNotCoverFee": "Sell amount lower than fee",
       "insufficientFunds": "Insufficient funds for miner fee and amount",
       "insufficientFundsUnconfirmed": "Funds still confirming. Try again once confirmed.",
-      "fundsFragmented": "This provider requires funds on a single address. Consolidate by sending your full balance to yourself, then try again once it confirms.",
       "transactionRejected": "User has rejected the transaction",
       "insufficientFundsForProtocolFee": "Insufficient %{symbol} on %{chainName} for fees",
       "unsupportedTradePair": "Unsupported Trade Pair",

--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
@@ -41,8 +41,6 @@ export const getQuoteErrorTranslation = (
         return tradeQuoteError.meta
           ? 'trade.errors.amountTooSmall'
           : 'trade.errors.amountTooSmallUnknownMinimum'
-      case SwapperTradeQuoteError.FundsFragmented:
-        return 'trade.errors.fundsFragmented'
       case SwapperTradeQuoteError.UnsupportedChain:
         return 'trade.errors.quoteUnsupportedChain'
       case SwapperTradeQuoteError.CrossChainNotSupported:

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -86,7 +86,6 @@ export const validateTradeQuote = (
         case SwapperTradeQuoteError.InvalidResponse:
         case SwapperTradeQuoteError.InsufficientFunds:
         case SwapperTradeQuoteError.InsufficientFundsUnconfirmed:
-        case SwapperTradeQuoteError.FundsFragmented:
           // no metadata associated with this error
           return { error: errorCode }
         case SwapperTradeQuoteError.FinalQuoteMaxSlippageExceeded:

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -51,7 +51,6 @@ export const SWAPPER_USER_ERRORS = [
   TradeQuoteError.SellAmountBelowMinimum,
   TradeQuoteError.InsufficientFunds,
   TradeQuoteError.InsufficientFundsUnconfirmed,
-  TradeQuoteError.FundsFragmented,
   TradeQuoteValidationError.SellAmountBelowTradeFee,
   TradeQuoteValidationError.InsufficientFirstHopAssetBalance,
   TradeQuoteValidationError.InsufficientFirstHopFeeAssetBalance,

--- a/src/utils/sentry/helpers.ts
+++ b/src/utils/sentry/helpers.ts
@@ -24,7 +24,6 @@ export const isExpectedError = (error: unknown): boolean => {
     TradeQuoteError.RateLimitExceeded,
     TradeQuoteError.SellAmountBelowMinimum,
     TradeQuoteError.TradingHalted,
-    TradeQuoteError.FundsFragmented,
   ]
 
   if (tradeQuoteErrors.some(errorType => errorMessage.includes(errorType))) {


### PR DESCRIPTION
## Description

BobGateway matches UTXO deposits via the `op_return` data on the deposit transaction, not the sending address. The sender address we were computing and passing was only consumed by BobGateway's own PSBT construction — which we don't use. We build our own UTXO transaction sending the trade amount to the deposit address with the optional `op_return` data.

Passing a sender had an unwanted side effect: order creation enforced a per-address confirmed-funds check, rejecting trades whose balance was spread across multiple addresses (surfaced to the user as `FundsFragmented`).

This PR:

- Omits the sender for UTXO sells so deposits are matched by `op_return` as intended. EVM sells continue to pass the send address.
- Removes the now-unused `getBobGatewaySender` helper (single-richest-address selection + fee/balance pre-check).
- Drops the `from: sender` `chainSpecific` field from UTXO tx build and fee-estimation calls.
- Removes the `FundsFragmented` `TradeQuoteError` and its translation/validation/sentry/error-mapping wiring, which existed solely for this check.

## Issue (if applicable)

closes #

## Risk

> High Risk PRs Require 2 approvals

Touches a UTXO on-chain transaction build path (BTC → BOB sells): the `from` field is no longer passed to `buildSendApiTransaction` / `getFeeData`. Scope is limited to the BobGateway swapper plus the removal of an otherwise-unused error enum and its references.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

BobGateway swapper only — BTC → BOB UTXO sells (transaction build + fee estimation) and EVM → BTC sells (unchanged, still passes send address).

## Testing

### Engineering

- Quote and execute a BTC → BOB sell from a wallet whose BTC balance is spread across multiple addresses — it should now quote and build successfully rather than failing with `FundsFragmented`.
- Quote and execute a BTC → BOB sell from a single-address wallet to confirm no regression.
- Confirm EVM → BTC sells still quote and execute (sender still passed).
- Verify the deposit transaction sends the correct amount to the deposit address with the expected `op_return` data.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

User-facing: previously-blocked BTC → BOB sells from multi-address balances now succeed. Verify a BOB Gateway BTC sell completes end-to-end in a preview environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the "Funds Fragmented" error handling, which is no longer applicable to trading logic.

* **Refactor**
  * Simplified sender validation requirements for UTXO-based asset trading, streamlining quote and fee calculations.
  * Updated error mapping and validation checks to align with revised trading workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->