### PR TITLE
feat(affiliate): adopt partnerCode in public-api + affiliate-dashboard

### DIFF
--- a/packages/affiliate-dashboard/src/App.tsx
+++ b/packages/affiliate-dashboard/src/App.tsx
@@ -36,6 +36,9 @@ export const App = (): React.JSX.Element => {
 
   const affiliateAddress = isConnected && address ? address : ''
   const configQuery = useAffiliateConfig(affiliateAddress)
+  // Attribution reads key on the stable partnerCode (resolved from the connected wallet's
+  // affiliate config), not the wallet address.
+  const partnerCode = configQuery.data?.partnerCode ?? ''
 
   const periods = useMemo(
     () => generatePeriods(configQuery.data?.createdAt),
@@ -44,8 +47,8 @@ export const App = (): React.JSX.Element => {
 
   const currentPeriod = periods.find(p => p.key === selectedKey) ?? periods[0]
 
-  const statsQuery = useAffiliateStats(affiliateAddress, currentPeriod)
-  const swapsQuery = useAffiliateSwaps(affiliateAddress, currentPeriod)
+  const statsQuery = useAffiliateStats(partnerCode, currentPeriod)
+  const swapsQuery = useAffiliateSwaps(partnerCode, currentPeriod)
   const actions = useAffiliateActions({ affiliateAddress, authHeaders })
 
   const swaps = useMemo(

--- a/packages/affiliate-dashboard/src/App.tsx
+++ b/packages/affiliate-dashboard/src/App.tsx
@@ -36,8 +36,6 @@ export const App = (): React.JSX.Element => {
 
   const affiliateAddress = isConnected && address ? address : ''
   const configQuery = useAffiliateConfig(affiliateAddress)
-  // Attribution reads key on the stable partnerCode (resolved from the connected wallet's
-  // affiliate config), not the wallet address.
   const partnerCode = configQuery.data?.partnerCode ?? ''
 
   const periods = useMemo(

--- a/packages/affiliate-dashboard/src/hooks/useAffiliateConfig.ts
+++ b/packages/affiliate-dashboard/src/hooks/useAffiliateConfig.ts
@@ -9,7 +9,7 @@ const AffiliateConfigSchema = z.object({
   id: z.string(),
   walletAddress: z.string(),
   receiveAddress: z.string().nullable(),
-  partnerCode: z.string().nullable(),
+  partnerCode: z.string(),
   partnerBps: z.number(),
   shapeshiftBps: z.number(),
   isActive: z.boolean(),

--- a/packages/affiliate-dashboard/src/hooks/useAffiliateStats.ts
+++ b/packages/affiliate-dashboard/src/hooks/useAffiliateStats.ts
@@ -20,8 +20,8 @@ const ApiResponseSchema = z.object({
   totalFeesEarnedUsd: NumericString,
 })
 
-const fetchStats = async (address: string, period: Period): Promise<AffiliateStats> => {
-  const params = new URLSearchParams({ address })
+const fetchStats = async (partnerCode: string, period: Period): Promise<AffiliateStats> => {
+  const params = new URLSearchParams({ partnerCode })
 
   if (period.startDate) params.append('startDate', period.startDate)
   if (period.endDate) params.append('endDate', period.endDate)
@@ -37,12 +37,12 @@ const fetchStats = async (address: string, period: Period): Promise<AffiliateSta
 }
 
 export const useAffiliateStats = (
-  address: string,
+  partnerCode: string,
   period: Period,
 ): UseQueryResult<AffiliateStats, Error> =>
   useQuery({
-    queryKey: ['affiliate', 'stats', address, period.startDate, period.endDate],
-    queryFn: () => fetchStats(address, period),
-    enabled: Boolean(address),
+    queryKey: ['affiliate', 'stats', partnerCode, period.startDate, period.endDate],
+    queryFn: () => fetchStats(partnerCode, period),
+    enabled: Boolean(partnerCode),
     placeholderData: keepPreviousData,
   })

--- a/packages/affiliate-dashboard/src/hooks/useAffiliateSwaps.ts
+++ b/packages/affiliate-dashboard/src/hooks/useAffiliateSwaps.ts
@@ -51,12 +51,12 @@ export interface AffiliateSwapsPage {
 }
 
 const fetchSwaps = async (
-  address: string,
+  partnerCode: string,
   period: Period,
   cursor: string | undefined,
 ): Promise<AffiliateSwapsPage> => {
   const params = new URLSearchParams({
-    address,
+    partnerCode,
     limit: String(SWAPS_PER_PAGE),
   })
 
@@ -69,13 +69,13 @@ const fetchSwaps = async (
 }
 
 export const useAffiliateSwaps = (
-  address: string,
+  partnerCode: string,
   period: Period,
 ): UseInfiniteQueryResult<InfiniteData<AffiliateSwapsPage, string | undefined>, Error> =>
   useInfiniteQuery({
-    queryKey: ['affiliate', 'swaps', address, period.key],
-    queryFn: ({ pageParam }) => fetchSwaps(address, period, pageParam),
-    enabled: Boolean(address),
+    queryKey: ['affiliate', 'swaps', partnerCode, period.key],
+    queryFn: ({ pageParam }) => fetchSwaps(partnerCode, period, pageParam),
+    enabled: Boolean(partnerCode),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: lastPage => {
       const next = lastPage.nextCursor?.trim()

--- a/packages/public-api/src/lib/quoteStore.ts
+++ b/packages/public-api/src/lib/quoteStore.ts
@@ -10,6 +10,7 @@ export type StoredQuote = {
   sendAddress: string
   receiveAddress: string
   partnerAddress?: string
+  partnerCode?: string
   partnerBps?: string
   shapeshiftBps: string
   affiliateBps: string

--- a/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
+++ b/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
@@ -14,7 +14,7 @@ registry.registerPath({
   operationId: 'getAffiliateStats',
   summary: 'Get affiliate statistics',
   description:
-    'Retrieve aggregated swap statistics for an affiliate address. Returns total swaps, volume, and fees earned. Supports optional date range filtering.',
+    'Retrieve aggregated swap statistics for an affiliate by partnerCode. Returns total swaps, volume, and fees earned. Supports optional date range filtering.',
   tags: ['Affiliate'],
   request: {
     query: AffiliateStatsRequestSchema,
@@ -44,11 +44,10 @@ export const getAffiliateStats = async (req: Request, res: Response): Promise<vo
       return
     }
 
-    const { address, partnerCode, startDate, endDate } = queryResult.data
+    const { partnerCode, startDate, endDate } = queryResult.data
 
     const url = new URL(`${env.SWAP_SERVICE_BASE_URL}/v1/affiliate/stats`)
-    if (partnerCode) url.searchParams.append('partnerCode', partnerCode)
-    else if (address) url.searchParams.append('address', address)
+    url.searchParams.append('partnerCode', partnerCode)
 
     if (startDate) url.searchParams.append('startDate', String(startDate))
     if (endDate) url.searchParams.append('endDate', String(endDate))

--- a/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
+++ b/packages/public-api/src/routes/affiliate/getAffiliateStats.ts
@@ -44,10 +44,11 @@ export const getAffiliateStats = async (req: Request, res: Response): Promise<vo
       return
     }
 
-    const { address, startDate, endDate } = queryResult.data
+    const { address, partnerCode, startDate, endDate } = queryResult.data
 
     const url = new URL(`${env.SWAP_SERVICE_BASE_URL}/v1/affiliate/stats`)
-    url.searchParams.append('address', address)
+    if (partnerCode) url.searchParams.append('partnerCode', partnerCode)
+    else if (address) url.searchParams.append('address', address)
 
     if (startDate) url.searchParams.append('startDate', String(startDate))
     if (endDate) url.searchParams.append('endDate', String(endDate))

--- a/packages/public-api/src/routes/affiliate/getAffiliateSwaps.ts
+++ b/packages/public-api/src/routes/affiliate/getAffiliateSwaps.ts
@@ -51,11 +51,12 @@ export const getAffiliateSwaps = async (req: Request, res: Response): Promise<vo
       return
     }
 
-    const { address, startDate, endDate, limit, cursor } = queryResult.data
+    const { address, partnerCode, startDate, endDate, limit, cursor } = queryResult.data
 
     const url = new URL(`${env.SWAP_SERVICE_BASE_URL}/v1/affiliate/swaps`)
 
-    url.searchParams.append('address', address)
+    if (partnerCode) url.searchParams.append('partnerCode', partnerCode)
+    else if (address) url.searchParams.append('address', address)
     url.searchParams.append('limit', String(limit))
 
     if (cursor) url.searchParams.append('cursor', cursor)

--- a/packages/public-api/src/routes/affiliate/getAffiliateSwaps.ts
+++ b/packages/public-api/src/routes/affiliate/getAffiliateSwaps.ts
@@ -21,7 +21,7 @@ registry.registerPath({
   operationId: 'getAffiliateSwaps',
   summary: 'Get affiliate swaps',
   description:
-    'Retrieve paginated swap history for an affiliate address. Supports optional date range filtering.',
+    'Retrieve paginated swap history for an affiliate by partnerCode. Supports optional date range filtering.',
   tags: ['Affiliate'],
   request: {
     query: AffiliateSwapsRequestSchema,
@@ -51,12 +51,11 @@ export const getAffiliateSwaps = async (req: Request, res: Response): Promise<vo
       return
     }
 
-    const { address, partnerCode, startDate, endDate, limit, cursor } = queryResult.data
+    const { partnerCode, startDate, endDate, limit, cursor } = queryResult.data
 
     const url = new URL(`${env.SWAP_SERVICE_BASE_URL}/v1/affiliate/swaps`)
 
-    if (partnerCode) url.searchParams.append('partnerCode', partnerCode)
-    else if (address) url.searchParams.append('address', address)
+    url.searchParams.append('partnerCode', partnerCode)
     url.searchParams.append('limit', String(limit))
 
     if (cursor) url.searchParams.append('cursor', cursor)

--- a/packages/public-api/src/routes/affiliate/types.ts
+++ b/packages/public-api/src/routes/affiliate/types.ts
@@ -114,16 +114,11 @@ export const SwapServiceAffiliateSwapsResponseSchema = z.object({
 
 export const AffiliateSwapsRequestSchema = z
   .object({
-    address: EVM_ADDRESS.optional(),
-    partnerCode: PartnerCodeSchema.optional(),
+    partnerCode: PartnerCodeSchema,
     startDate: z.string().datetime().optional(),
     endDate: z.string().datetime().optional(),
     limit: z.coerce.number().int().min(1).max(100).default(50),
     cursor: z.string().trim().min(1, 'cursor must not be empty').optional(),
-  })
-  .refine(({ address, partnerCode }) => Boolean(address || partnerCode), {
-    message: 'address or partnerCode is required',
-    path: ['partnerCode'],
   })
   .refine(
     ({ startDate, endDate }) =>
@@ -146,14 +141,9 @@ export const AffiliateSwapsResponseSchema = registry.register(
 
 export const AffiliateStatsRequestSchema = z
   .object({
-    address: EVM_ADDRESS.optional(),
-    partnerCode: PartnerCodeSchema.optional(),
+    partnerCode: PartnerCodeSchema,
     startDate: z.string().datetime().optional(),
     endDate: z.string().datetime().optional(),
-  })
-  .refine(({ address, partnerCode }) => Boolean(address || partnerCode), {
-    message: 'address or partnerCode is required',
-    path: ['partnerCode'],
   })
   .refine(
     ({ startDate, endDate }) =>

--- a/packages/public-api/src/routes/affiliate/types.ts
+++ b/packages/public-api/src/routes/affiliate/types.ts
@@ -4,6 +4,16 @@ import { registry } from '../../registry'
 import { EVM_ADDRESS } from '../../types'
 import { AssetSchema } from '../assets/types'
 
+const PartnerCodeSchema = z
+  .string()
+  .trim()
+  .min(3)
+  .max(32)
+  .regex(
+    /^[a-z0-9]+$/,
+    'partnerCode must be 3–32 lowercase letters or numbers (e.g. mypartnercode)',
+  )
+
 // --- Affiliate Config ---
 
 export const AffiliateAddressParamsSchema = z.object({
@@ -16,7 +26,7 @@ export const AffiliateConfigResponseSchema = registry.register(
     id: z.string().openapi({ example: 'abc123' }),
     walletAddress: EVM_ADDRESS,
     receiveAddress: EVM_ADDRESS.nullable(),
-    partnerCode: z.string().nullable().openapi({ example: 'mypartner' }),
+    partnerCode: z.string().openapi({ example: 'mypartner' }),
     partnerBps: z.number().openapi({ example: 50 }),
     shapeshiftBps: z.number().openapi({ example: 10 }),
     isActive: z.boolean().openapi({ example: true }),
@@ -28,15 +38,7 @@ export const AffiliateConfigResponseSchema = registry.register(
 export const CreateAffiliateRequestSchema = z.object({
   walletAddress: EVM_ADDRESS,
   receiveAddress: EVM_ADDRESS.optional(),
-  partnerCode: z
-    .string()
-    .trim()
-    .min(3)
-    .max(32)
-    .regex(
-      /^[a-z0-9]+$/,
-      'partnerCode must be 3–32 lowercase letters or numbers (e.g. mypartnercode)',
-    ),
+  partnerCode: PartnerCodeSchema,
   bps: z.number().int().min(0).max(1000),
 })
 
@@ -112,11 +114,16 @@ export const SwapServiceAffiliateSwapsResponseSchema = z.object({
 
 export const AffiliateSwapsRequestSchema = z
   .object({
-    address: EVM_ADDRESS,
+    address: EVM_ADDRESS.optional(),
+    partnerCode: PartnerCodeSchema.optional(),
     startDate: z.string().datetime().optional(),
     endDate: z.string().datetime().optional(),
     limit: z.coerce.number().int().min(1).max(100).default(50),
     cursor: z.string().trim().min(1, 'cursor must not be empty').optional(),
+  })
+  .refine(({ address, partnerCode }) => Boolean(address || partnerCode), {
+    message: 'address or partnerCode is required',
+    path: ['partnerCode'],
   })
   .refine(
     ({ startDate, endDate }) =>
@@ -139,9 +146,14 @@ export const AffiliateSwapsResponseSchema = registry.register(
 
 export const AffiliateStatsRequestSchema = z
   .object({
-    address: EVM_ADDRESS,
+    address: EVM_ADDRESS.optional(),
+    partnerCode: PartnerCodeSchema.optional(),
     startDate: z.string().datetime().optional(),
     endDate: z.string().datetime().optional(),
+  })
+  .refine(({ address, partnerCode }) => Boolean(address || partnerCode), {
+    message: 'address or partnerCode is required',
+    path: ['partnerCode'],
   })
   .refine(
     ({ startDate, endDate }) =>

--- a/packages/public-api/src/routes/quote/getQuote.ts
+++ b/packages/public-api/src/routes/quote/getQuote.ts
@@ -189,6 +189,7 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       receiveAddress,
       sendAddress,
       partnerAddress: req.affiliateInfo?.partnerAddress,
+      partnerCode: req.affiliateInfo?.partnerCode,
       createdAt: now,
       expiresAt: now + QuoteStore.QUOTE_TTL_MS,
       metadata: {

--- a/packages/public-api/src/routes/status/utils.ts
+++ b/packages/public-api/src/routes/status/utils.ts
@@ -22,6 +22,7 @@ const buildSwapRegistrationBody = (storedQuote: ReturnType<typeof quoteStore.get
       buyAccountId: storedQuote.receiveAddress,
       receiveAddress: storedQuote.receiveAddress,
       partnerAddress: storedQuote.partnerAddress,
+      partnerCode: storedQuote.partnerCode,
       partnerBps: storedQuote.partnerBps ? Number(storedQuote.partnerBps) : undefined,
       affiliateBps: Number(storedQuote.affiliateBps),
       shapeshiftBps: Number(storedQuote.shapeshiftBps),


### PR DESCRIPTION
## Description

Pairs with shapeshift/microservices#44, which moved partner attribution to a stable `partnerCode`. This adopts `partnerCode` end-to-end on the web side (write + read).

### Write path — forward `partnerCode` on swap registration
public-api already resolves `partnerCode` (from `X-Partner-Code`, in `auth.ts`) but was dropping it, forwarding only `partnerAddress`. Now it's threaded through so swaps attribute by code directly:
- `StoredQuote` gains optional `partnerCode`
- `getQuote` persists `req.affiliateInfo?.partnerCode`
- `buildSwapRegistrationBody` forwards `partnerCode` in the `POST /swaps` body

`partnerAddress` is still sent as the payout snapshot and the path for `X-Partner-Address` callers. (swap-service's reverse-lookup means this isn't *required* for correctness, but sending the code is cleaner.)

### Read path — stats/swaps by `partnerCode`
- **public-api** `/v1/affiliate/{stats,swaps}`: dual-param — accept `partnerCode` (preferred) **or** `address` (these are documented public endpoints; external callers using `address` keep working), forwarded to swap-service.
- **affiliate-dashboard**: `useAffiliateStats`/`useAffiliateSwaps` now query by the `partnerCode` from `useAffiliateConfig` (resolved from the connected wallet) instead of the wallet address.

### `partnerCode` no longer nullable
`Affiliate.partnerCode` is `NOT NULL` and every affiliate has one, so the affiliate config response schema (public-api) and the dashboard's config schema drop `.nullable()`.

### Deploy ordering
swap-service #44 is merged and backward-compatible (accepts swaps/queries with or without `partnerCode`), so this ships independently and any time.

## Testing
- public-api: `pnpm test` 30/30, `tsc --noEmit` clean, `eslint` clean.
- affiliate-dashboard: `eslint` clean; `tsc` clean for `src/` (the only tsc errors are a pre-existing `@vitejs/plugin-react` d.ts parse artifact, unrelated to this change; the package builds via Vite).
- Changes are additive on the public endpoints (address still accepted); the dashboard already loads `partnerCode` via `useAffiliateConfig`.