### PR TITLE
chore(rfox): update current epoch IPFS metadata hash

### DIFF
--- a/src/pages/RFOX/constants.ts
+++ b/src/pages/RFOX/constants.ts
@@ -11,7 +11,7 @@ export const unstakeEvent = getAbiItem({ abi: RFOX_ABI, name: 'Unstake' })
 
 export const IPFS_GATEWAY = 'https://gateway.pinata.cloud/ipfs'
 
-export const CURRENT_EPOCH_IPFS_HASH = 'bafkreidmtyeqdmu254zdrkquys2gofu53pxeftmm4wptk6a74bxa5tdfce'
+export const CURRENT_EPOCH_IPFS_HASH = 'bafkreid5rxhvniibexuq3cckoujzbkmjtombwhmdzlgu72tucpisgqsoo4'
 export const STUB_RUNE_ADDRESS = 'thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqn8p0r8'
 export const RFOX_V3_UPGRADE_EPOCH = 18
 


### PR DESCRIPTION
## Description

Updates `CURRENT_EPOCH_IPFS_HASH` in RFOX constants to the latest pinned epoch metadata (`bafkreid5rxhvniibexuq3cckoujzbkmjtombwhmdzlgu72tucpisgqsoo4`). Data-only pointer bump; no logic changes.

## Issue (if applicable)

N/A

## Risk

Low. Single-constant change pointing the RFOX current-epoch metadata at a newly pinned IPFS hash — no code paths, no on-chain transaction changes, no contract interactions.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None — RFOX rewards metadata display only.

## Testing

### Engineering

- Load the RFOX page and confirm the current epoch's metadata resolves and renders from the new IPFS hash (via `IPFS_GATEWAY`).

### Operations

- [x] :checkered_flag: Data-only IPFS pointer update; verify RFOX current-epoch reward data displays correctly in a preview environment.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the current epoch content reference to a new IPFS hash, so the app now points to the latest epoch data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->