### PR TITLE
fix(swap-widget): filter assets to production-supported chains

### DIFF
--- a/packages/swap-widget/src/constants/chains.ts
+++ b/packages/swap-widget/src/constants/chains.ts
@@ -39,6 +39,14 @@ const BASE_ASSETS_BY_CHAIN_ID: Record<ChainId, Asset> = {
   [solana.chainId]: solana,
 }
 
+export const SUPPORTED_CHAIN_IDS_SET: ReadonlySet<ChainId> = new Set(
+  Object.keys(BASE_ASSETS_BY_CHAIN_ID),
+)
+
+export const isSupportedChainId = (chainId: ChainId): boolean => {
+  return SUPPORTED_CHAIN_IDS_SET.has(chainId)
+}
+
 export const getBaseAsset = (chainId: ChainId): Asset | undefined => {
   return BASE_ASSETS_BY_CHAIN_ID[chainId]
 }

--- a/packages/swap-widget/src/hooks/useAssets.ts
+++ b/packages/swap-widget/src/hooks/useAssets.ts
@@ -2,6 +2,7 @@ import { ASSET_NAMESPACE, fromAssetId } from '@shapeshiftoss/caip'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 
+import { isSupportedChainId } from '../constants/chains'
 import type { Asset, AssetId, ChainId } from '../types'
 
 type AssetQueryResult<TData> = Omit<UseQueryResult<RawAssetData>, 'data'> & { data: TData }
@@ -52,7 +53,9 @@ export const useAssetData = (): UseQueryResult<RawAssetData> => {
 export const useAssets = (): AssetQueryResult<Asset[]> => {
   const { data, ...rest } = useAssetData()
 
-  const assets = data ? data.ids.map(id => data.byId[id]).filter(Boolean) : []
+  const assets = data
+    ? data.ids.map(id => data.byId[id]).filter(asset => asset && isSupportedChainId(asset.chainId))
+    : []
 
   return { data: assets, ...rest }
 }


### PR DESCRIPTION
## Description

`useAssets` previously surfaced every asset in the raw asset data, including assets on chains that are not validated for the swap widget. This adds an `isSupportedChainId` helper (backed by `BASE_ASSETS_BY_CHAIN_ID`) and filters the asset list in `useAssets` so only production-supported chains are returned.

This follows up on #12425, which restricted the public API and swap widget to production-validated chains.

## Issue (if applicable)

closes #

## Risk

> High Risk PRs Require 2 approvals

Low risk. Isolated to the `@shapeshiftoss/swap-widget` package — no on-chain transaction changes, no core state management changes. Narrows the asset list shown in the swap widget to chains that have a base asset configured.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None directly. Only affects which assets are selectable in the swap widget.

## Testing

### Engineering

- Load the swap widget and confirm only assets on production-supported chains (those present in `BASE_ASSETS_BY_CHAIN_ID`) appear in the asset list.
- Confirm assets on unsupported chains are no longer selectable.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

N/A