### PR TITLE
fix: surface thorchain tx execution errors and gate tcy claim on inbound halt

### DIFF
--- a/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
+++ b/src/lib/utils/thorchain/hooks/useSendThorTx.tsx
@@ -293,18 +293,17 @@ export const useSendThorTx = ({
   })
 
   const executeTransaction = useCallback(async () => {
-    if (!memo) return
-    if (!asset) return
-    if (!wallet) return
-    if (!accountId) return
-    if (!transactionType) return
-    if (!estimateFeesArgs) return
-    if (accountNumber === undefined) return
-    if (isToken(asset.assetId) && !inboundAddressData) return
-    // Never broadcast to a halted inbound vault. Pairs with the inboundAddress halt guard above as a
-    // second layer: even if a consumer obtained an address out-of-band, execution still bails here.
-    // We intentionally fetch halted inbounds so fees still estimate (read only) during a halt.
-    if (inboundAddressData?.halted) return
+    if (!memo) throw new Error('Missing transaction memo')
+    if (!asset) throw new Error('Missing asset')
+    if (!wallet) throw new Error('No wallet connected')
+    if (!accountId) throw new Error('Missing account')
+    if (!transactionType) throw new Error('Unable to determine transaction type')
+    if (!estimateFeesArgs) throw new Error('Fee estimation data not ready')
+    if (accountNumber === undefined) throw new Error('Unable to resolve account number')
+    if (isToken(asset.assetId) && !inboundAddressData)
+      throw new Error('Missing inbound address data for token send')
+    // Never broadcast to a halted inbound vault; we intentionally fetch halted inbounds so fees still estimate (read only) during a halt.
+    if (inboundAddressData?.halted) throw new Error('Inbound vault is halted')
 
     if (
       action !== 'withdrawRunepool' &&

--- a/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
+++ b/src/pages/Lending/Pool/components/Repay/RepayConfirm.tsx
@@ -313,8 +313,15 @@ export const RepayConfirm = ({
 
     mixpanel?.track(MixPanelEvent.RepayConfirm, eventData)
 
-    const _txId = await executeTransaction()
-    if (!_txId) throw new Error('failed to broadcast transaction')
+    const _txId = await executeTransaction().catch((err: unknown) => {
+      console.error('[lending repay] executeTransaction failed:', err)
+      return undefined
+    })
+
+    if (!_txId) {
+      setIsLoanPending(false)
+      throw new Error('failed to broadcast transaction')
+    }
 
     setTxid(_txId)
   }, [

--- a/src/pages/TCY/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/TCY/components/Claim/ClaimConfirm.tsx
@@ -8,6 +8,7 @@ import {
   ModalCloseButton,
 } from '@chakra-ui/react'
 import { fromAssetId, tcyAssetId, thorchainAssetId, thorchainChainId } from '@shapeshiftoss/caip'
+import { SwapperName } from '@shapeshiftoss/swapper'
 import { BigAmount } from '@shapeshiftoss/utils'
 import { useMutation } from '@tanstack/react-query'
 import noop from 'lodash/noop'
@@ -34,6 +35,7 @@ import { useSendThorTx } from '@/lib/utils/thorchain/hooks/useSendThorTx'
 import { useThorchainMimir } from '@/lib/utils/thorchain/hooks/useThorchainMimir'
 import { isUtxoChainId } from '@/lib/utils/utxo'
 import { useIsSweepNeededQuery } from '@/pages/Lending/hooks/useIsSweepNeededQuery'
+import { useIsTradingActive } from '@/react-queries/hooks/useIsTradingActive'
 import { actionSlice } from '@/state/slices/actionSlice/actionSlice'
 import { ActionStatus, ActionType } from '@/state/slices/actionSlice/types'
 import {
@@ -88,7 +90,15 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
     select: mimir => mimir.TCYCLAIMINGHALT === 1,
   })
 
-  const isHalted = Boolean(isChainHalted) || Boolean(isTcyClaimingHalted)
+  // The claim is an L1 inbound deposit, so a halted inbound vault blocks it. useIsChainHalted only
+  // covers the mimir-based halt, so check the inbound halted flag (via isTradingActive) here too.
+  const { isTradingActive, isLoading: isTradingActiveLoading } = useIsTradingActive({
+    assetId: claim.assetId,
+    swapperName: SwapperName.Thorchain,
+  })
+  const isInboundHalted = !isTradingActiveLoading && isTradingActive === false
+
+  const isHalted = Boolean(isChainHalted) || Boolean(isTcyClaimingHalted) || isInboundHalted
   const [runeAddress, setRuneAddress] = useState<string>()
   const methods = useForm<AddressFormValues>()
 
@@ -146,7 +156,11 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
   const { data: isSweepNeeded, isFetching: isSweepNeededFeching } =
     useIsSweepNeededQuery(isSweepNeededArgs)
 
-  const { mutateAsync: handleClaim, isPending: isClaimMutationPending } = useMutation({
+  const {
+    mutateAsync: handleClaim,
+    isPending: isClaimMutationPending,
+    error: claimError,
+  } = useMutation({
     mutationFn: async () => {
       if (!runeAddress) return
 
@@ -181,7 +195,7 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
     if (isSweepNeeded) {
       return navigate(TCYClaimRoute.Sweep, { state: { selectedClaim: claim } })
     }
-    await handleClaim()
+    await handleClaim().catch(err => console.error('[TCY claim] failed:', err))
   }, [handleClaim, isSweepNeeded, navigate, claim])
 
   const feeAsset = useAppSelector(state => selectFeeAssetById(state, claim.assetId))
@@ -243,12 +257,21 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
 
   const confirmCopy = useMemo(() => {
     if (isTcyClaimingHalted) return translate('TCY.claimingHalted')
-    if (isChainHalted) return translate('common.chainHalted')
+    if (isChainHalted || isInboundHalted) return translate('common.chainHalted')
     if (isError) return translate('common.insufficientFunds')
     return translate('TCY.claimConfirm.confirmAndClaim')
-  }, [isError, translate, isChainHalted, isTcyClaimingHalted])
+  }, [isError, translate, isChainHalted, isInboundHalted, isTcyClaimingHalted])
 
   const confirmAlert = useMemo(() => {
+    if (claimError) {
+      return (
+        <Alert status='error' variant='subtle' mt={2}>
+          <AlertIcon />
+          <RawText fontSize='sm'>{translate('common.somethingWentWrong')}</RawText>
+        </Alert>
+      )
+    }
+
     if (hasEnoughBalanceForDustAndFees) return null
     if (!feeAsset) return null
 
@@ -263,7 +286,13 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
         </RawText>
       </Alert>
     )
-  }, [feeAsset, hasEnoughBalanceForDustAndFees, requiredAmountCryptoPrecision, translate])
+  }, [
+    claimError,
+    feeAsset,
+    hasEnoughBalanceForDustAndFees,
+    requiredAmountCryptoPrecision,
+    translate,
+  ])
 
   const assetAccountHelper = useMemo(() => {
     if (!feeAsset) return null
@@ -334,7 +363,8 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
           isSweepNeededFeching ||
           isEstimatedFeesDataLoading ||
           isChainHaltedFetching ||
-          isTcyClaimingHaltedFetching
+          isTcyClaimingHaltedFetching ||
+          isTradingActiveLoading
         }
         dustAmountUserCurrency={dustAmountUserCurrency}
         isError={isError}

--- a/src/pages/TCY/components/Claim/ClaimConfirm.tsx
+++ b/src/pages/TCY/components/Claim/ClaimConfirm.tsx
@@ -96,9 +96,15 @@ export const ClaimConfirm = ({ claim, setClaimTxid }: ClaimConfirmProps) => {
     assetId: claim.assetId,
     swapperName: SwapperName.Thorchain,
   })
-  const isInboundHalted = !isTradingActiveLoading && isTradingActive === false
+  const isInboundHalted = useMemo(
+    () => !isTradingActiveLoading && isTradingActive === false,
+    [isTradingActive, isTradingActiveLoading],
+  )
 
-  const isHalted = Boolean(isChainHalted) || Boolean(isTcyClaimingHalted) || isInboundHalted
+  const isHalted = useMemo(
+    () => Boolean(isChainHalted) || Boolean(isTcyClaimingHalted) || isInboundHalted,
+    [isChainHalted, isInboundHalted, isTcyClaimingHalted],
+  )
   const [runeAddress, setRuneAddress] = useState<string>()
   const methods = useForm<AddressFormValues>()
 

--- a/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
+++ b/src/pages/ThorChainLP/components/ReusableLpStatus/TransactionRow.tsx
@@ -485,7 +485,11 @@ export const TransactionRow: React.FC<TransactionRowProps> = ({
       return
     }
 
-    const _txId = await executeTransaction()
+    const _txId = await executeTransaction().catch((err: unknown) => {
+      console.error('[thorchain lp] executeTransaction failed:', err)
+      return undefined
+    })
+
     if (!_txId) {
       setIsSubmitting(false)
       throw new Error('failed to broadcast transaction')


### PR DESCRIPTION
## Description

Surfaces THORChain transaction execution errors that were previously swallowed, and hardens the TCY claim flow against inbound-vault halts.

- `useSendThorTx.executeTransaction` now `throw`s descriptive errors (missing memo/asset/wallet/account/tx-type/fees, missing inbound data for tokens, halted vault) instead of silently `return`ing `undefined`. Callers can now distinguish and report real failure causes.
- Repay (`RepayConfirm`) and ThorChain LP (`TransactionRow`) callers catch and log the underlying error, reset their pending/submitting flag, and keep their existing generic broadcast-failure handling — no user-facing behavior change beyond better logging.
- TCY claim (`ClaimConfirm`) surfaces a user-facing error alert when the claim mutation fails, and is now also gated on the inbound vault `halted` flag (via `useIsTradingActive`) in addition to the existing mimir-based chain/claiming halt checks — a TCY claim is an L1 inbound deposit, so a halted inbound vault must block it.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low–moderate. Touches the shared `useSendThorTx` hook used by all THORChain flows (savers, LP, RUNEPool, lending repay, TCY stake/unstake/claim). The `executeTransaction` change converts silent-undefined guard clauses into thrown errors; every consumer already either wraps the call in `try/catch` (savers Confirm, TCY stake/unstake, TCY claim mutation) or checks `!txId` and re-throws (repay, LP), so the thrown errors land in existing error paths. No on-chain transaction construction or memo/amount logic is modified.

## Testing

### Engineering

- THORChain LP add/remove, savers deposit/withdraw, RUNEPool, and lending repay: confirm happy-path broadcasts still succeed and that a forced failure now logs a descriptive `[...] executeTransaction failed:` error while still showing the existing failure toast/state.
- TCY claim: with a halted inbound vault (or forced mutation failure), confirm the button is disabled/relabelled `chainHalted` and the new error alert renders on failure; confirm a normal claim still broadcasts and navigates to Status.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

User-facing change is limited to the TCY claim screen: an error alert now appears if a claim fails, and the confirm button is disabled when the asset's inbound vault is halted. QA can functionally verify on the TCY claim flow in a preview environment.

## Screenshots (if applicable)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved transaction validation by failing explicitly with clearer errors when required memo/asset/wallet/account details, fee inputs, or inbound data can’t be resolved.
  - Standardized broadcast/sign failure handling for repay confirmations and liquidity transaction signing, with consistent “failed to broadcast transaction” behavior.
  - Prevented claim and transaction flows from proceeding while chain, inbound, or TCY halt conditions are active.
- **User Experience**
  - Claim screens more accurately reflect combined chain, inbound, and TCY-specific halt states.
  - Confirm buttons now remain disabled/loading until halt status (including trading-state loading) is fully determined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->