### PR TITLE
feat(public-api): production chain parity + p-queue v8 migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -335,7 +335,6 @@
       "@bithighlander/bitcoin-cash-js-lib@^5.2.1": "5.2.1",
       "friendly-challenge@0.9.2": "0.9.2",
       "react-dom@^18.2.0": "18.2.0",
-      "p-queue": "^6.6.2",
       "web3": "4.2.1-dev.a0d6730.0",
       "@shapeshiftoss/bitcoinjs-lib@5.2.0-shapeshift.2": "5.2.0-shapeshift.2",
       "@typescript-eslint/parser": "^8.16.0",

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -291,7 +291,9 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
       const transactions = await Promise.all(
         data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
           if (input.knownTxIds?.has(tx.txid)) return prev
-          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
+          prev.push(
+            requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }),
+          )
           return prev
         }, []),
       )

--- a/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/CosmosSdkBaseAdapter.ts
@@ -278,18 +278,20 @@ export abstract class CosmosSdkBaseAdapter<T extends CosmosSdkChainId> implement
     try {
       const requestQueue = input.requestQueue ?? new PQueue()
 
-      const data = await requestQueue.add(() =>
-        this.providers.http.getTxHistory({
-          pubkey: input.pubkey,
-          pageSize: input.pageSize,
-          cursor: input.cursor,
-        }),
+      const data = await requestQueue.add(
+        () =>
+          this.providers.http.getTxHistory({
+            pubkey: input.pubkey,
+            pageSize: input.pageSize,
+            cursor: input.cursor,
+          }),
+        { throwOnTimeout: true },
       )
 
       const transactions = await Promise.all(
         data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
           if (input.knownTxIds?.has(tx.txid)) return prev
-          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey)))
+          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
           return prev
         }, []),
       )

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -171,7 +171,9 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
       const transactions = await Promise.all(
         data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
           if (input.knownTxIds?.has(tx.txid)) return prev
-          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
+          prev.push(
+            requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }),
+          )
           return prev
         }, []),
       )

--- a/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
+++ b/packages/chain-adapters/src/cosmossdk/thorchain/ThorchainChainAdapter.ts
@@ -158,18 +158,20 @@ export class ChainAdapter extends CosmosSdkBaseAdapter<KnownChainIds.ThorchainMa
     try {
       const requestQueue = input.requestQueue ?? new PQueue()
 
-      const data = await requestQueue.add(() =>
-        this.httpV1.getTxHistory({
-          pubkey: input.pubkey,
-          pageSize: input.pageSize,
-          cursor: input.cursor,
-        }),
+      const data = await requestQueue.add(
+        () =>
+          this.httpV1.getTxHistory({
+            pubkey: input.pubkey,
+            pageSize: input.pageSize,
+            cursor: input.cursor,
+          }),
+        { throwOnTimeout: true },
       )
 
       const transactions = await Promise.all(
         data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
           if (input.knownTxIds?.has(tx.txid)) return prev
-          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey)))
+          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
           return prev
         }, []),
       )

--- a/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
+++ b/packages/chain-adapters/src/evm/EvmBaseAdapter.ts
@@ -673,18 +673,20 @@ export abstract class EvmBaseAdapter<T extends EvmChainId> implements IChainAdap
   async getTxHistory(input: TxHistoryInput): Promise<TxHistoryResponse> {
     const requestQueue = input.requestQueue ?? new PQueue()
 
-    const data = await requestQueue.add(() =>
-      this.providers.http.getTxHistory({
-        pubkey: input.pubkey,
-        pageSize: input.pageSize,
-        cursor: input.cursor,
-      }),
+    const data = await requestQueue.add(
+      () =>
+        this.providers.http.getTxHistory({
+          pubkey: input.pubkey,
+          pageSize: input.pageSize,
+          cursor: input.cursor,
+        }),
+      { throwOnTimeout: true },
     )
 
     const transactions = await Promise.all(
       data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
         if (input.knownTxIds?.has(tx.txid)) return prev
-        prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey)))
+        prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
         return prev
       }, []),
     )

