### PR TITLE
fix: enable TCY deposit signing on KeepKey

### DIFF
--- a/packages/hdwallet-keepkey/src/thorchain.ts
+++ b/packages/hdwallet-keepkey/src/thorchain.ts
@@ -118,7 +118,7 @@ export async function thorchainSignTx(
         }
 
         const coinAsset = m.value.coins[0].asset
-        if (coinAsset !== 'THOR.RUNE') {
+        if (coinAsset !== 'THOR.RUNE' && coinAsset !== 'THOR.TCY') {
           throw new Error('THORChain: Unsupported coin asset: ' + coinAsset)
         }
 


### PR DESCRIPTION
## Description

The KeepKey THORChain `MsgDeposit` handler (`packages/hdwallet-keepkey/src/thorchain.ts`) hardcoded a guard rejecting any coin asset other than `THOR.RUNE`. Staking TCY builds a `MsgDeposit` with coin asset `THOR.TCY`, so signing failed at the wallet layer with `THORChain: Unsupported coin asset: THOR.TCY` (surfaced in the UI as "something went wrong"). Native and Ledger wallets sign the proto tx generically and have no such restriction, which is why TCY staking only failed on KeepKey.

This allows `THOR.TCY` alongside `THOR.RUNE` in the KeepKey deposit allowlist, matching the chain adapter's own deposit coin allowlist (`ThorchainChainAdapter.buildSendApiTransaction`). Scope is intentionally limited to TCY deposit, the confirmed-working path.

## Issue (if applicable)

closes #12410

Closes [SS-5695](https://linear.app/shapeshift-dao/issue/SS-5695/unable-to-stake-tcy-on-keepkey)

## Risk

> High Risk PRs Require 2 approvals

This is an `hdwallet` change that modifies an on-chain transaction signing path (THORChain `MsgDeposit`), so it is **higher risk** and touches a hardware wallet. The change is a one-line allowlist addition that only widens which coin assets KeepKey will sign for a deposit; it does not alter the RUNE path or the message construction.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- Protocol: THORChain
- Transaction type: `MsgDeposit`
- Wallet: KeepKey only

## Testing

### Engineering

1. Connect a KeepKey wallet.
2. Navigate to TCY and stake an amount (`tcy+` memo → `MsgDeposit` with coin asset `THOR.TCY`).
3. Confirm on device — signing now succeeds and the tx broadcasts (previously threw `THORChain: Unsupported coin asset: THOR.TCY`).
4. Regression: confirm RUNE deposits/LP and existing THORChain flows still sign on KeepKey, and that TCY staking still works on Native/Ledger.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not behind a flag. To functionally test: stake TCY on a KeepKey device and verify the transaction signs and broadcasts without the "something went wrong" error.

## Screenshots (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced THORChain deposit handling to support additional coin asset types, expanding compatibility for multi-asset transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
