### PR TITLE
fix: update Zcash consensus branch ID for NU6.2 network upgrade

### DIFF
--- a/packages/hdwallet-ledger/src/bitcoin.ts
+++ b/packages/hdwallet-ledger/src/bitcoin.ts
@@ -20,7 +20,13 @@ const ZCASH_VERSION_GROUP_ID: Record<number, number> = {
   5: 0x26a7270a,
 }
 
-const ZCASH_CONSENSUS_BRANCH_ID = 0x4dec4df0
+// Consensus branch ID of the currently-active Zcash network upgrade.
+// On each network upgrade, bump this together with ZCASH_UPGRADE_ACTIVATION_HEIGHT.
+const ZCASH_CONSENSUS_BRANCH_ID = 0x5437f330
+
+// Activation height of the upgrade above. Used as a fallback block height so Ledger
+// derives the matching consensus branch ID when every input is still unconfirmed.
+const ZCASH_UPGRADE_ACTIVATION_HEIGHT = 3364600
 
 type ZcashInput = core.BTCSignTxInputLedger & {
   txid?: string
@@ -399,11 +405,14 @@ export async function btcSignTx(
     segwit,
     useTrustedInputForSegwit: Boolean(segwit),
     // For Zcash, pass the current network blockHeight so Ledger uses correct consensus branch ID.
-    // Use the highest confirmed input blockHeight, or fallback to a height above NU6.1 activation (3146400).
-    // This ensures correct consensus branch ID (0x4dec4df0) even when spending unconfirmed outputs.
+    // Use the highest confirmed input blockHeight, or fall back to the active upgrade's activation
+    // height so Ledger derives ZCASH_CONSENSUS_BRANCH_ID even when spending unconfirmed outputs.
     blockHeight:
       msg.coin === 'Zcash'
-        ? Math.max(...blockHeights.filter((h): h is number => h !== undefined && h > 0), 3150000)
+        ? Math.max(
+            ...blockHeights.filter((h): h is number => h !== undefined && h > 0),
+            ZCASH_UPGRADE_ACTIVATION_HEIGHT,
+          )
         : undefined,
     expiryHeight: msg.coin === 'Zcash' ? Buffer.alloc(4) : undefined,
   }

--- a/packages/hdwallet-native/src/bitcoin.ts
+++ b/packages/hdwallet-native/src/bitcoin.ts
@@ -26,7 +26,7 @@ const ZCASH_VERSION_GROUP_ID: Record<number, number> = {
   5: 0x26a7270a,
 }
 
-const ZCASH_CONSENSUS_BRANCH_ID = 0x4dec4df0
+const ZCASH_CONSENSUS_BRANCH_ID = 0x5437f330
 
 type NonWitnessUtxo = Buffer
 

--- a/packages/hdwallet-trezor/src/bitcoin.ts
+++ b/packages/hdwallet-trezor/src/bitcoin.ts
@@ -36,7 +36,7 @@ const ZCASH_VERSION_GROUP_ID: Record<number, number> = {
   5: 0x26a7270a,
 }
 
-const ZCASH_CONSENSUS_BRANCH_ID = 0x4dec4df0
+const ZCASH_CONSENSUS_BRANCH_ID = 0x5437f330
 
 function translateInputScriptType(scriptType?: core.BTCInputScriptType): string {
   switch (scriptType) {


### PR DESCRIPTION
## Description

Zcash activated network upgrade **NU6.2** (consensus branch ID `0x5437f330`, mainnet activation height `3364600`). The wallet adapters still signed with the prior **NU6.1** branch ID `0x4dec4df0`, so every signed Zcash transaction failed consensus validation with:

> `transaction did not pass consensus validation: transaction uses an incorrect consensus branch id`

and could not be broadcast.

Changes:
- Bump `ZCASH_CONSENSUS_BRANCH_ID` to `0x5437f330` in the **native**, **ledger**, and **trezor** adapters.
- Fix the Ledger fallback `blockHeight`: it was `3150000` (above NU6.1 but **below** NU6.2 activation `3364600`), which would make Ledger derive the stale NU6.1 branch ID when spending only unconfirmed inputs. It now falls back to the active upgrade's activation height via the new `ZCASH_UPGRADE_ACTIVATION_HEIGHT` constant, paired with the branch ID so both are bumped together on future upgrades.

Verified against the zcash consensus source (`upgrades.cpp`, `chainparams.cpp`): the v5 (ZIP-225) transaction format and version group id (`0x26a7270a`) are unchanged by NU6.2, and the `@shapeshiftoss/bitcoinjs-lib` fork flows the branch ID into the ZIP-244 sighash as data — so no library/version-group change is required.

## Issue (if applicable)

closes #12423

Closes SS-5700 — https://linear.app/shapeshift-dao/issue/SS-5700/unable-to-send-zcash

## Risk

> High Risk PRs Require 2 approvals

High risk — this modifies on-chain transaction signing for Zcash across all wallet adapters (native, Ledger, Trezor). No format/serialization changes; only the consensus branch ID value (and the Ledger fallback height) change.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Zcash (ZEC) send transactions on native, Ledger, and Trezor wallets. No other chains affected.

## Testing

### Engineering

1. Rebuild the affected packages: `pnpm --filter @shapeshiftoss/hdwallet-native --filter @shapeshiftoss/hdwallet-ledger --filter @shapeshiftoss/hdwallet-trezor run build`.
2. Send a Zcash transaction with a native wallet and confirm it broadcasts (no "incorrect consensus branch id" error).
3. Send a Zcash transaction with a Ledger and confirm it broadcasts, including a case where the inputs are unconfirmed (exercises the fallback height path).
4. Trezor: confirm Zcash send broadcasts.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not behind a flag. Functional test: connect a wallet holding ZEC, send a small amount, confirm the transaction broadcasts successfully and confirms on-chain.

## Screenshots (if applicable)

n/a