--- a/packages/chain-adapters/src/evm/SecondClassEvmAdapter.ts
+++ b/packages/chain-adapters/src/evm/SecondClassEvmAdapter.ts
@@ -135,8 +135,9 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
 
   async getTransactionStatus(txHash: string): Promise<TxStatus> {
     try {
-      const receipt = await this.requestQueue.add(() =>
-        this.viemClient.getTransactionReceipt({ hash: txHash as Hex }),
+      const receipt = await this.requestQueue.add(
+        () => this.viemClient.getTransactionReceipt({ hash: txHash as Hex }),
+        { throwOnTimeout: true },
       )
 
       switch (receipt.status) {
@@ -157,9 +158,12 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
   async getAccount(pubkey: string): Promise<Account<T>> {
     try {
       const [balance, nonce] = await Promise.all([
-        this.requestQueue.add(() => this.viemClient.getBalance({ address: getAddress(pubkey) })),
-        this.requestQueue.add(() =>
-          this.viemClient.getTransactionCount({ address: getAddress(pubkey) }),
+        this.requestQueue.add(() => this.viemClient.getBalance({ address: getAddress(pubkey) }), {
+          throwOnTimeout: true,
+        }),
+        this.requestQueue.add(
+          () => this.viemClient.getTransactionCount({ address: getAddress(pubkey) }),
+          { throwOnTimeout: true },
         ),
       ])
 
@@ -241,17 +245,19 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
     const multicallAddress = this.viemClient.chain?.contracts?.multicall3?.address
     if (!multicallAddress) throw new Error(`No multicall address on chain: ${this.chainId}`)
 
-    const results = await this.requestQueue.add(() =>
-      this.viemClient.multicall({
-        contracts: tokens.map(token => ({
-          address: getAddress(token.contractAddress),
-          abi: erc20Abi,
-          functionName: 'balanceOf' as const,
-          args: [getAddress(pubkey)],
-        })),
-        allowFailure: true,
-        multicallAddress,
-      }),
+    const results = await this.requestQueue.add(
+      () =>
+        this.viemClient.multicall({
+          contracts: tokens.map(token => ({
+            address: getAddress(token.contractAddress),
+            abi: erc20Abi,
+            functionName: 'balanceOf' as const,
+            args: [getAddress(pubkey)],
+          })),
+          allowFailure: true,
+          multicallAddress,
+        }),
+      { throwOnTimeout: true },
     )
 
     return tokens
@@ -286,13 +292,15 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
     const results = await Promise.all(
       tokens.map(async token => {
         try {
-          const balance = await this.requestQueue.add(() =>
-            this.viemClient.readContract({
-              address: getAddress(token.contractAddress),
-              abi: erc20Abi,
-              functionName: 'balanceOf',
-              args: [getAddress(pubkey)],
-            }),
+          const balance = await this.requestQueue.add(
+            () =>
+              this.viemClient.readContract({
+                address: getAddress(token.contractAddress),
+                abi: erc20Abi,
+                functionName: 'balanceOf',
+                args: [getAddress(pubkey)],
+              }),
+            { throwOnTimeout: true },
           )
 
           return {
@@ -319,13 +327,15 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
     try {
       const estimateGasBody = this.buildEstimateGasBody(input)
 
-      const gasLimit = await this.requestQueue.add(() =>
-        this.viemClient.estimateGas({
-          account: getAddress(estimateGasBody.from),
-          to: getAddress(estimateGasBody.to),
-          value: parseUnits(estimateGasBody.value, 0),
-          data: isHex(estimateGasBody.data) ? estimateGasBody.data : toHex(estimateGasBody.data),
-        }),
+      const gasLimit = await this.requestQueue.add(
+        () =>
+          this.viemClient.estimateGas({
+            account: getAddress(estimateGasBody.from),
+            to: getAddress(estimateGasBody.to),
+            value: parseUnits(estimateGasBody.value, 0),
+            data: isHex(estimateGasBody.data) ? estimateGasBody.data : toHex(estimateGasBody.data),
+          }),
+        { throwOnTimeout: true },
       )
 
       const { fast, average, slow } = await this.getGasFeeData()
@@ -368,8 +378,9 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
         receiverAddress !== CONTRACT_INTERACTION && assertAddressNotSanctioned(receiverAddress),
       ])
 
-      const hash = await this.requestQueue.add(() =>
-        this.viemClient.sendRawTransaction({ serializedTransaction: hex as Hex }),
+      const hash = await this.requestQueue.add(
+        () => this.viemClient.sendRawTransaction({ serializedTransaction: hex as Hex }),
+        { throwOnTimeout: true },
       )
       return hash
     } catch (err) {
@@ -415,11 +426,13 @@ export abstract class SecondClassEvmAdapter<T extends EvmChainId> extends EvmBas
     }
 
     try {
-      const trace = await this.requestQueue.add(() =>
-        this.viemClient.request({
-          method: 'debug_traceTransaction' as any,
-          params: [txHash, { tracer: 'callTracer' }] as any,
-        }),
+      const trace = await this.requestQueue.add(
+        () =>
+          this.viemClient.request({
+            method: 'debug_traceTransaction' as any,
+            params: [txHash, { tracer: 'callTracer' }] as any,
+          }),
+        { throwOnTimeout: true },
       )
 
       const internalTxs: { from: string; to: string; value: string }[] = []

--- a/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
+++ b/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
@@ -271,7 +271,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.SolanaMainnet> 
       const transactions = await Promise.all(
         data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
           if (input.knownTxIds?.has(tx.txid)) return prev
-          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
+          prev.push(
+            requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }),
+          )
           return prev
         }, []),
       )

--- a/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
+++ b/packages/chain-adapters/src/solana/SolanaChainAdapter.ts
@@ -258,18 +258,20 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.SolanaMainnet> 
     try {
       const requestQueue = input.requestQueue ?? new PQueue()
 
-      const data = await requestQueue.add(() =>
-        this.providers.http.getTxHistory({
-          pubkey: input.pubkey,
-          pageSize: input.pageSize,
-          cursor: input.cursor,
-        }),
+      const data = await requestQueue.add(
+        () =>
+          this.providers.http.getTxHistory({
+            pubkey: input.pubkey,
+            pageSize: input.pageSize,
+            cursor: input.cursor,
+          }),
+        { throwOnTimeout: true },
       )
 
       const transactions = await Promise.all(
         data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
           if (input.knownTxIds?.has(tx.txid)) return prev
-          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey)))
+          prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
           return prev
         }, []),
       )

--- a/packages/chain-adapters/src/starknet/StarknetChainAdapter.ts
+++ b/packages/chain-adapters/src/starknet/StarknetChainAdapter.ts
@@ -175,22 +175,24 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.StarknetMainnet
         // Wrap the entire batch in a single queue operation
         // The batchedProvider (with batch: 0) will automatically batch all concurrent callContract calls
         // into a single JSON-RPC request, avoiding RPC spamming
-        const batchResults = await this.requestQueue.add(() =>
-          Promise.all(
-            batch.map(tokenAddress => {
-              const calldata = [normalizedAddress]
-              return this.batchedProvider
-                .callContract({
-                  contractAddress: tokenAddress,
-                  entrypoint: 'balanceOf',
-                  calldata,
-                })
-                .catch(() => {
-                  // Return zero balance if call fails (e.g., account not deployed, token doesn't exist)
-                  return ['0x0', '0x0']
-                })
-            }),
-          ),
+        const batchResults = await this.requestQueue.add(
+          () =>
+            Promise.all(
+              batch.map(tokenAddress => {
+                const calldata = [normalizedAddress]
+                return this.batchedProvider
+                  .callContract({
+                    contractAddress: tokenAddress,
+                    entrypoint: 'balanceOf',
+                    calldata,
+                  })
+                  .catch(() => {
+                    // Return zero balance if call fails (e.g., account not deployed, token doesn't exist)
+                    return ['0x0', '0x0']
+                  })
+              }),
+            ),
+          { throwOnTimeout: true },
         )
         results.push(...batchResults)
       }

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -305,68 +305,71 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
   }
 
   private rpcRequest<T>(method: string, params: Record<string, unknown> = {}): Promise<T> {
-    return this.requestQueue.add(async () => {
-      const maxRetries = 5
-      let lastError: Error | undefined
+    return this.requestQueue.add(
+      async () => {
+        const maxRetries = 5
+        let lastError: Error | undefined
 
-      for (let attempt = 0; attempt < maxRetries; attempt++) {
-        try {
-          const response = await fetch(this.rpcUrl, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              id: 1,
-              jsonrpc: '2.0',
-              method,
-              params,
-            }),
-          })
+        for (let attempt = 0; attempt < maxRetries; attempt++) {
+          try {
+            const response = await fetch(this.rpcUrl, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                id: 1,
+                jsonrpc: '2.0',
+                method,
+                params,
+              }),
+            })
 
-          if (response.status === 429) {
-            const retryAfter = parseInt(response.headers.get('Retry-After') || '2', 10)
-            const backoffDelay = Math.min(retryAfter * 1000, 10000) * Math.pow(1.5, attempt)
-            await new Promise(resolve => setTimeout(resolve, backoffDelay))
-            continue
-          }
+            if (response.status === 429) {
+              const retryAfter = parseInt(response.headers.get('Retry-After') || '2', 10)
+              const backoffDelay = Math.min(retryAfter * 1000, 10000) * Math.pow(1.5, attempt)
+              await new Promise(resolve => setTimeout(resolve, backoffDelay))
+              continue
+            }
 
-          if (response.status === 500 || response.status === 502 || response.status === 503) {
-            lastError = new Error(`TON RPC server error: ${response.status}`)
-            const backoffDelay = 1000 * Math.pow(2, attempt)
-            await new Promise(resolve => setTimeout(resolve, backoffDelay))
-            continue
-          }
-
-          const data = (await response.json()) as TonRpcResponse<T>
-
-          if (!data.ok && data.error) {
-            lastError = new Error(this.formatTonError(data.error))
-            if (this.isRetryableError(data.error)) {
+            if (response.status === 500 || response.status === 502 || response.status === 503) {
+              lastError = new Error(`TON RPC server error: ${response.status}`)
               const backoffDelay = 1000 * Math.pow(2, attempt)
               await new Promise(resolve => setTimeout(resolve, backoffDelay))
               continue
             }
-            throw lastError
-          }
 
-          if (data.result === undefined) {
-            throw new Error('TON RPC returned success but no result data')
-          }
+            const data = (await response.json()) as TonRpcResponse<T>
 
-          return data.result
-        } catch (err) {
-          if (err instanceof Error && err.message.includes('TON RPC')) {
-            throw err
-          }
-          lastError = err instanceof Error ? err : new Error(String(err))
-          if (attempt < maxRetries - 1) {
-            const backoffDelay = 1000 * Math.pow(2, attempt)
-            await new Promise(resolve => setTimeout(resolve, backoffDelay))
+            if (!data.ok && data.error) {
+              lastError = new Error(this.formatTonError(data.error))
+              if (this.isRetryableError(data.error)) {
+                const backoffDelay = 1000 * Math.pow(2, attempt)
+                await new Promise(resolve => setTimeout(resolve, backoffDelay))
+                continue
+              }
+              throw lastError
+            }
+
+            if (data.result === undefined) {
+              throw new Error('TON RPC returned success but no result data')
+            }
+
+            return data.result
+          } catch (err) {
+            if (err instanceof Error && err.message.includes('TON RPC')) {
+              throw err
+            }
+            lastError = err instanceof Error ? err : new Error(String(err))
+            if (attempt < maxRetries - 1) {
+              const backoffDelay = 1000 * Math.pow(2, attempt)
+              await new Promise(resolve => setTimeout(resolve, backoffDelay))
+            }
           }
         }
-      }
 
-      throw lastError || new Error('Max retries exceeded for TON RPC request')
-    }, { throwOnTimeout: true })
+        throw lastError || new Error('Max retries exceeded for TON RPC request')
+      },
+      { throwOnTimeout: true },
+    )
   }
 
   private formatTonError(error: string): string {
@@ -417,36 +420,39 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
   }
 
   private httpApiRequest<T>(endpoint: string): Promise<T> {
-    return this.requestQueue.add(async () => {
-      const maxRetries = 3
-      let lastError: Error | undefined
+    return this.requestQueue.add(
+      async () => {
+        const maxRetries = 3
+        let lastError: Error | undefined
 
-      for (let attempt = 0; attempt < maxRetries; attempt++) {
-        const isV3Endpoint = endpoint.startsWith('/api/v3')
-        const baseUrl = isV3Endpoint
-          ? this.rpcUrl.replace(/\/api\/v2\/jsonRPC$/, '')
-          : this.rpcUrl.replace('/jsonRPC', '')
-        const response = await fetch(`${baseUrl}${endpoint}`, {
-          method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
-        })
+        for (let attempt = 0; attempt < maxRetries; attempt++) {
+          const isV3Endpoint = endpoint.startsWith('/api/v3')
+          const baseUrl = isV3Endpoint
+            ? this.rpcUrl.replace(/\/api\/v2\/jsonRPC$/, '')
+            : this.rpcUrl.replace('/jsonRPC', '')
+          const response = await fetch(`${baseUrl}${endpoint}`, {
+            method: 'GET',
+            headers: { 'Content-Type': 'application/json' },
+          })
 
-        if (response.status === 429) {
-          const retryAfter = parseInt(response.headers.get('Retry-After') || '2', 10)
-          await new Promise(resolve => setTimeout(resolve, retryAfter * 1000))
-          continue
+          if (response.status === 429) {
+            const retryAfter = parseInt(response.headers.get('Retry-After') || '2', 10)
+            await new Promise(resolve => setTimeout(resolve, retryAfter * 1000))
+            continue
+          }
+
+          if (!response.ok) {
+            lastError = new Error(`HTTP API error: ${response.status}`)
+            continue
+          }
+
+          return response.json() as Promise<T>
         }
 
-        if (!response.ok) {
-          lastError = new Error(`HTTP API error: ${response.status}`)
-          continue
-        }
-
-        return response.json() as Promise<T>
-      }
-
-      throw lastError || new Error('Max retries exceeded')
-    }, { throwOnTimeout: true })
+        throw lastError || new Error('Max retries exceeded')
+      },
+      { throwOnTimeout: true },
+    )
   }
 
   getName() {

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -366,7 +366,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       }
 
       throw lastError || new Error('Max retries exceeded for TON RPC request')
-    }) as Promise<T>
+    }, { throwOnTimeout: true })
   }
 
   private formatTonError(error: string): string {
@@ -446,7 +446,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       }
 
       throw lastError || new Error('Max retries exceeded')
-    }) as Promise<T>
+    }, { throwOnTimeout: true })
   }
 
   getName() {
@@ -634,7 +634,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         return response
       }
 
