### PR TITLE
fix(chainflip): raise timeout for deposit channel creation

### DIFF
--- a/packages/swapper/src/swappers/ChainflipSwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/utils/helpers.ts
@@ -126,7 +126,8 @@ export const getChainFlipSwap = ({
     swapUrl += `&chunkIntervalBlocks=${chunkIntervalBlocks}`
   }
 
-  return chainflipService.get<ChainflipBaasSwapDepositAddress>(swapUrl)
+  // Opening a deposit channel can spike past the default 10s timeout (notably on Tron).
+  return chainflipService.get<ChainflipBaasSwapDepositAddress>(swapUrl, { timeout: 30_000 })
 }
 
 const fetchChainFlipAssets = async ({


### PR DESCRIPTION
## Description

Chainflip swaps involving Tron intermittently fail at quote time with **"An error occurred getting a quote"**.

Root cause is a timeout, not a logic bug. The `chainflipService` axios instance applies a blanket **10s timeout to every call**. Opening a deposit channel (`/swap`) takes ~5–7s across all chains and intermittently spikes past 10s — most notably with **Tron as the deposit chain**, where I measured channel-opening times up to **~19s**. When `/swap` exceeds 10s, axios aborts it and the quote fails.

Measured live against `chainflip-broker.io`:

| route | time |
|---|---|
| eth.eth → usdc.eth | 4.5–6.2s |
| btc.btc → eth.eth | 5.9–6.6s |
| sol.sol → eth.eth | 5.3–6.7s |
| trx.tron → eth.eth | 6.1s / **19.4s** / **19.7s** |

The `/quotes-native` and `/swap` endpoints themselves work correctly for all Tron directions — only the timeout was clipping the slow channel-opening tail.

### Fix

Give the deposit-channel (`/swap`) call a dedicated **30s** timeout (covers the observed spikes) while leaving the fast quote/status calls on the 10s default. The change is not chain-gated — all chains benefit, since even EVM/SOL/BTC sit close to the old 10s cap.

## Issue (if applicable)

closes #

## Risk

Low. Single-line change to a per-request HTTP timeout for the Chainflip deposit-channel call. No on-chain transaction logic is added or modified. Worst case is a user waiting slightly longer for a quote when the broker is slow, instead of an outright failure.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Chainflip swapper quote flow (deposit channel creation) across all supported chains. No signing/broadcast paths touched.

## Testing

### Engineering

- Initiate a Chainflip swap involving Tron (e.g. `30 TRX → USDT` on Tron, or `ETH → TRX`). Previously this would intermittently fail with "An error occurred getting a quote" when `/swap` exceeded 10s; it should now produce a quote with a deposit address.
- Regression-check non-Tron Chainflip quotes (ETH/BTC/SOL) still quote normally.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Functional test: in a preview environment, request Chainflip quotes for Tron pairs repeatedly (TRX→USDT, ETH→TRX, USDT-on-Tron→ETH). Confirm quotes resolve to a deposit address instead of erroring with "An error occurred getting a quote".

## Screenshots (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap reliability by allowing more time for deposit channel requests to complete, reducing failures caused by timeouts during slower network conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->