### PR TITLE
chore: release v1.1029.0

### DIFF
--- a/packages/public-api/src/constants.ts
+++ b/packages/public-api/src/constants.ts
@@ -9,19 +9,35 @@ export const SUPPORTED_CHAIN_IDS: readonly KnownChainIds[] = [
   KnownChainIds.BnbSmartChainMainnet,
   KnownChainIds.EthereumMainnet,
   KnownChainIds.GnosisMainnet,
+  KnownChainIds.HyperEvmMainnet,
+  KnownChainIds.KatanaMainnet,
+  KnownChainIds.MegaEthMainnet,
+  KnownChainIds.MonadMainnet,
   KnownChainIds.OptimismMainnet,
+  KnownChainIds.PlasmaMainnet,
   KnownChainIds.PolygonMainnet,
   // UTXO
   KnownChainIds.BitcoinCashMainnet,
   KnownChainIds.BitcoinMainnet,
   KnownChainIds.DogecoinMainnet,
   KnownChainIds.LitecoinMainnet,
+  KnownChainIds.ZcashMainnet,
   // Cosmos SDK
   KnownChainIds.CosmosMainnet,
   KnownChainIds.MayachainMainnet,
   KnownChainIds.ThorchainMainnet,
   // Solana
   KnownChainIds.SolanaMainnet,
+  // Tron
+  KnownChainIds.TronMainnet,
+  // Sui
+  KnownChainIds.SuiMainnet,
+  // TON
+  KnownChainIds.TonMainnet,
+  // NEAR
+  KnownChainIds.NearMainnet,
+  // Starknet
+  KnownChainIds.StarknetMainnet,
 ]
 
 export const SUPPORTED_CHAIN_IDS_SET: ReadonlySet<string> = new Set(SUPPORTED_CHAIN_IDS)

--- a/packages/swap-widget/src/constants/chains.ts
+++ b/packages/swap-widget/src/constants/chains.ts
@@ -39,6 +39,14 @@ const BASE_ASSETS_BY_CHAIN_ID: Record<ChainId, Asset> = {
   [solana.chainId]: solana,
 }
 
+export const SUPPORTED_CHAIN_IDS_SET: ReadonlySet<ChainId> = new Set(
+  Object.keys(BASE_ASSETS_BY_CHAIN_ID),
+)
+
+export const isSupportedChainId = (chainId: ChainId): boolean => {
+  return SUPPORTED_CHAIN_IDS_SET.has(chainId)
+}
+
 export const getBaseAsset = (chainId: ChainId): Asset | undefined => {
   return BASE_ASSETS_BY_CHAIN_ID[chainId]
 }

--- a/packages/swap-widget/src/hooks/useAssets.ts
+++ b/packages/swap-widget/src/hooks/useAssets.ts
@@ -2,6 +2,7 @@ import { ASSET_NAMESPACE, fromAssetId } from '@shapeshiftoss/caip'
 import type { UseQueryResult } from '@tanstack/react-query'
 import { useQuery } from '@tanstack/react-query'
 
+import { isSupportedChainId } from '../constants/chains'
 import type { Asset, AssetId, ChainId } from '../types'
 
 type AssetQueryResult<TData> = Omit<UseQueryResult<RawAssetData>, 'data'> & { data: TData }
@@ -52,7 +53,9 @@ export const useAssetData = (): UseQueryResult<RawAssetData> => {
 export const useAssets = (): AssetQueryResult<Asset[]> => {
   const { data, ...rest } = useAssetData()
 
-  const assets = data ? data.ids.map(id => data.byId[id]).filter(Boolean) : []
+  const assets = data
+    ? data.ids.map(id => data.byId[id]).filter(asset => asset && isSupportedChainId(asset.chainId))
+    : []
 
   return { data: assets, ...rest }
 }


### PR DESCRIPTION
# Production changes - testing required

## Public API + swap widget chain coverage
- feat: expand public api supported chains to production parity (#12432)
- fix(swap-widget): filter assets to production-supported chains (#12431)

The public API's `SUPPORTED_CHAIN_IDS` allowlist now matches the web app's full production chain set (27 chains, adding Monad, MegaETH, HyperEVM, Katana, Plasma, Zcash, Tron, Sui, Ton, Near, and Starknet), and the swap widget's `useAssets` now filters out assets on chains that are not production-validated. Test that the swap widget only surfaces assets on production-supported chains (no assets from unsupported chains appearing in the asset picker) and that quotes/swaps still work normally across the listed chains.

# Dev/local only - no production testing required

_No commits in this release are behind a feature flag that is off in production._

---

Note: the two commits in this list both target production parity for the public API and swap widget, so neither is gated behind a flagged-off feature. None of the off-in-prod flags (e.g. `VITE_FEATURE_CELO`, `VITE_FEATURE_AGENTIC_CHAT`, `VITE_FEATURE_WORLDCHAIN`, `VITE_FEATURE_BERACHAIN`, and other dev-only chains) are referenced by these commits.