### PR TITLE
feat: expand public api supported chains to production parity

### DIFF
--- a/packages/public-api/src/constants.ts
+++ b/packages/public-api/src/constants.ts
@@ -9,19 +9,35 @@ export const SUPPORTED_CHAIN_IDS: readonly KnownChainIds[] = [
   KnownChainIds.BnbSmartChainMainnet,
   KnownChainIds.EthereumMainnet,
   KnownChainIds.GnosisMainnet,
+  KnownChainIds.HyperEvmMainnet,
+  KnownChainIds.KatanaMainnet,
+  KnownChainIds.MegaEthMainnet,
+  KnownChainIds.MonadMainnet,
   KnownChainIds.OptimismMainnet,
+  KnownChainIds.PlasmaMainnet,
   KnownChainIds.PolygonMainnet,
   // UTXO
   KnownChainIds.BitcoinCashMainnet,
   KnownChainIds.BitcoinMainnet,
   KnownChainIds.DogecoinMainnet,
   KnownChainIds.LitecoinMainnet,
+  KnownChainIds.ZcashMainnet,
   // Cosmos SDK
   KnownChainIds.CosmosMainnet,
   KnownChainIds.MayachainMainnet,
   KnownChainIds.ThorchainMainnet,
   // Solana
   KnownChainIds.SolanaMainnet,
+  // Tron
+  KnownChainIds.TronMainnet,
+  // Sui
+  KnownChainIds.SuiMainnet,
+  // TON
+  KnownChainIds.TonMainnet,
+  // NEAR
+  KnownChainIds.NearMainnet,
+  // Starknet
+  KnownChainIds.StarknetMainnet,
 ]
 
 export const SUPPORTED_CHAIN_IDS_SET: ReadonlySet<string> = new Set(SUPPORTED_CHAIN_IDS)


### PR DESCRIPTION
## Description

Adds the remaining production-enabled chains to the public API's `SUPPORTED_CHAIN_IDS` allowlist (`packages/public-api/src/constants.ts`) so the API exposes the same chains that are enabled in web production.

New chains: **Monad, MegaETH, HyperEVM, Katana, Plasma** (EVM), **Zcash** (UTXO), **Tron, Sui, Ton, Near, Starknet**.

This brings the allowlist to full parity with the web app's production chain set (27 chains). #12425 had restricted the API to a smaller curated subset; this closes the gap (a client integrated Monad + MegaETH and found them filtered out).

## Issue (if applicable)

closes #

## Risk

Low. Data-only change to a static allowlist constant. No on-chain transactions, no contract interactions. Effect is which chains' assets/chains the public API surfaces — the existing `getAsset`/`getAssetIds`/`/chains` filtering already keys off this set; assets only appear if present in the loaded asset data, and quotes only return if an enabled swapper supports the chain (Relay covers Monad/MegaETH).

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Public API `/v1/chains` and `/v1/assets` responses gain the listed chains. No wallet or signing paths touched.

## Testing

### Engineering

- `GET /v1/chains` returns all 27 chains including Monad (`eip155:143`), MegaETH (`eip155:4326`), HyperEVM, Katana, Plasma, Zcash, Tron, Sui, Ton, Near, Starknet.
- `GET /v1/assets?chainId=eip155:143` (and `:4326`) returns non-empty asset lists (previously filtered to empty).
- Request a rate selling into a Monad or MegaETH asset → Relay returns a rate.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Public-API-only change; no web UI surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added support for additional blockchain networks including HyperEvm, Katana, MegaEth, Monad, Zcash, Tron, Sui, TON, NEAR, and Starknet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->