### PR TITLE
fix(tron): scope account-activation warning to self-sends

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -2191,7 +2191,7 @@
   },
   "tron": {
     "recipientNotActivated": {
-      "sendWarning": "This address hasn't been activated on Tron yet. Your tokens will arrive, but the recipient won't be able to move them until they also receive some TRX."
+      "sendWarning": "This account hasn't been activated on Tron yet. Your tokens will arrive, but you won't be able to move or swap them out until the account holds some TRX to cover fees."
     }
   },
   "transactionHistory": {

--- a/src/components/Modals/Send/views/SendAmountDetails.tsx
+++ b/src/components/Modals/Send/views/SendAmountDetails.tsx
@@ -21,6 +21,7 @@ import {
   fromAssetId,
   starknetChainId,
   tronAssetId,
+  tronChainId,
 } from '@shapeshiftoss/caip'
 import { useMutation } from '@tanstack/react-query'
 import get from 'lodash/get'
@@ -57,6 +58,7 @@ import { isStarknetChainAdapter } from '@/lib/utils/starknet'
 import {
   selectAssetById,
   selectPortfolioAccountMetadataByAccountId,
+  selectWalletAccountIds,
 } from '@/state/slices/selectors'
 import { useAppSelector } from '@/state/store'
 
@@ -117,6 +119,19 @@ export const SendAmountDetails = () => {
   } = useIsStarknetAccountDeployed(accountId)
 
   const { data: isTronRecipientActivated } = useIsTronAddressActivated(to, asset?.chainId)
+
+  const walletAccountIds = useAppSelector(selectWalletAccountIds)
+  // The activation warning is only actionable when funding your own fresh Tron account - it tells
+  // you that you'll need TRX before you can move/swap the tokens out. Sending to third-party
+  // addresses (incl. exchange/bridge deposit addresses like Chainflip, which sweep funds
+  // regardless of activation) would only produce false alarms, so scope it to self-sends.
+  const isToOwnTronAccount = useMemo(() => {
+    if (!to) return false
+    return walletAccountIds.some(walletAccountId => {
+      const { chainId, account } = fromAccountId(walletAccountId)
+      return chainId === tronChainId && account === to
+    })
+  }, [walletAccountIds, to])
 
   const deployAccountMutation = useMutation({
     mutationFn: async () => {
@@ -408,14 +423,16 @@ export const SendAmountDetails = () => {
               </AlertDescription>
             </Alert>
           )}
-          {isTronRecipientActivated === false && asset?.assetId !== tronAssetId && (
-            <Alert status='warning' borderRadius='lg' mb={3}>
-              <AlertIcon />
-              <AlertDescription>
-                <Text translation='tron.recipientNotActivated.sendWarning' />
-              </AlertDescription>
-            </Alert>
-          )}
+          {isTronRecipientActivated === false &&
+            asset?.assetId !== tronAssetId &&
+            isToOwnTronAccount && (
+              <Alert status='warning' borderRadius='lg' mb={3}>
+                <AlertIcon />
+                <AlertDescription>
+                  <Text translation='tron.recipientNotActivated.sendWarning' />
+                </AlertDescription>
+              </Alert>
+            )}
           {!hasNoAccountForAsset && (
             <Flex alignItems='center' justifyContent='space-between' mb={4}>
               <Flex alignItems='center'>


### PR DESCRIPTION
## Description

The Tron account-activation warning in the Send flow fired on **any** send to an unactivated Tron address. In practice this includes Chainflip deposit channel addresses (and other exchange/bridge deposit addresses), which are freshly generated, unactivated, and sweep funds regardless of activation. The warning was therefore a false alarm in exactly the cases where the destination isn't a human wallet — scary copy that could push users to abandon an otherwise-fine swap.

This PR scopes the warning to **self-sends only** — when the recipient is one of the user's own Tron accounts. That's the one case where it's actionable: it tells you you'll need TRX in the account before you can move/swap the tokens out. No address-classification heuristic is needed; scoping to self-sends sidesteps the "can't distinguish a Chainflip deposit address" problem entirely.

The warning copy is also reworded from recipient-framing ("the recipient won't be able to move them") to self-framing ("you won't be able to move or swap them out").

> Note: the 9 non-English locales still carry the previous wording for `tron.recipientNotActivated.sendWarning` and should be re-synced via the translate workflow in a follow-up.

## Issue (if applicable)

closes #

## Risk

Low. UI-only change to a warning's render condition and copy. No on-chain transaction logic is touched — sends behave identically; only the conditional display of an informational warning changes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Tron sends (TRC-20) in the Send modal — display only.

## Testing

### Engineering

1. With a Tron account, open Send for a TRC-20 token (e.g. USDT).
2. Send to a **third-party / unactivated** Tron address (e.g. a Chainflip deposit address): the activation warning should **no longer** appear.
3. Send to **one of your own** unactivated Tron accounts: the warning **should** appear, now with the self-framed copy.
4. Sending native TRX (`tronAssetId`) never shows the warning (unchanged).

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

User-facing functional test: in a preview env, attempt a Tron USDT swap that routes through a Chainflip deposit address and confirm the activation warning no longer appears on the send step.

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Tron “recipient not activated” warning so it shows only when it’s relevant (including checks for sending to one of your own Tron accounts).
  * Updated the warning text to reference the **account** (not the recipient address) and to clarify that tokens can’t be moved or swapped until the account has TRX to cover network fees.
  * Enhanced the overall wording for clearer, more accurate guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->