-      const data = requestQueue ? await requestQueue.add(fetchTxHistory) : await fetchTxHistory()
+      const data = requestQueue
+        ? await requestQueue.add(fetchTxHistory, { throwOnTimeout: true })
+        : await fetchTxHistory()
 
       if (!data?.transactions || data.transactions.length === 0) {
         return {
@@ -653,7 +655,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
 
       const bufferedMaxLt = (BigInt(maxLt) + TRACE_LT_SEARCH_RANGE).toString()
       const fetchJettons = () => this.fetchJettonTransfers(pubkey, minLt, bufferedMaxLt)
-      const jettonData = requestQueue ? await requestQueue.add(fetchJettons) : await fetchJettons()
+      const jettonData = requestQueue
+        ? await requestQueue.add(fetchJettons, { throwOnTimeout: true })
+        : await fetchJettons()
 
       const jettonAddrBook = { ...addressBook, ...jettonData.address_book }
 

--- a/packages/chain-adapters/src/tron/TronChainAdapter.ts
+++ b/packages/chain-adapters/src/tron/TronChainAdapter.ts
@@ -210,14 +210,16 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
           callValue: 0,
         }
 
-        const result = await this.requestQueue.add(() =>
-          tronWeb.transactionBuilder.triggerSmartContract(
-            contractAddress,
-            functionSelector,
-            options,
-            parameter,
-            from,
-          ),
+        const result = await this.requestQueue.add(
+          () =>
+            tronWeb.transactionBuilder.triggerSmartContract(
+              contractAddress,
+              functionSelector,
+              options,
+              parameter,
+              from,
+            ),
+          { throwOnTimeout: true },
         )
 
         if (!result.result || !result.result.result) {
@@ -233,12 +235,14 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
           visible: true,
         }
 
-        const response = await this.requestQueue.add(() =>
-          fetch(`${this.rpcUrl}/wallet/createtransaction`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify(requestBody),
-          }),
+        const response = await this.requestQueue.add(
+          () =>
+            fetch(`${this.rpcUrl}/wallet/createtransaction`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(requestBody),
+            }),
+          { throwOnTimeout: true },
         )
 
         const responseData = await response.json()
@@ -252,8 +256,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
 
       // Add memo if provided
       if (memo) {
-        txData = (await this.requestQueue.add(() =>
-          tronWeb.transactionBuilder.addUpdateData(txData as any, memo, 'utf8'),
+        txData = (await this.requestQueue.add(
+          () => tronWeb.transactionBuilder.addUpdateData(txData as any, memo, 'utf8'),
+          { throwOnTimeout: true },
         )) as TronUnsignedTx
       }
 
@@ -315,12 +320,14 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
         visible: true,
       }
 
-      const response = await this.requestQueue.add(() =>
-        fetch(`${this.rpcUrl}/wallet/triggersmartcontract`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(requestBody),
-        }),
+      const response = await this.requestQueue.add(
+        () =>
+          fetch(`${this.rpcUrl}/wallet/triggersmartcontract`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+          }),
+        { throwOnTimeout: true },
       )
 
       const result = await response.json()
@@ -462,7 +469,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
 
       // Get live network prices from chain parameters
       const tronWeb = new TronWeb({ fullHost: this.rpcUrl })
-      const params = await this.requestQueue.add(() => tronWeb.trx.getChainParameters())
+      const params = await this.requestQueue.add(() => tronWeb.trx.getChainParameters(), {
+        throwOnTimeout: true,
+      })
       const bandwidthPrice = params.find(p => p.key === 'getTransactionFee')?.value ?? 1000
       const energyPrice = params.find(p => p.key === 'getEnergyFee')?.value ?? 100
 
@@ -496,14 +505,16 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
         try {
           // Use actual sender if available, otherwise use recipient for estimation
           const estimationFrom = from || to
-          const baseTx = await this.requestQueue.add(() =>
-            tronWeb.transactionBuilder.sendTrx(to, Number(value), estimationFrom),
+          const baseTx = await this.requestQueue.add(
+            () => tronWeb.transactionBuilder.sendTrx(to, Number(value), estimationFrom),
+            { throwOnTimeout: true },
           )
 
           // Add memo if provided to get accurate size
           const finalTx = memo
-            ? await this.requestQueue.add(() =>
-                tronWeb.transactionBuilder.addUpdateData(baseTx, memo, 'utf8'),
+            ? await this.requestQueue.add(
+                () => tronWeb.transactionBuilder.addUpdateData(baseTx, memo, 'utf8'),
+                { throwOnTimeout: true },
               )
             : baseTx
 
@@ -525,15 +536,17 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TronMainnet> {
       // Check if recipient address needs activation (1 TRX cost)
       let accountActivationFee = 0
       try {
-        const recipientInfoResponse = await this.requestQueue.add(() =>
-          fetch(`${this.rpcUrl}/wallet/getaccount`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              address: to,
-              visible: true,
+        const recipientInfoResponse = await this.requestQueue.add(
+          () =>
+            fetch(`${this.rpcUrl}/wallet/getaccount`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                address: to,
+                visible: true,
+              }),
             }),
-          }),
+          { throwOnTimeout: true },
         )
         const recipientInfo = await recipientInfoResponse.json()
         const recipientExists = recipientInfo && Object.keys(recipientInfo).length > 1

--- a/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
+++ b/packages/chain-adapters/src/utxo/UtxoBaseAdapter.ts
@@ -547,21 +547,23 @@ export abstract class UtxoBaseAdapter<T extends UtxoChainId> implements IChainAd
     const requestQueue = input.requestQueue ?? new PQueue()
 
     if (!this.accountAddresses[input.pubkey]) {
-      await requestQueue.add(() => this.getAccount(input.pubkey))
+      await requestQueue.add(() => this.getAccount(input.pubkey), { throwOnTimeout: true })
     }
 
-    const data = await requestQueue.add(() =>
-      this.providers.http.getTxHistory({
-        pubkey: input.pubkey,
-        pageSize: input.pageSize,
-        cursor: input.cursor,
-      }),
+    const data = await requestQueue.add(
+      () =>
+        this.providers.http.getTxHistory({
+          pubkey: input.pubkey,
+          pageSize: input.pageSize,
+          cursor: input.cursor,
+        }),
+      { throwOnTimeout: true },
     )
 
     const transactions = await Promise.all(
       data.txs.reduce<Promise<Transaction>[]>((prev, tx) => {
         if (input.knownTxIds?.has(tx.txid)) return prev
-        prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey)))
+        prev.push(requestQueue.add(() => this.parseTx(tx, input.pubkey), { throwOnTimeout: true }))
         return prev
       }, []),
     )

--- a/packages/hdwallet-ledger-webusb/src/transport.ts
+++ b/packages/hdwallet-ledger-webusb/src/transport.ts
@@ -21,7 +21,7 @@ import {
   openApp,
   Thorchain,
 } from '@shapeshiftoss/hdwallet-ledger'
-import PQueue from 'p-queue/dist'
+import PQueue from 'p-queue'
 
 import { VENDOR_ID } from './adapter'
 

--- a/packages/public-api/.env.example
+++ b/packages/public-api/.env.example
@@ -21,6 +21,9 @@ UNCHAINED_GNOSIS_HTTP_URL=https://dev-api.gnosis.shapeshift.com
 UNCHAINED_DOGECOIN_HTTP_URL=https://dev-api.dogecoin.shapeshift.com
 UNCHAINED_LITECOIN_HTTP_URL=https://dev-api.litecoin.shapeshift.com
 UNCHAINED_BITCOINCASH_HTTP_URL=https://dev-api.bitcoincash.shapeshift.com
+UNCHAINED_ZCASH_HTTP_URL=https://dev-api.zcash.shapeshift.com
+UNCHAINED_SOLANA_HTTP_URL=https://dev-api.solana.shapeshift.com
+UNCHAINED_THORCHAIN_V1_HTTP_URL=https://dev-api.thorchain-v1.shapeshift.com
 
 # First-class EVM node URLs — passed to chain adapter constructors and
 # consumed by @shapeshiftoss/contracts via process.env.VITE_*_NODE_URL.
@@ -33,11 +36,25 @@ VITE_GNOSIS_NODE_URL=https://dev-api.gnosis.shapeshift.com/api/v1/jsonrpc
 VITE_ARBITRUM_NODE_URL=https://dev-api.arbitrum.shapeshift.com/api/v1/jsonrpc
 VITE_BASE_NODE_URL=https://dev-api.base.shapeshift.com/api/v1/jsonrpc
 
+# Second-class EVM node URLs — same VITE_*_NODE_URL contract as first-class.
+VITE_HYPEREVM_NODE_URL=https://rpc.hyperliquid.xyz/evm
+VITE_KATANA_NODE_URL=https://rpc.katana.network
+VITE_MEGAETH_NODE_URL=https://mainnet.megaeth.com/rpc
+VITE_MONAD_NODE_URL=https://rpc.monad.xyz
+VITE_PLASMA_NODE_URL=https://rpc.plasma.to
+
 # Node URLs
 THORCHAIN_NODE_URL=https://dev-api.thorchain.shapeshift.com/lcd
 MAYACHAIN_NODE_URL=https://dev-api.mayachain.shapeshift.com/lcd
 TRON_NODE_URL=https://api.trongrid.io
 SUI_NODE_URL=https://fullnode.mainnet.sui.io
+SOLANA_NODE_URL=https://dev-api.solana.shapeshift.com/api/v1/jsonrpc
+TON_NODE_URL=https://toncenter.com/api/v2/jsonRPC
+STARKNET_NODE_URL=https://rpc.starknet.lava.build
+NEAR_NODE_URL=https://rpc.mainnet.near.org
+NEAR_NODE_URL_FALLBACK_1=https://near.lava.build
+NEAR_NODE_URL_FALLBACK_2=https://rpc.fastnear.com
+FASTNEAR_API_URL=https://api.fastnear.com
 
 # Midgard URLs
 THORCHAIN_MIDGARD_URL=https://dev-api.thorchain.shapeshift.com/midgard/v2

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -58,8 +58,8 @@ const envSchema = z.object({
   TON_NODE_URL: url,
   STARKNET_NODE_URL: url,
   NEAR_NODE_URL: url,
-  NEAR_NODE_URL_FALLBACK_1: z.string().default(''),
-  NEAR_NODE_URL_FALLBACK_2: z.string().default(''),
+  NEAR_NODE_URL_FALLBACK_1: z.union([url, z.literal('')]).default(''),
+  NEAR_NODE_URL_FALLBACK_2: z.union([url, z.literal('')]).default(''),
   FASTNEAR_API_URL: url,
 
   // Midgard URLs

--- a/packages/public-api/src/env.ts
+++ b/packages/public-api/src/env.ts
@@ -27,6 +27,9 @@ const envSchema = z.object({
   UNCHAINED_DOGECOIN_HTTP_URL: url,
   UNCHAINED_LITECOIN_HTTP_URL: url,
   UNCHAINED_BITCOINCASH_HTTP_URL: url,
+  UNCHAINED_ZCASH_HTTP_URL: url,
+  UNCHAINED_SOLANA_HTTP_URL: url,
+  UNCHAINED_THORCHAIN_V1_HTTP_URL: url,
 
   // First-class EVM node URLs — passed to chain adapter constructors and
   // consumed by @shapeshiftoss/contracts via process.env.VITE_*_NODE_URL.
@@ -39,11 +42,25 @@ const envSchema = z.object({
   VITE_POLYGON_NODE_URL: url,
   VITE_BASE_NODE_URL: url,
 
+  // Second-class EVM node URLs — same VITE_*_NODE_URL contract as first-class.
+  VITE_HYPEREVM_NODE_URL: url,
+  VITE_KATANA_NODE_URL: url,
+  VITE_MEGAETH_NODE_URL: url,
+  VITE_MONAD_NODE_URL: url,
+  VITE_PLASMA_NODE_URL: url,
+
   // Node URLs
   THORCHAIN_NODE_URL: url,
   MAYACHAIN_NODE_URL: url,
   TRON_NODE_URL: url,
   SUI_NODE_URL: url,
+  SOLANA_NODE_URL: url,
+  TON_NODE_URL: url,
+  STARKNET_NODE_URL: url,
+  NEAR_NODE_URL: url,
+  NEAR_NODE_URL_FALLBACK_1: z.string().default(''),
+  NEAR_NODE_URL_FALLBACK_2: z.string().default(''),
+  FASTNEAR_API_URL: url,
 
   // Midgard URLs
   THORCHAIN_MIDGARD_URL: url,

--- a/packages/public-api/src/integration.test.ts
+++ b/packages/public-api/src/integration.test.ts
@@ -368,27 +368,23 @@ describe('/v1/swap/rates', () => {
 })
 
 describe('/v1/swap/quote', () => {
-  it(
-    'does not require authentication',
-    { retry: 2 },
-    async () => {
-      const res = await fetch(`${API_URL}/v1/swap/quote`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          sellAssetId: ASSET_IDS.ETH,
-          buyAssetId: ASSET_IDS.USDC_ETH,
-          sellAmountCryptoBaseUnit: '100000000000000000',
-          sendAddress: ADDRESS.evm,
-          receiveAddress: ADDRESS.evm,
-          swapperName: '0x',
-        }),
-      })
-      expect(res.status).not.toBe(401)
-      const data = (await res.json()) as QuoteResponse
-      expect(data).toMatchObject({ quoteId: expect.any(String), swapperName: expect.any(String) })
-    },
-  )
+  it('does not require authentication', { retry: 2 }, async () => {
+    const res = await fetch(`${API_URL}/v1/swap/quote`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        sellAssetId: ASSET_IDS.ETH,
+        buyAssetId: ASSET_IDS.USDC_ETH,
+        sellAmountCryptoBaseUnit: '100000000000000000',
+        sendAddress: ADDRESS.evm,
+        receiveAddress: ADDRESS.evm,
+        swapperName: '0x',
+      }),
+    })
+    expect(res.status).not.toBe(401)
+    const data = (await res.json()) as QuoteResponse
+    expect(data).toMatchObject({ quoteId: expect.any(String), swapperName: expect.any(String) })
+  })
 
   it.each(QUOTES)(
     'returns a quote $label via $swapperName',

--- a/packages/public-api/src/integration.test.ts
+++ b/packages/public-api/src/integration.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest'
 import type { Asset, AssetsListResponse } from './routes/assets/types'
 import type { ChainsListResponse } from './routes/chains/types'
 import type { QuoteResponse } from './routes/quote/types'
+import { QuoteResponseSchema } from './routes/quote/types'
 import type { RateResponse } from './routes/rates/types'
+import { RateResponseSchema } from './routes/rates/types'
 
 const API_URL = process.env.API_URL ?? `http://localhost:${process.env.PORT ?? '3001'}`
 
@@ -13,7 +15,220 @@ const ASSET_IDS = {
   ETH: 'eip155:1/slip44:60',
   USDC_ETH: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
   BTC: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+  HYPEREVM: 'eip155:999/slip44:60',
+  KATANA: 'eip155:747474/slip44:60',
+  MEGAETH: 'eip155:4326/slip44:60',
+  MONAD: 'eip155:143/slip44:60',
+  PLASMA: 'eip155:9745/slip44:60',
+  ZEC: 'bip122:00040fe8ec8471911baa1db1266ea15d/slip44:133',
+  ATOM: 'cosmos:cosmoshub-4/slip44:118',
+  RUNE: 'cosmos:thorchain-1/slip44:931',
+  CACAO: 'cosmos:mayachain-mainnet-v1/slip44:931',
+  SOL: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501',
+  TRX: 'tron:0x2b6653dc/slip44:195',
+  SUI: 'sui:35834a8a/slip44:784',
+  TON: 'ton:mainnet/slip44:607',
+  NEAR: 'near:mainnet/slip44:397',
+  STRK: 'starknet:SN_MAIN/slip44:9004',
 } as const
+
+const ADDRESS = {
+  evm: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+  btc: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
+  zec: 't1Tcr8tigNAFvjm7tZ2Hq4bkFmsQzhuhUfd',
+  maya: 'maya1g98cy3n9mmjrpn0sxmn63lztelera37nu75fmz',
+  sol: 'GThUX1Atko4tqhN2NaiTazWSeFWMuiUvfFnyJyUghFMJ',
+  tron: 'TQn9Y2khEsLJW1ChVWFMSMeRDow5KcbLSE',
+  sui: '0x0000000000000000000000000000000000000000000000000000000000000001',
+  ton: 'EQDrjaLahLkMB-hMCmkzOyBuHJ139ZUYmPHu6RRBKnbdLIYI',
+  near: 'kevin.near',
+  starknet: '0x0000000000000000000000000000000000000000000000000000000000000001',
+} as const
+
+const RATES: { label: string; sellAssetId: string; buyAssetId: string; amount: string }[] = [
+  {
+    label: 'HyperEVM Chain',
+    sellAssetId: ASSET_IDS.HYPEREVM,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000000000000',
+  },
+  {
+    label: 'Katana Chain',
+    sellAssetId: ASSET_IDS.KATANA,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000000000000',
+  },
+  {
+    label: 'MegaETH Chain',
+    sellAssetId: ASSET_IDS.MEGAETH,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000000000000',
+  },
+  {
+    label: 'Monad Chain',
+    sellAssetId: ASSET_IDS.MONAD,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000000000000',
+  },
+  {
+    label: 'Plasma Chain',
+    sellAssetId: ASSET_IDS.PLASMA,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000000000000',
+  },
+  {
+    label: 'Zcash Chain',
+    sellAssetId: ASSET_IDS.ZEC,
+    buyAssetId: ASSET_IDS.BTC,
+    amount: '100000000',
+  },
+  {
+    label: 'Cosmos Chain',
+    sellAssetId: ASSET_IDS.ATOM,
+    buyAssetId: ASSET_IDS.BTC,
+    amount: '10000000',
+  },
+  {
+    label: 'THORChain Chain',
+    sellAssetId: ASSET_IDS.RUNE,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000',
+  },
+  {
+    label: 'Mayachain Chain',
+    sellAssetId: ASSET_IDS.CACAO,
+    buyAssetId: ASSET_IDS.BTC,
+    amount: '1000000000000',
+  },
+  {
+    label: 'Solana Chain',
+    sellAssetId: ASSET_IDS.SOL,
+    buyAssetId: ASSET_IDS.BTC,
+    amount: '1000000000',
+  },
+  {
+    label: 'Tron Chain',
+    sellAssetId: ASSET_IDS.TRX,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '1000000000',
+  },
+  {
+    label: 'Sui Chain',
+    sellAssetId: ASSET_IDS.SUI,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '5000000000',
+  },
+  {
+    label: 'TON Chain',
+    sellAssetId: ASSET_IDS.TON,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '5000000000',
+  },
+  {
+    label: 'NEAR Chain',
+    sellAssetId: ASSET_IDS.NEAR,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '5000000000000000000000000',
+  },
+  {
+    label: 'Starknet Chain',
+    sellAssetId: ASSET_IDS.STRK,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    amount: '50000000000000000000',
+  },
+]
+
+const QUOTES: {
+  label: string
+  sellAssetId: string
+  buyAssetId: string
+  swapperName: string
+  sendAddress: string
+  receiveAddress: string
+  amount: string
+}[] = [
+  {
+    label: 'Second-Class EVM Adapter (HyperEVM)',
+    sellAssetId: ASSET_IDS.HYPEREVM,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    swapperName: 'Relay',
+    sendAddress: ADDRESS.evm,
+    receiveAddress: ADDRESS.evm,
+    amount: '1000000000000000000',
+  },
+  {
+    label: 'UTXO Adapter (Zcash)',
+    sellAssetId: ASSET_IDS.ZEC,
+    buyAssetId: ASSET_IDS.BTC,
+    swapperName: 'MAYAChain',
+    sendAddress: ADDRESS.zec,
+    receiveAddress: ADDRESS.btc,
+    amount: '100000000',
+  },
+  {
+    label: 'CosmosSDK Adapter (Mayachain)',
+    sellAssetId: ASSET_IDS.CACAO,
+    buyAssetId: ASSET_IDS.BTC,
+    swapperName: 'MAYAChain',
+    sendAddress: ADDRESS.maya,
+    receiveAddress: ADDRESS.btc,
+    amount: '1000000000000',
+  },
+  {
+    label: 'Solana Adapter',
+    sellAssetId: ASSET_IDS.SOL,
+    buyAssetId: ASSET_IDS.BTC,
+    swapperName: 'Chainflip',
+    sendAddress: ADDRESS.sol,
+    receiveAddress: ADDRESS.btc,
+    amount: '1000000000',
+  },
+  {
+    label: 'Tron Adapter',
+    sellAssetId: ASSET_IDS.TRX,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    swapperName: 'NEAR Intents',
+    sendAddress: ADDRESS.tron,
+    receiveAddress: ADDRESS.evm,
+    amount: '1000000000',
+  },
+  {
+    label: 'Sui Adapter',
+    sellAssetId: ASSET_IDS.SUI,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    swapperName: 'NEAR Intents',
+    sendAddress: ADDRESS.sui,
+    receiveAddress: ADDRESS.evm,
+    amount: '5000000000',
+  },
+  {
+    label: 'TON Adapter',
+    sellAssetId: ASSET_IDS.TON,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    swapperName: 'NEAR Intents',
+    sendAddress: ADDRESS.ton,
+    receiveAddress: ADDRESS.evm,
+    amount: '5000000000',
+  },
+  {
+    label: 'NEAR Adapter',
+    sellAssetId: ASSET_IDS.NEAR,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    swapperName: 'NEAR Intents',
+    sendAddress: ADDRESS.near,
+    receiveAddress: ADDRESS.evm,
+    amount: '5000000000000000000000000',
+  },
+  {
+    label: 'Starknet Adapter',
+    sellAssetId: ASSET_IDS.STRK,
+    buyAssetId: ASSET_IDS.USDC_ETH,
+    swapperName: 'NEAR Intents',
+    sendAddress: ADDRESS.starknet,
+    receiveAddress: ADDRESS.evm,
+    amount: '50000000000000000000',
+  },
+]
 
 const TEST_PAIRS = {
   evmSameChain: {
@@ -67,7 +282,7 @@ describe('/v1/assets', () => {
 })
 
 describe('/v1/swap/rates', () => {
-  it('does not require authentication', async () => {
+  it('does not require authentication', { retry: 2 }, async () => {
     const params = new URLSearchParams({
       sellAssetId: ASSET_IDS.ETH,
       buyAssetId: ASSET_IDS.USDC_ETH,
@@ -129,23 +344,73 @@ describe('/v1/swap/rates', () => {
     expect(typeof first.affiliateBps).toBe('string')
     expect(Number(first.affiliateBps)).toBeGreaterThan(0)
   })
+
+  it.each(RATES)(
+    'returns a rate for $label',
+    { timeout: 30_000, retry: 2 },
+    async ({ sellAssetId, buyAssetId, amount }) => {
+      const params = new URLSearchParams({
+        sellAssetId,
+        buyAssetId,
+        sellAmountCryptoBaseUnit: amount,
+      })
+      const res = await fetch(`${API_URL}/v1/swap/rates?${params}`)
+      expect(res.ok).toBe(true)
+      const data = (await res.json()) as RateResponse
+      const parsed = RateResponseSchema.safeParse(data)
+      expect(parsed.success ? [] : parsed.error.issues).toEqual([])
+      const validRates = data.rates.filter(
+        r => !r.error && r.buyAmountCryptoBaseUnit && r.buyAmountCryptoBaseUnit !== '0',
+      )
+      expect(validRates.length).toBeGreaterThan(0)
+    },
+  )
 })
 
 describe('/v1/swap/quote', () => {
-  it('does not require authentication', async () => {
-    const res = await fetch(`${API_URL}/v1/swap/quote`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        sellAssetId: ASSET_IDS.ETH,
-        buyAssetId: ASSET_IDS.USDC_ETH,
-        sellAmountCryptoBaseUnit: '100000000000000000',
-        receiveAddress: '0x0000000000000000000000000000000000000000',
-        swapperName: '0x',
-      }),
-    })
-    expect(res.status).not.toBe(401)
-    const data = (await res.json()) as QuoteResponse
-    expect(data).toMatchObject({ quoteId: expect.any(String), swapperName: expect.any(String) })
-  })
+  it(
+    'does not require authentication',
+    { retry: 2 },
+    async () => {
+      const res = await fetch(`${API_URL}/v1/swap/quote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sellAssetId: ASSET_IDS.ETH,
+          buyAssetId: ASSET_IDS.USDC_ETH,
+          sellAmountCryptoBaseUnit: '100000000000000000',
+          sendAddress: ADDRESS.evm,
+          receiveAddress: ADDRESS.evm,
+          swapperName: '0x',
+        }),
+      })
+      expect(res.status).not.toBe(401)
+      const data = (await res.json()) as QuoteResponse
+      expect(data).toMatchObject({ quoteId: expect.any(String), swapperName: expect.any(String) })
+    },
+  )
+
+  it.each(QUOTES)(
+    'returns a quote $label via $swapperName',
+    { timeout: 30_000, retry: 2 },
+    async ({ sellAssetId, buyAssetId, swapperName, sendAddress, receiveAddress, amount }) => {
+      const res = await fetch(`${API_URL}/v1/swap/quote`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          sellAssetId,
+          buyAssetId,
+          sellAmountCryptoBaseUnit: amount,
+          sendAddress,
+          receiveAddress,
+          swapperName,
+        }),
+      })
+      const data = (await res.json()) as QuoteResponse & { error?: unknown }
+      expect(res.ok).toBe(true)
+      expect(data.quoteId).toEqual(expect.any(String))
+      const parsed = QuoteResponseSchema.safeParse(data)
+      expect(parsed.success ? [] : parsed.error.issues).toEqual([])
+    },
+  )
 })

--- a/packages/public-api/src/swapperDeps.ts
+++ b/packages/public-api/src/swapperDeps.ts
@@ -1,6 +1,8 @@
 import type { ChainId } from '@shapeshiftoss/caip'
+import { fromAssetId } from '@shapeshiftoss/caip'
 import * as adapters from '@shapeshiftoss/chain-adapters'
 import type { SwapperDeps } from '@shapeshiftoss/swapper'
+import type { Asset } from '@shapeshiftoss/types'
 import { KnownChainIds } from '@shapeshiftoss/types'
 import * as unchained from '@shapeshiftoss/unchained-client'
 
@@ -11,6 +13,34 @@ import { env } from './env'
 // ws is required by chain-adapter constructors but the public-api never
 // subscribes to txs, so the URL is never dialed.
 const wsPlaceholderUrl = 'ws://localhost'
+
+// Second-class EVM and Starknet adapters resolve their token list lazily from the
+// loaded asset data, mirroring the main web app's per-chain getKnownTokens closures.
+const makeGetKnownTokens =
+  (chainId: ChainId, assetNamespace: string, normalizeAddress?: (reference: string) => string) =>
+  () =>
+    Object.values(getAssetsById())
+      .filter((asset): asset is Asset => {
+        if (!asset) return false
+        const { chainId: assetChainId, assetNamespace: namespace } = fromAssetId(asset.assetId)
+        return assetChainId === chainId && namespace === assetNamespace
+      })
+      .map(asset => {
+        const { assetReference } = fromAssetId(asset.assetId)
+        return {
+          assetId: asset.assetId,
+          contractAddress: normalizeAddress ? normalizeAddress(assetReference) : assetReference,
+          symbol: asset.symbol,
+          name: asset.name,
+          precision: asset.precision,
+        }
+      })
+
+// Starknet contract addresses are stored unpadded; the adapter matches on 64-char hex.
+const normalizeStarknetAddress = (reference: string) =>
+  reference.startsWith('0x')
+    ? `0x${reference.slice(2).padStart(64, '0')}`
+    : `0x${reference.padStart(64, '0')}`
 
 const evmAdapters: Record<ChainId, adapters.EvmChainAdapter> = {
   [KnownChainIds.EthereumMainnet]: new adapters.ethereum.ChainAdapter({
@@ -92,6 +122,27 @@ const evmAdapters: Record<ChainId, adapters.EvmChainAdapter> = {
     },
     rpcUrl: env.VITE_BASE_NODE_URL,
   }),
+  // Second-class EVM chains — rpcUrl + lazily-resolved known tokens, no unchained http/ws.
+  [KnownChainIds.HyperEvmMainnet]: new adapters.hyperevm.ChainAdapter({
+    rpcUrl: env.VITE_HYPEREVM_NODE_URL,
+    getKnownTokens: makeGetKnownTokens(KnownChainIds.HyperEvmMainnet, 'erc20'),
+  }),
+  [KnownChainIds.KatanaMainnet]: new adapters.katana.ChainAdapter({
+    rpcUrl: env.VITE_KATANA_NODE_URL,
+    getKnownTokens: makeGetKnownTokens(KnownChainIds.KatanaMainnet, 'erc20'),
+  }),
+  [KnownChainIds.MegaEthMainnet]: new adapters.megaeth.ChainAdapter({
+    rpcUrl: env.VITE_MEGAETH_NODE_URL,
+    getKnownTokens: makeGetKnownTokens(KnownChainIds.MegaEthMainnet, 'erc20'),
+  }),
+  [KnownChainIds.MonadMainnet]: new adapters.monad.ChainAdapter({
+    rpcUrl: env.VITE_MONAD_NODE_URL,
+    getKnownTokens: makeGetKnownTokens(KnownChainIds.MonadMainnet, 'erc20'),
+  }),
+  [KnownChainIds.PlasmaMainnet]: new adapters.plasma.ChainAdapter({
+    rpcUrl: env.VITE_PLASMA_NODE_URL,
+    getKnownTokens: makeGetKnownTokens(KnownChainIds.PlasmaMainnet, 'erc20'),
+  }),
 }
 
 const utxoAdapters: Record<ChainId, adapters.UtxoChainAdapter> = {
@@ -136,10 +187,98 @@ const utxoAdapters: Record<ChainId, adapters.UtxoChainAdapter> = {
     coinName: 'BitcoinCash',
     thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
   }),
+  [KnownChainIds.ZcashMainnet]: new adapters.zcash.ChainAdapter({
+    providers: {
+      http: new unchained.zcash.V1Api(
+        new unchained.zcash.Configuration({ basePath: env.UNCHAINED_ZCASH_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.utxo.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Zcash',
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+    mayaMidgardUrl: env.MAYACHAIN_MIDGARD_URL,
+  }),
 }
 
-const notImplemented = (type: string) => () => {
-  throw new Error(`Chain adapter ${type} not implemented in public API`)
+const cosmosSdkAdapters: Record<ChainId, adapters.CosmosSdkChainAdapter> = {
+  [KnownChainIds.CosmosMainnet]: new adapters.cosmos.ChainAdapter({
+    providers: {
+      http: new unchained.cosmos.V1Api(
+        new unchained.cosmos.Configuration({ basePath: env.UNCHAINED_COSMOS_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.cosmossdk.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Cosmos',
+    midgardUrl: env.THORCHAIN_MIDGARD_URL,
+  }),
+  [KnownChainIds.ThorchainMainnet]: new adapters.thorchain.ChainAdapter({
+    providers: {
+      http: new unchained.thorchain.V1Api(
+        new unchained.thorchain.Configuration({ basePath: env.UNCHAINED_THORCHAIN_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.cosmossdk.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Thorchain',
+    thorMidgardUrl: env.THORCHAIN_MIDGARD_URL,
+    mayaMidgardUrl: env.MAYACHAIN_MIDGARD_URL,
+    httpV1: new unchained.thorchainV1.V1Api(
+      new unchained.thorchainV1.Configuration({ basePath: env.UNCHAINED_THORCHAIN_V1_HTTP_URL }),
+    ),
+  }),
+  [KnownChainIds.MayachainMainnet]: new adapters.mayachain.ChainAdapter({
+    providers: {
+      http: new unchained.mayachain.V1Api(
+        new unchained.mayachain.Configuration({ basePath: env.UNCHAINED_MAYACHAIN_HTTP_URL }),
+      ),
+      ws: new unchained.ws.Client<unchained.cosmossdk.Tx>(wsPlaceholderUrl),
+    },
+    coinName: 'Mayachain',
+    midgardUrl: env.MAYACHAIN_MIDGARD_URL,
+  }),
+}
+
+const solanaAdapter = new adapters.solana.ChainAdapter({
+  providers: {
+    http: new unchained.solana.V1Api(
+      new unchained.solana.Configuration({ basePath: env.UNCHAINED_SOLANA_HTTP_URL }),
+    ),
+    ws: new unchained.ws.Client<unchained.solana.Tx>(wsPlaceholderUrl),
+  },
+  rpcUrl: env.SOLANA_NODE_URL,
+})
+
+const tronAdapter = new adapters.tron.ChainAdapter({
+  providers: { http: new unchained.tron.TronApi({ rpcUrl: env.TRON_NODE_URL }) },
+  rpcUrl: env.TRON_NODE_URL,
+})
+
+const suiAdapter = new adapters.sui.ChainAdapter({ rpcUrl: env.SUI_NODE_URL })
+
+const tonAdapter = new adapters.ton.ChainAdapter({ rpcUrl: env.TON_NODE_URL })
+
+const nearAdapter = new adapters.near.ChainAdapter({
+  rpcUrls: [env.NEAR_NODE_URL, env.NEAR_NODE_URL_FALLBACK_1, env.NEAR_NODE_URL_FALLBACK_2].filter(
+    Boolean,
+  ),
+  fastNearApiUrl: env.FASTNEAR_API_URL,
+})
+
+const starknetAdapter = new adapters.starknet.ChainAdapter({
+  rpcUrl: env.STARKNET_NODE_URL,
+  getKnownTokens: makeGetKnownTokens(
+    KnownChainIds.StarknetMainnet,
+    'token',
+    normalizeStarknetAddress,
+  ),
+})
+
+const otherAdaptersById: Record<ChainId, unknown> = {
+  [KnownChainIds.SolanaMainnet]: solanaAdapter,
+  [KnownChainIds.TronMainnet]: tronAdapter,
+  [KnownChainIds.SuiMainnet]: suiAdapter,
+  [KnownChainIds.TonMainnet]: tonAdapter,
+  [KnownChainIds.NearMainnet]: nearAdapter,
+  [KnownChainIds.StarknetMainnet]: starknetAdapter,
 }
 
 export const getSwapperDeps = (): SwapperDeps => ({
@@ -147,9 +286,13 @@ export const getSwapperDeps = (): SwapperDeps => ({
   config: getServerConfig(),
   mixPanel: undefined,
   assertGetChainAdapter: (chainId: ChainId) => {
-    const adapter = evmAdapters[chainId] ?? utxoAdapters[chainId]
+    const adapter =
+      evmAdapters[chainId] ??
+      utxoAdapters[chainId] ??
+      cosmosSdkAdapters[chainId] ??
+      otherAdaptersById[chainId]
     if (!adapter) throw new Error(`No chain adapter registered for ${chainId}`)
-    return adapter as unknown as adapters.ChainAdapter<KnownChainIds>
+    return adapter as adapters.ChainAdapter<KnownChainIds>
   },
   assertGetEvmChainAdapter: (chainId: ChainId) => {
     const adapter = evmAdapters[chainId]
@@ -161,26 +304,16 @@ export const getSwapperDeps = (): SwapperDeps => ({
     if (!adapter) throw new Error(`No UTXO chain adapter registered for ${chainId}`)
     return adapter
   },
-  assertGetCosmosSdkChainAdapter: notImplemented('CosmosSdk') as unknown as (
-    chainId: ChainId,
-  ) => adapters.CosmosSdkChainAdapter,
-  assertGetSolanaChainAdapter: notImplemented('Solana') as unknown as (
-    chainId: ChainId,
-  ) => adapters.solana.ChainAdapter,
-  assertGetTronChainAdapter: notImplemented('Tron') as unknown as (
-    chainId: ChainId,
-  ) => adapters.tron.ChainAdapter,
-  assertGetSuiChainAdapter: notImplemented('Sui') as unknown as (
-    chainId: ChainId,
-  ) => adapters.sui.ChainAdapter,
-  assertGetNearChainAdapter: notImplemented('Near') as unknown as (
-    chainId: ChainId,
-  ) => adapters.near.ChainAdapter,
-  assertGetStarknetChainAdapter: notImplemented('Starknet') as unknown as (
-    chainId: ChainId,
-  ) => adapters.starknet.ChainAdapter,
-  assertGetTonChainAdapter: notImplemented('Ton') as unknown as (
-    chainId: ChainId,
-  ) => adapters.ton.ChainAdapter,
+  assertGetCosmosSdkChainAdapter: (chainId: ChainId) => {
+    const adapter = cosmosSdkAdapters[chainId]
+    if (!adapter) throw new Error(`No CosmosSdk chain adapter registered for ${chainId}`)
+    return adapter
+  },
+  assertGetSolanaChainAdapter: () => solanaAdapter,
+  assertGetTronChainAdapter: () => tronAdapter,
+  assertGetSuiChainAdapter: () => suiAdapter,
+  assertGetNearChainAdapter: () => nearAdapter,
+  assertGetStarknetChainAdapter: () => starknetAdapter,
+  assertGetTonChainAdapter: () => tonAdapter,
   fetchIsSmartContractAddressQuery: () => Promise.resolve(false),
 })

--- a/packages/swap-widget/src/hooks/useBalances.ts
+++ b/packages/swap-widget/src/hooks/useBalances.ts
@@ -199,7 +199,7 @@ export const useEvmBalances = (
           } catch {
             return null
           }
-        })
+        }, { throwOnTimeout: true })
       },
       enabled: !!address,
       staleTime: 60_000,
@@ -231,7 +231,7 @@ export const useEvmBalances = (
           } catch {
             return null
           }
-        })
+        }, { throwOnTimeout: true })
       },
       enabled: !!address,
       staleTime: 60_000,

--- a/packages/swap-widget/src/hooks/useBalances.ts
+++ b/packages/swap-widget/src/hooks/useBalances.ts
@@ -184,22 +184,25 @@ export const useEvmBalances = (
       queryKey: ['nativeBalance', address, asset.chainId],
       queryFn: () => {
         if (!address) return Promise.resolve(null)
-        return balanceQueue.add(async () => {
-          try {
-            const result = await getBalance(config, {
-              address: address as `0x${string}`,
-              // @ts-ignore - swap-widget supports more chains than main app's wagmi type registration
-              chainId: asset.chainId,
-            })
-            return {
-              assetId: asset.assetId,
-              balance: result.value.toString(),
-              precision: asset.precision,
+        return balanceQueue.add(
+          async () => {
+            try {
+              const result = await getBalance(config, {
+                address: address as `0x${string}`,
+                // @ts-ignore - swap-widget supports more chains than main app's wagmi type registration
+                chainId: asset.chainId,
+              })
+              return {
+                assetId: asset.assetId,
+                balance: result.value.toString(),
+                precision: asset.precision,
+              }
+            } catch {
+              return null
             }
-          } catch {
-            return null
-          }
-        }, { throwOnTimeout: true })
+          },
+          { throwOnTimeout: true },
+        )
       },
       enabled: !!address,
       staleTime: 60_000,
@@ -212,26 +215,29 @@ export const useEvmBalances = (
       queryKey: ['erc20Balance', address, asset.chainId, asset.tokenAddress],
       queryFn: () => {
         if (!address) return Promise.resolve(null)
-        return balanceQueue.add(async () => {
-          try {
-            if (!asset.tokenAddress) return null
-            const result = await readContract(config, {
-              address: asset.tokenAddress,
-              abi: erc20Abi,
-              functionName: 'balanceOf',
-              args: [address as `0x${string}`],
-              // @ts-ignore - swap-widget supports more chains than main app's wagmi type registration
-              chainId: asset.chainId,
-            })
-            return {
-              assetId: asset.assetId,
-              balance: (result as bigint).toString(),
-              precision: asset.precision,
+        return balanceQueue.add(
+          async () => {
+            try {
+              if (!asset.tokenAddress) return null
+              const result = await readContract(config, {
+                address: asset.tokenAddress,
+                abi: erc20Abi,
+                functionName: 'balanceOf',
+                args: [address as `0x${string}`],
+                // @ts-ignore - swap-widget supports more chains than main app's wagmi type registration
+                chainId: asset.chainId,
+              })
+              return {
+                assetId: asset.assetId,
+                balance: (result as bigint).toString(),
+                precision: asset.precision,
+              }
+            } catch {
+              return null
             }
-          } catch {
-            return null
-          }
-        }, { throwOnTimeout: true })
+          },
+          { throwOnTimeout: true },
+        )
       },
       enabled: !!address,
       staleTime: 60_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,6 @@ overrides:
   '@bithighlander/bitcoin-cash-js-lib@^5.2.1': 5.2.1
   friendly-challenge@0.9.2: 0.9.2
   react-dom@^18.2.0: 18.2.0
-  p-queue: ^6.6.2
   web3: 4.2.1-dev.a0d6730.0
   '@shapeshiftoss/bitcoinjs-lib@5.2.0-shapeshift.2': 5.2.0-shapeshift.2
   '@typescript-eslint/parser': ^8.16.0
@@ -421,8 +420,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       p-queue:
-        specifier: ^6.6.2
-        version: 6.6.2
+        specifier: ^8.0.1
+        version: 8.1.1
       p-ratelimit:
         specifier: ^1.0.1
         version: 1.0.1
@@ -906,8 +905,8 @@ importers:
         specifier: ^2.4.0
         version: 2.6.0
       p-queue:
-        specifier: ^6.6.2
-        version: 6.6.2
+        specifier: ^8.0.1
+        version: 8.1.1
       viem:
         specifier: 2.43.5
         version: 2.43.5(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -1450,8 +1449,8 @@ importers:
         specifier: ^1.0.4
         version: 1.0.13
       p-queue:
-        specifier: ^6.6.2
-        version: 6.6.2
+        specifier: ^7.4.1
+        version: 7.4.1
 
   packages/hdwallet-metamask-multichain:
     dependencies:
@@ -2010,8 +2009,8 @@ importers:
         specifier: ^0.3.12
         version: 0.3.12
       p-queue:
-        specifier: ^6.6.2
-        version: 6.6.2
+        specifier: ^8.0.1
+        version: 8.1.1
       react-virtuoso:
         specifier: 4.7.11
         version: 4.7.11(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -13627,10 +13626,6 @@ packages:
     resolution: {integrity: sha512-4Ispi9I9qYGO4lueiLDhe4q4iK5ERK8reLsuzH6BPaXn53EGaua8H66PXIFGrW897hwjXp+pVLrm/DLxN0RF0A==}
     engines: {node: '>=12'}
 
-  p-finally@1.0.0:
-    resolution: {integrity: sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==}
-    engines: {node: '>=4'}
-
   p-lazy@3.1.0:
     resolution: {integrity: sha512-sCJn0Cdahs6G6SX9+DUihVFUhrzDEduzE5xeViVBGtoqy5dBWko7W8T6Kk6TjR2uevRXJO7CShfWrqdH5s3w3g==}
     engines: {node: '>=8'}
@@ -13659,17 +13654,25 @@ packages:
     resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
-  p-queue@6.6.2:
-    resolution: {integrity: sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==}
-    engines: {node: '>=8'}
+  p-queue@7.4.1:
+    resolution: {integrity: sha512-vRpMXmIkYF2/1hLBKisKeVYJZ8S2tZ0zEAmIJgdVKP2nq0nh4qCdf8bgw+ZgKrkh71AOCaqzwbJJk1WtdcF3VA==}
+    engines: {node: '>=12'}
+
+  p-queue@8.1.1:
+    resolution: {integrity: sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ==}
+    engines: {node: '>=18'}
 
   p-ratelimit@1.0.1:
     resolution: {integrity: sha512-tKBGoow6aWRH68K2eQx+qc1gSegjd5VLirZYc1Yms9pPFsYQ9TFI6aMn0vJH2vmvzjNpjlWZOFft4aPUen2w0A==}
     engines: {node: '>=10.23.0'}
 
-  p-timeout@3.2.0:
-    resolution: {integrity: sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==}
-    engines: {node: '>=8'}
+  p-timeout@5.1.0:
+    resolution: {integrity: sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==}
+    engines: {node: '>=12'}
+
+  p-timeout@6.1.4:
+    resolution: {integrity: sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==}
+    engines: {node: '>=14.16'}
 
   p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
@@ -26112,7 +26115,7 @@ snapshots:
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
       mipd: 0.0.7(typescript@5.8.2)
-      p-queue: 6.6.2
+      p-queue: 7.4.1
       webpack: 5.105.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -40881,8 +40884,6 @@ snapshots:
 
   p-debounce@4.0.0: {}
 
-  p-finally@1.0.0: {}
-
   p-lazy@3.1.0: {}
 
   p-limit@2.3.0:
@@ -40909,16 +40910,21 @@ snapshots:
     dependencies:
       aggregate-error: 3.1.0
 
-  p-queue@6.6.2:
+  p-queue@7.4.1:
     dependencies:
-      eventemitter3: 4.0.7
-      p-timeout: 3.2.0
+      eventemitter3: 5.0.4
+      p-timeout: 5.1.0
+
+  p-queue@8.1.1:
+    dependencies:
+      eventemitter3: 5.0.4
+      p-timeout: 6.1.4
 
   p-ratelimit@1.0.1: {}
 
-  p-timeout@3.2.0:
-    dependencies:
-      p-finally: 1.0.0
+  p-timeout@5.1.0: {}
+
+  p-timeout@6.1.4: {}
 
   p-try@2.2.0: {}
 


### PR DESCRIPTION
## Description

Brings the public API to production chain parity and removes a vestigial dependency pin that was blocking it.

**1. `fix(deps)`: migrate p-queue 6.x → 8.x, drop legacy override.** A 2023 pnpm override pinned `p-queue` to the CJS 6.6.2 build for the old webpack/jest toolchain (now Vite + Vitest), silently forcing chain-adapters and swap-widget down to v6 despite both declaring `^8.0.1`. The pin masked both the module format and the v7+ `.add()` API change (`Promise<T | void>`). Removing it surfaced a `new PQueue()` crash in `SecondClassEvmAdapter`'s constructor under esbuild's node-mode interop. Fix: drop the override, migrate all 34 `.add()` call sites to `{ throwOnTimeout: true }` (a runtime no-op since no queue sets a timeout — only restores the `Promise<T>` type), and fix a `p-queue/dist` deep import in hdwallet-ledger-webusb that broke under v7+'s `exports` map.

**2. `feat(public-api)`: wire up production chains and swappers.** Register chain adapters for the full production set: second-class EVM (HyperEVM, Katana, MegaETH, Monad, Plasma), Zcash, Cosmos SDK (Cosmos, Thorchain, Mayachain), and Solana, Tron, Sui, TON, NEAR, Starknet. Second-class EVM + Starknet resolve known tokens lazily from loaded asset data. Adds the matching node/unchained env vars.

**3. `test(public-api)`: rates + quotes sweep.** Table-driven integration coverage over all wired chains — strict rates (≥1 valid rate per chain) and a real executable `quoteId` per adapter class.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Medium. The p-queue change touches shared `chain-adapters`, `swap-widget`, and `hdwallet-ledger-webusb` (used by the web app), but the `.add()` migration is behavior-preserving (no queue configures a `timeout`, so `throwOnTimeout` is a runtime no-op). No on-chain transaction logic is modified. The public-api wiring is additive. Validated with `pnpm type-check` and `pnpm build:web` (both green).

## Testing

### Engineering

- `pnpm type-check` and `pnpm build:web` pass.
- Public API: `cd packages/public-api && pnpm dev` (boot exercises every adapter constructor — the original p-queue crash site), then `pnpm test:integration` against the running server. The sweep confirms all 15 chains return rates and a real `quoteId` per adapter class. Not part of CI (needs a live server). Note: the Cosmos (ATOM) rate case is THORChain-gated and will only pass while THORChain is live.
- Web app / swap-widget: regression-only — verify EVM swaps, balances, and tx history still function (p-queue is used in those paths).

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

## Screenshots (if applicable)

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated queued network requests across chain adapters (EVM, Cosmos SDK, Solana, Thorchain, UTXO, Starknet, TON, Tron) and swap balance fetching to **throw on timeouts** instead of relying on prior queue defaults.
* **New Features**
  * Expanded public-api environment support with new **Unchained HTTP URL** examples/validation and broader node URL configuration, including **second-class EVM** endpoints.
  * Improved swapper dependency wiring by enabling additional chain adapters and deriving known-token lists dynamically.
* **Tests**
  * Expanded swap integration tests with more parameterized **rates** and **quote** scenarios and stronger response assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->