### PR TITLE
fix(yields): match yield.xyz snake_case yield types to fix Earn page crash

### DIFF
--- a/src/components/MultiHopTrade/components/Earn/components/EarnFooter.tsx
+++ b/src/components/MultiHopTrade/components/Earn/components/EarnFooter.tsx
@@ -40,9 +40,9 @@ const statsBoxSx: FlexProps = {
 
 const getActionTextKey = (yieldType: string | undefined): string => {
   switch (yieldType) {
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'staking':
       return 'defi.stake'
     case 'vault':
@@ -64,7 +64,7 @@ const getYieldExplainers = (selectedYield: AugmentedYieldDto): ExplainerItem[] =
   const outputTokenSymbol = selectedYield.outputToken?.symbol
 
   switch (yieldType) {
-    case 'liquid-staking':
+    case 'liquid_staking':
       return [
         {
           icon: <Icon as={MdSwapHoriz} color='text.subtle' />,
@@ -81,8 +81,8 @@ const getYieldExplainers = (selectedYield: AugmentedYieldDto): ExplainerItem[] =
           textKey: 'earn.explainers.liquidStakingWithdraw',
         },
       ]
-    case 'native-staking':
-    case 'pooled-staking':
+    case 'native_staking':
+    case 'pooled_staking':
     case 'staking':
       return [
         {
@@ -252,7 +252,7 @@ export const EarnFooter = memo(
                     {translate('earn.yieldType')}
                   </Text>
                   <Text fontSize='sm' fontWeight='medium' textTransform='capitalize'>
-                    {selectedYield.mechanics.type.replace(/-/g, ' ')}
+                    {selectedYield.mechanics.type.replace(/[-_]/g, ' ')}
                   </Text>
                 </Flex>
               )}

--- a/src/components/MultiHopTrade/components/Earn/components/YieldSelector.tsx
+++ b/src/components/MultiHopTrade/components/Earn/components/YieldSelector.tsx
@@ -42,7 +42,7 @@ type YieldSelectorProps = {
 }
 
 const isNativeStaking = (type: string | undefined): boolean =>
-  ['native-staking', 'staking'].includes(type ?? '')
+  ['native_staking', 'staking'].includes(type ?? '')
 
 const getDisplayInfo = (
   yieldItem: AugmentedYieldDto,
@@ -157,7 +157,7 @@ const YieldItem = memo(
 )
 
 const isStakingType = (type: string | undefined): boolean =>
-  ['native-staking', 'pooled-staking', 'staking'].includes(type ?? '')
+  ['native_staking', 'pooled_staking', 'staking'].includes(type ?? '')
 
 export const YieldSelector = memo(
   ({

--- a/src/hooks/useTxDetails/useTxDetails.test.ts
+++ b/src/hooks/useTxDetails/useTxDetails.test.ts
@@ -140,21 +140,21 @@ describe('yieldActionToMethod', () => {
       ).toBe(Method.Stake)
     })
 
-    it('should return Stake for native-staking yield deposits', () => {
+    it('should return Stake for native_staking yield deposits', () => {
       expect(
-        yieldActionToMethod(makeYieldAction(ActionType.Deposit, { yieldType: 'native-staking' })),
+        yieldActionToMethod(makeYieldAction(ActionType.Deposit, { yieldType: 'native_staking' })),
       ).toBe(Method.Stake)
     })
 
-    it('should return Stake for liquid-staking yield deposits', () => {
+    it('should return Stake for liquid_staking yield deposits', () => {
       expect(
-        yieldActionToMethod(makeYieldAction(ActionType.Deposit, { yieldType: 'liquid-staking' })),
+        yieldActionToMethod(makeYieldAction(ActionType.Deposit, { yieldType: 'liquid_staking' })),
       ).toBe(Method.Stake)
     })
 
-    it('should return Stake for pooled-staking yield deposits', () => {
+    it('should return Stake for pooled_staking yield deposits', () => {
       expect(
-        yieldActionToMethod(makeYieldAction(ActionType.Deposit, { yieldType: 'pooled-staking' })),
+        yieldActionToMethod(makeYieldAction(ActionType.Deposit, { yieldType: 'pooled_staking' })),
       ).toBe(Method.Stake)
     })
 
@@ -186,7 +186,7 @@ describe('yieldActionToMethod', () => {
       expect(
         yieldActionToMethod(
           makeYieldAction(ActionType.Withdraw, {
-            yieldType: 'liquid-staking',
+            yieldType: 'liquid_staking',
             cooldownPeriodSeconds: 86400,
           }),
         ),
@@ -203,7 +203,7 @@ describe('yieldActionToMethod', () => {
       expect(
         yieldActionToMethod(
           makeYieldAction(ActionType.Withdraw, {
-            yieldType: 'native-staking',
+            yieldType: 'native_staking',
             cooldownPeriodSeconds: 0,
           }),
         ),

--- a/src/lib/yieldxyz/types.ts
+++ b/src/lib/yieldxyz/types.ts
@@ -32,9 +32,9 @@ export enum ActionIntent {
 
 export type YieldType =
   | 'staking'
-  | 'native-staking'
-  | 'pooled-staking'
-  | 'liquid-staking'
+  | 'native_staking'
+  | 'pooled_staking'
+  | 'liquid_staking'
   | 'restaking'
   | 'vault'
   | 'lending'

--- a/src/lib/yieldxyz/utils.test.ts
+++ b/src/lib/yieldxyz/utils.test.ts
@@ -35,9 +35,9 @@ describe('getTransactionButtonText', () => {
   it('should use staking terminology when yieldType is staking', () => {
     expect(getTransactionButtonText('STAKE', undefined, 'staking')).toBe('Stake')
     expect(getTransactionButtonText('UNSTAKE', undefined, 'staking')).toBe('Unstake')
-    expect(getTransactionButtonText('DEPOSIT', undefined, 'liquid-staking')).toBe('Stake')
-    expect(getTransactionButtonText('WITHDRAW', undefined, 'liquid-staking')).toBe('Unstake')
-    expect(getTransactionButtonText(undefined, 'Deposit ETH', 'native-staking')).toBe('Stake')
+    expect(getTransactionButtonText('DEPOSIT', undefined, 'liquid_staking')).toBe('Stake')
+    expect(getTransactionButtonText('WITHDRAW', undefined, 'liquid_staking')).toBe('Unstake')
+    expect(getTransactionButtonText(undefined, 'Deposit ETH', 'native_staking')).toBe('Stake')
   })
 
   it('should return Confirm as final fallback', () => {
@@ -301,15 +301,15 @@ describe('getYieldActionLabelKeys', () => {
       enter: 'defi.stake',
       exit: 'defi.unstake',
     })
-    expect(getYieldActionLabelKeys('native-staking')).toEqual({
+    expect(getYieldActionLabelKeys('native_staking')).toEqual({
       enter: 'defi.stake',
       exit: 'defi.unstake',
     })
-    expect(getYieldActionLabelKeys('pooled-staking')).toEqual({
+    expect(getYieldActionLabelKeys('pooled_staking')).toEqual({
       enter: 'defi.stake',
       exit: 'defi.unstake',
     })
-    expect(getYieldActionLabelKeys('liquid-staking')).toEqual({
+    expect(getYieldActionLabelKeys('liquid_staking')).toEqual({
       enter: 'defi.stake',
       exit: 'defi.unstake',
     })
@@ -340,9 +340,9 @@ describe('getYieldActionLabelKeys', () => {
 describe('isStakingYieldType', () => {
   it('should return true for staking-related yield types', () => {
     expect(isStakingYieldType('staking')).toBe(true)
-    expect(isStakingYieldType('native-staking')).toBe(true)
-    expect(isStakingYieldType('pooled-staking')).toBe(true)
-    expect(isStakingYieldType('liquid-staking')).toBe(true)
+    expect(isStakingYieldType('native_staking')).toBe(true)
+    expect(isStakingYieldType('pooled_staking')).toBe(true)
+    expect(isStakingYieldType('liquid_staking')).toBe(true)
     expect(isStakingYieldType('restaking')).toBe(true)
   })
 
@@ -361,9 +361,9 @@ describe('formatYieldTxTitle', () => {
 
   it('should use staking terminology when yieldType is staking', () => {
     expect(formatYieldTxTitle('Deposit ETH', 'ETH', 'staking')).toBe('Stake ETH')
-    expect(formatYieldTxTitle('Withdraw ETH', 'ETH', 'liquid-staking')).toBe('Unstake ETH')
-    expect(formatYieldTxTitle('Exit ETH', 'ETH', 'native-staking')).toBe('Unstake ETH')
-    expect(formatYieldTxTitle('Unstake ETH', 'ETH', 'pooled-staking')).toBe('Unstake ETH')
+    expect(formatYieldTxTitle('Withdraw ETH', 'ETH', 'liquid_staking')).toBe('Unstake ETH')
+    expect(formatYieldTxTitle('Exit ETH', 'ETH', 'native_staking')).toBe('Unstake ETH')
+    expect(formatYieldTxTitle('Unstake ETH', 'ETH', 'pooled_staking')).toBe('Unstake ETH')
   })
 
   it('should preserve unknown titles', () => {
@@ -376,9 +376,9 @@ describe('getYieldSuccessMessageKey', () => {
   it('should return staking success keys for staking yield types', () => {
     expect(getYieldSuccessMessageKey('staking', 'enter')).toBe('successStaked')
     expect(getYieldSuccessMessageKey('staking', 'exit')).toBe('successUnstaked')
-    expect(getYieldSuccessMessageKey('native-staking', 'enter')).toBe('successStaked')
-    expect(getYieldSuccessMessageKey('liquid-staking', 'exit')).toBe('successUnstaked')
-    expect(getYieldSuccessMessageKey('pooled-staking', 'enter')).toBe('successStaked')
+    expect(getYieldSuccessMessageKey('native_staking', 'enter')).toBe('successStaked')
+    expect(getYieldSuccessMessageKey('liquid_staking', 'exit')).toBe('successUnstaked')
+    expect(getYieldSuccessMessageKey('pooled_staking', 'enter')).toBe('successStaked')
   })
 
   it('should return staking success key for restaking yield types', () => {

--- a/src/lib/yieldxyz/utils.ts
+++ b/src/lib/yieldxyz/utils.ts
@@ -73,9 +73,9 @@ const assertNever = (value: never): never => {
 
 const YIELD_TYPES: YieldType[] = [
   'staking',
-  'native-staking',
-  'pooled-staking',
-  'liquid-staking',
+  'native_staking',
+  'pooled_staking',
+  'liquid_staking',
   'restaking',
   'vault',
   'lending',
@@ -87,9 +87,9 @@ export const isValidYieldType = (value: string): value is YieldType =>
 export const isStakingYieldType = (yieldType: YieldType): boolean => {
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return true
     case 'vault':
@@ -250,15 +250,15 @@ export type YieldActionLabelKeys = {
  * Gets the appropriate translation keys for yield actions based on yield type.
  *
  * Yield types and their terminology:
- * - staking, native-staking, pooled-staking, liquid-staking, restaking → Stake/Unstake
+ * - staking, native_staking, pooled_staking, liquid_staking, restaking → Stake/Unstake
  * - vault, lending → Deposit/Withdraw
  */
 export const getYieldActionLabelKeys = (yieldType: YieldType): YieldActionLabelKeys => {
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return { enter: 'defi.stake', exit: 'defi.unstake' }
     case 'vault':
@@ -277,9 +277,9 @@ export type YieldLoadingStateKeys = {
 export const getYieldLoadingStateKeys = (yieldType: YieldType): YieldLoadingStateKeys => {
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return { enter: 'yieldXYZ.staking', exit: 'yieldXYZ.unstaking' }
     case 'vault':
@@ -298,9 +298,9 @@ export type YieldHeadingKeys = {
 export const getYieldHeadingKeys = (yieldType: YieldType): YieldHeadingKeys => {
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return { enter: 'yieldXYZ.stakeSymbol', exit: 'yieldXYZ.unstakeSymbol' }
     case 'vault':
@@ -319,9 +319,9 @@ export type YieldPendingStatusKeys = {
 export const getYieldPendingStatusKeys = (yieldType: YieldType): YieldPendingStatusKeys => {
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return { enter: 'yieldXYZ.stakingPending', exit: 'yieldXYZ.unstakingPending' }
     case 'vault':
@@ -335,9 +335,9 @@ export const getYieldPendingStatusKeys = (yieldType: YieldType): YieldPendingSta
 export const getYieldMinAmountKey = (yieldType: YieldType): string => {
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return 'yieldXYZ.minStake'
     case 'vault':
@@ -364,9 +364,9 @@ export const getYieldSuccessMessageKey = (
 
   switch (yieldType) {
     case 'staking':
-    case 'native-staking':
-    case 'pooled-staking':
-    case 'liquid-staking':
+    case 'native_staking':
+    case 'pooled_staking':
+    case 'liquid_staking':
     case 'restaking':
       return action === 'enter' ? 'successStaked' : 'successUnstaked'
     case 'vault':

--- a/src/pages/Yields/YieldAssetDetails.tsx
+++ b/src/pages/Yields/YieldAssetDetails.tsx
@@ -197,7 +197,7 @@ export const YieldAssetDetails = memo(() => {
     () =>
       Array.from(new Set(assetYields.map(y => y.mechanics.type))).map(type => ({
         id: type,
-        name: type.charAt(0).toUpperCase() + type.slice(1).replace(/-/g, ' '),
+        name: type.charAt(0).toUpperCase() + type.slice(1).replace(/[-_]/g, ' '),
       })),
     [assetYields],
   )

--- a/src/pages/Yields/components/YieldExplainers.tsx
+++ b/src/pages/Yields/components/YieldExplainers.tsx
@@ -23,7 +23,7 @@ const getYieldExplainers = (selectedYield: AugmentedYieldDto): ExplainerItem[] =
   const outputTokenSymbol = selectedYield.outputToken?.symbol
 
   switch (yieldType) {
-    case 'liquid-staking':
+    case 'liquid_staking':
       return [
         {
           icon: swapIcon,
@@ -39,8 +39,8 @@ const getYieldExplainers = (selectedYield: AugmentedYieldDto): ExplainerItem[] =
           relevance: 'both' as const,
         },
       ]
-    case 'native-staking':
-    case 'pooled-staking':
+    case 'native_staking':
+    case 'pooled_staking':
     case 'staking':
       return [
         { icon: giftIcon, textKey: 'earn.explainers.rewardsSchedule', relevance: 'enter' as const },

--- a/src/pages/Yields/components/YieldsList.tsx
+++ b/src/pages/Yields/components/YieldsList.tsx
@@ -264,7 +264,7 @@ export const YieldsList = memo(() => {
     const uniqueTypes = [...new Set(sourceYields.map(y => y.mechanics.type))]
     return uniqueTypes.map(type => ({
       id: type,
-      name: type.charAt(0).toUpperCase() + type.slice(1).replace(/-/g, ' '),
+      name: type.charAt(0).toUpperCase() + type.slice(1).replace(/[-_]/g, ' '),
     }))
   }, [filterSourceYields, yields?.all])
 


### PR DESCRIPTION
## Description

yield.xyz changed its `/providers` yield type values from hyphenated to `snake_case` (e.g. `liquid-staking` → `liquid_staking`, `native-staking` → `native_staking`, `pooled-staking` → `pooled_staking`).

Our `YieldType` union and the exhaustive `switch` statements over it still expected the old hyphenated form, so `assertNever` threw on the new values and crashed the entire Earn/Yields page with the "Oops, something went wrong" error.

This updates the canonical `YieldType` values and every consumer to the `snake_case` format the API now returns:
- `YieldType` union (`types.ts`)
- All exhaustive switches + `YIELD_TYPES` array (`utils.ts`)
- `includes` checks and `case` labels in `EarnFooter`, `YieldExplainers`, `YieldSelector`
- Display transforms now strip both `-` and `_` so the type still renders as "Liquid staking" (`EarnFooter`, `YieldAssetDetails`, `YieldsList`)
- Tests updated to the new values

The throwing `assertNever` is intentionally kept so any future unhandled/renamed type fails loudly and is caught early, rather than silently mislabeling staking products as deposits.

> Note: the crash log proved `liquid_staking`; `native_staking`/`pooled_staking` were updated for consistency on the assumption yield.xyz is uniformly snake_case. Worth confirming against the authenticated `/providers` response.

## Issue (if applicable)

closes #12444

Linear: [SS-5702](https://linear.app/shapeshift-dao/issue/SS-5702/earn-page-gives-oops-error)

## Risk

Low risk. No on-chain transaction logic changed — this only corrects the string values used for yield-type classification and display copy. The actual stake/withdraw flows are driven by yield.xyz transaction payloads, not these labels.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

yield.xyz (Earn/Yields) display and label classification only.

## Testing

### Engineering

- `pnpm test:web src/lib/yieldxyz/utils.test.ts src/hooks/useTxDetails/useTxDetails.test.ts`
- Navigate to the Earn page — it should load without the "Oops" error.
- Verify staking yields (e.g. a liquid staking provider) show "Stake/Unstake" terminology and the correct explainers, while vault/lending show "Deposit/Withdraw".

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Functional QA: open the Earn page and confirm it loads, yield type filters render correctly (e.g. "Liquid staking"), and entering/exiting a staking position uses staking terminology.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal yield type identifier formatting for consistency and standardization across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->