### PR TITLE
fix: render connected dApp icon in a square box

### DIFF
--- a/src/plugins/walletConnectToDapps/components/DAppInfo.tsx
+++ b/src/plugins/walletConnectToDapps/components/DAppInfo.tsx
@@ -18,7 +18,7 @@ export const DAppInfo: FC<IProps> = ({ metadata }) => {
   return (
     <Grid templateRows='repeat(2, 1fr)' templateColumns='repeat(5, 1fr)' gap={4}>
       <GridItem rowSpan={3} colSpan={1}>
-        {icon && <Avatar src={icon} icon={foxIcon} />}
+        {icon && <Avatar src={icon} icon={foxIcon} borderRadius='none' />}
       </GridItem>
       <GridItem colSpan={4}>{name}</GridItem>
       <GridItem colSpan={4}>{url}</GridItem>

--- a/src/plugins/walletConnectToDapps/components/header/DappAvatar.tsx
+++ b/src/plugins/walletConnectToDapps/components/header/DappAvatar.tsx
@@ -24,7 +24,7 @@ export const DappAvatar: React.FC<DappAvatarProps> = ({
   const menuBg = useColorModeValue('gray.100', 'gray.700')
 
   return (
-    <Avatar size={size} src={image} icon={foxIcon}>
+    <Avatar size={size} src={image} icon={foxIcon} borderRadius='none'>
       {connected && (
         <CircleIcon
           color={connectedIconColor}


### PR DESCRIPTION
## Description

The connected-dApp avatar in the WalletConnect (wallet-connect-to-dApps) UI used Chakra `Avatar`'s default **circular** mask. A circle discards the corners of the square, and a dApp's favicon (square by convention) has its content — the ShapeShift fox's **ears** — in those top corners, so they got chopped off when a dApp was connected.

Fix: render the dApp icon as a **square** (`borderRadius='none'`) so any dApp favicon shows fully, in both:
- `DappAvatar.tsx` — the header connected-dApp button
- `DAppInfo.tsx` — the expanded "Connected dApp(s)" panel

This is a general fix: a square box never clips a dApp icon's corners, regardless of the dApp's favicon. A dApp wanting a round look ships a transparent-corner icon.

## Issue (if applicable)

Closes #12418
Closes SS-5697 — https://linear.app/shapeshift-dao/issue/SS-5697/fox-icon-has-ears-chopped-off-when-wallet-connected

## Risk

Very low. Cosmetic-only: changes the `borderRadius` of the connected-dApp `Avatar` from a circle to a square in two components. No logic, transactions, or wallet/contract interactions affected.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None — purely the visual shape of the connected-dApp icon.

## Testing

### Engineering

1. Connect a dApp via WalletConnect (e.g. the swap widget / any dApp with a square favicon).
2. Open the connected-dApp header dropdown ("Connected dApp(s)").
3. The dApp icon (the fox) renders in a square box with **no clipped ears**, in both the header button avatar and the expanded panel row.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Cosmetic icon-shape change; verify the connected-dApp fox icon is no longer chopped.

## Screenshots (if applicable)

Before: fox ears clipped by the circular avatar. After: full fox in a square box.