### PR TITLE
fix(swapper): flag cross-account trades for unsupported swappers

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1042,6 +1042,7 @@
       "quoteExpired": "Quote expired, try again.",
       "quoteUnsupportedChain": "Chain not supported",
       "quoteCrossChainNotSupported": "Cross chain not supported",
+      "crossAccountNotSupported": "Cross-account not supported",
       "networkFeeEstimateFailed": "Failed to estimate network fee",
       "assetNotSupportedByWallet": "%{assetSymbol}.%{chainSymbol} not supported by wallet",
       "intermediaryAssetNotSupportedByWallet": "Intermediary asset %{assetSymbol}.%{chainSymbol} not supported by wallet",

--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
@@ -37,6 +37,8 @@ export const getQuoteErrorTranslation = (
         return 'trade.errors.insufficientFundsForProtocolFee'
       case TradeQuoteValidationError.IntermediaryAssetNotNotSupportedByWallet:
         return 'trade.errors.intermediaryAssetNotSupportedByWallet'
+      case TradeQuoteValidationError.CrossAccountNotSupported:
+        return 'trade.errors.crossAccountNotSupported'
       case SwapperTradeQuoteError.SellAmountBelowMinimum:
         return tradeQuoteError.meta
           ? 'trade.errors.amountTooSmall'

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -21,6 +21,7 @@ import { TradeQuoteValidationError, TradeQuoteWarning } from '../types'
 import { isMultiHopTradeQuote, isMultiHopTradeRate } from '@/components/MultiHopTrade/utils'
 import { bn, bnOrZero } from '@/lib/bignumber/bignumber'
 import { assertGetChainAdapter, assertUnreachable, isTruthy } from '@/lib/utils'
+import { isCrossAccountTradeSupported } from '@/state/helpers'
 import type { ReduxState } from '@/state/reducer'
 import {
   selectPortfolioAccountBalances,
@@ -32,10 +33,12 @@ import {
   selectAssets,
   selectFeeAssetById,
   selectPortfolioAccountIdByNumberByChainId,
+  selectPortfolioAccountMetadataByAccountId,
 } from '@/state/slices/selectors'
 import {
   selectFirstHopSellAccountId,
   selectInputSellAmountCryptoPrecision,
+  selectLastHopBuyAccountId,
   selectSecondHopSellAccountId,
 } from '@/state/slices/tradeInputSlice/selectors'
 import { getTotalProtocolFeeByAssetForStep } from '@/state/slices/tradeQuoteSlice/helpers'
@@ -167,6 +170,26 @@ export const validateTradeQuote = (
   // this is the account we're selling from - network fees are paid from the sell account for the current hop
   const firstHopSellAccountId = selectFirstHopSellAccountId(state)
   const secondHopSellAccountId = selectSecondHopSellAccountId(state)
+
+  // A trade is cross-account when the sell and receive accounts belong to different account numbers.
+  // Account number (not accountId) is the correct discriminator: the same account number maps to the
+  // same address across EVM chains, so a normal L1<->L2 bridge (e.g. account 0 -> account 0) is NOT
+  // cross-account, whereas account 0 -> account 1 is. Some swappers (e.g. Arbitrum Bridge) surface a
+  // rate but cannot fulfill a cross-account trade, so we flag it here to block execution while still
+  // surfacing the rate.
+  const buyAccountId = selectLastHopBuyAccountId(state)
+  const sellAccountNumber = firstHopSellAccountId
+    ? selectPortfolioAccountMetadataByAccountId(state, { accountId: firstHopSellAccountId })
+        ?.bip44Params?.accountNumber
+    : undefined
+  const buyAccountNumber = buyAccountId
+    ? selectPortfolioAccountMetadataByAccountId(state, { accountId: buyAccountId })?.bip44Params
+        ?.accountNumber
+    : undefined
+  const isCrossAccountTrade =
+    sellAccountNumber !== undefined &&
+    buyAccountNumber !== undefined &&
+    sellAccountNumber !== buyAccountNumber
 
   const firstHopFeeAssetBalance = selectPortfolioCryptoBalanceByFilter(state, {
     assetId: firstHopSellFeeAsset?.assetId,
@@ -336,6 +359,10 @@ export const validateTradeQuote = (
         },
       feesExceedsSellAmount && { error: TradeQuoteValidationError.SellAmountBelowTradeFee },
       invalidQuoteSellAmount && { error: TradeQuoteValidationError.QuoteSellAmountInvalid },
+      isCrossAccountTrade &&
+        !isCrossAccountTradeSupported(swapperName) && {
+          error: TradeQuoteValidationError.CrossAccountNotSupported,
+        },
 
       ...insufficientBalanceForProtocolFeesErrors,
     ].filter(isTruthy),

--- a/src/state/apis/swapper/types.ts
+++ b/src/state/apis/swapper/types.ts
@@ -30,6 +30,7 @@ export enum TradeQuoteValidationError {
   InsufficientSecondHopFeeAssetBalance = 'InsufficientSecondHopFeeAssetBalance',
   InsufficientFundsForProtocolFee = 'InsufficientFundsForProtocolFee',
   IntermediaryAssetNotNotSupportedByWallet = 'IntermediaryAssetNotNotSupportedByWallet',
+  CrossAccountNotSupported = 'CrossAccountNotSupported',
   QuoteSellAmountInvalid = 'QuoteSellAmountInvalid',
   QueryFailed = 'QueryFailed',
   UnknownError = 'UnknownError',

--- a/src/state/slices/tradeQuoteSlice/constants.ts
+++ b/src/state/slices/tradeQuoteSlice/constants.ts
@@ -56,4 +56,5 @@ export const SWAPPER_USER_ERRORS = [
   TradeQuoteValidationError.InsufficientFirstHopFeeAssetBalance,
   TradeQuoteValidationError.InsufficientSecondHopFeeAssetBalance,
   TradeQuoteValidationError.InsufficientFundsForProtocolFee,
+  TradeQuoteValidationError.CrossAccountNotSupported,
 ]


### PR DESCRIPTION
## Description

Swappers that don't support cross-account trades (e.g. **Arbitrum Bridge**) returned a *rate* but no executable *quote* when the sell and receive accounts differed (account 0 → account 1). This left a selectable best-rate quote that dead-ended at execution — surfacing as `missing swapperName` and then `Unable to execute trade`, and the rate landing under "Unavailable Swappers".

This surfaces the cross-account limitation as a **quote validation error**, so the rate is still shown in **Available Quotes** (best rate, selectable, with its values), but the trade button is **blocked with a clear "Cross-account not supported" message** — mirroring how other user errors (e.g. insufficient funds) already behave.

### How
- New `TradeQuoteValidationError.CrossAccountNotSupported`, emitted from `validateTradeQuote` when the trade is cross-account **and** `isCrossAccountTradeSupported(swapperName)` is false.
- Cross-account is detected by comparing the **sell vs buy account number** (not accountId). Account number is the correct discriminator: the same number maps to the same address across EVM chains, so a normal L1↔L2 bridge (account 0 → account 0) is **not** flagged, while account 0 → account 1 is.
- Added to `SWAPPER_USER_ERRORS` so the route stays in the available list rather than being bucketed as unavailable.
- Mapped to a terse translation (`trade.errors.crossAccountNotSupported`: "Cross-account not supported").

## Issue (if applicable)

closes #

## Risk

Low. No on-chain transaction changes. This only adds a validation error that gates the trade button for an already-unexecutable scenario (cross-account on a swapper that can't do it) — it makes a previously broken path fail gracefully at input rather than at execution.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Swapper quote validation / trade input UI only. Most visible with Arbitrum Bridge (the swapper currently flagged as not supporting cross-account); other swappers that genuinely support cross-account are unaffected.

## Testing

### Engineering

1. Connect a wallet with multiple accounts on an EVM chain.
2. Set up a trade where the swapper would be **Arbitrum Bridge** (e.g. FOX on Arbitrum → FOX on Ethereum) with the **receive account different from the send account** (account 0 → account 1).
3. Confirm the Arbitrum Bridge rate appears in **Available Quotes** (with its rate values, selectable as best rate).
4. Confirm the preview button is **disabled** showing **"Cross-account not supported"** — and you cannot proceed to confirm.
5. Regression: a **same-account** bridge (account 0 → account 0, L1↔L2) is **not** flagged and proceeds normally; other swappers that support cross-account (Thorchain, Relay, etc.) still work for cross-account trades.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not behind a flag. User-facing: in a preview environment, attempt a cross-account (account 0 → account 1) trade routed via Arbitrum Bridge and verify the rate shows but the trade is blocked with "Cross-account not supported".

> Note: only the `en` translation is added in this PR; other locales fall back to English until a follow-up `/translate` pass.

## Screenshots (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The system now detects and prevents trades that span multiple accounts when not supported by the selected swap method, with an appropriate error message to guide users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->