### PR TITLE
chore: bump public package versions for next release

### DIFF
--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/caip",
-  "version": "8.16.7",
+  "version": "8.16.9",
   "description": "CAIP Implementation",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",

--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/chain-adapters",
-  "version": "11.3.9",
+  "version": "11.4.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/contracts",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "17.7.3",
+  "version": "17.8.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/types",
-  "version": "8.6.7",
+  "version": "8.6.8",
   "description": "Common types shared across packages",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",

--- a/packages/unchained-client/package.json
+++ b/packages/unchained-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/unchained-client",
-  "version": "10.14.10",
+  "version": "10.14.11",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/utils",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Description

Bumps the public `@shapeshiftoss/*` packages that have **unreleased, shippable source changes since their last published npm version**, so the `publish-packages` workflow ships them on the next release (it publishes any package whose `package.json` version isn't yet on npm, on push to `main`).

Bump levels reflect the **actual change surface**, not the conventional-commit tag:

| Package | develop | npm | → new | level | why |
|---|---|---|---|---|---|
| swapper | 17.7.3 | 17.7.3 | **17.8.0** | minor | new swappers/exports (BOB Gateway, chainflip Tron, affiliate split) |
| chain-adapters | 11.3.9 | 11.3.9 | **11.4.0** | minor | new exported Jito MEV module + Abstract chain adapter |
| utils | 1.0.5 | 1.0.6 | **1.1.0** | minor | new exported asset/chain constants; leapfrogs npm |
| types | 8.6.7 | 8.6.7 | **8.6.8** | patch | small additive enum/type members |
| caip | 8.16.7 | 8.16.8 | **8.16.9** | patch | asset-data regen (data only); leapfrogs npm |
| contracts | 1.0.6 | 1.0.6 | **1.0.7** | patch | internal FOXy ABI removal |
| unchained-client | 10.14.10 | 10.14.10 | **10.14.11** | patch | fixes only |

**Not bumped:**
- `errors` — its only change since publish is a **test file** (not in the published bundle), so nothing shippable changed.
- `hdwallet-*` and `swap-widget` — out of scope.

## Notes

- Version-only change; `workspace:^` deps are `link:`-based so `pnpm-lock.yaml` is unaffected (no lockfile diff).
- `caip`/`utils` leapfrog the versions already on npm (8.16.8 / 1.0.6) that `develop` had fallen behind.
- Reflects only merged `develop` — in-flight swapper refactors on other branches will get their own bump when they land.

## Testing

No code change; publish is gated by the existing `publish-packages.yml` workflow on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several package versions across the codebase to the latest releases.
  * Included minor and patch version bumps for core libraries and client packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->