### PR TITLE
chore: release v1.1036.0

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -36,7 +36,7 @@
     "@coral-xyz/anchor": "0.29.0",
     "@cowprotocol/app-data": "^2.3.0",
     "@defuse-protocol/one-click-sdk-typescript": "^0.1.1-0.2",
-    "@gobob/bob-sdk": "5.6.0",
+    "@gobob/bob-sdk": "5.8.1",
     "@mysten/sui": "^1.45.2",
     "@shapeshiftoss/bitcoinjs-lib": "7.0.0-shapeshift.0",
     "@shapeshiftoss/caip": "workspace:^",

--- a/packages/swapper/src/swappers/BobGatewaySwapper/BobGatewaySwapper.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/BobGatewaySwapper.ts
@@ -1,8 +1,9 @@
 import type { Swapper } from '../../types'
-import { executeEvmTransaction } from '../../utils'
+import { executeEvmTransaction, executeTronTransaction } from '../../utils'
 
 export const bobGatewaySwapper: Swapper = {
   executeEvmTransaction,
   executeUtxoTransaction: (txToSign, { signAndBroadcastTransaction }) =>
     signAndBroadcastTransaction(txToSign),
+  executeTronTransaction,
 }

--- a/packages/swapper/src/swappers/BobGatewaySwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/endpoints.ts
@@ -3,6 +3,7 @@ import { evm } from '@shapeshiftoss/chain-adapters'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { bnOrZero } from '@shapeshiftoss/utils'
 
+import { getTronTransactionFees } from '../../tron-utils/getTronTransactionFees'
 import type { SwapperApi, UtxoFeeData } from '../../types'
 import { getExecutableTradeStep, isExecutableTradeQuote } from '../../utils'
 import { getBobGatewayTradeQuote } from './swapperApi/getTradeQuote'
@@ -11,6 +12,7 @@ import {
   getBobGatewayClient,
   mapBobGatewayOrderStatusToTxStatus,
   registerBobGatewayTx,
+  toTronBase58,
 } from './utils/helpers'
 
 const registeredSwapIds = new Set<string>()
@@ -133,6 +135,28 @@ export const bobGatewayApi: SwapperApi = {
 
     return feeData.networkFeeCryptoBaseUnit
   },
+  getUnsignedTronTransaction: ({ from, stepIndex, tradeQuote, assertGetTronChainAdapter }) => {
+    if (!isExecutableTradeQuote(tradeQuote)) {
+      throw new Error('[BobGateway] unable to execute a trade rate')
+    }
+
+    const step = getExecutableTradeStep(tradeQuote, stepIndex)
+    const { accountNumber, bobSpecific, sellAsset } = step
+
+    const adapter = assertGetTronChainAdapter(sellAsset.chainId)
+
+    if (!bobSpecific?.tronTx) throw new Error('[BobGateway] invalid tron transaction')
+    const { to, data, value } = bobSpecific.tronTx
+
+    return adapter.buildCustomApiTx({
+      accountNumber,
+      from,
+      to: toTronBase58(to),
+      value,
+      data,
+    })
+  },
+  getTronTransactionFees,
   checkTradeStatus: async ({ swap, config, txHash }) => {
     if (!swap) throw new Error('[BobGateway] swap is required for status check')
 

--- a/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeRate.ts
@@ -6,9 +6,9 @@ import { v4 as uuid } from 'uuid'
 import type { GetTradeRateInput, SwapErrorRight, SwapperDeps, TradeRate } from '../../../types'
 import { SwapperName } from '../../../types'
 import { getInputOutputRate } from '../../../utils'
-import { DUMMY_BTC_ADDRESS, DUMMY_EVM_ADDRESS } from '../utils/constants'
 import {
   assertValidTrade,
+  dummyAddressForChainId,
   getBobGatewayAllowanceContract,
   getBobGatewayQuote,
   getBobGatewayRateNetworkFeeCryptoBaseUnit,
@@ -36,9 +36,9 @@ export const getBobGatewayTradeRate = async (
 
   const { sellChainName, buyChainName } = assertion.unwrap()
 
-  const recipient =
-    receiveAddress ?? (buyAsset.chainId === btcChainId ? DUMMY_BTC_ADDRESS : DUMMY_EVM_ADDRESS)
-  const sender = sellAsset.chainId === btcChainId ? undefined : DUMMY_EVM_ADDRESS
+  const recipient = receiveAddress ?? dummyAddressForChainId(buyAsset.chainId)
+  const sender =
+    sellAsset.chainId === btcChainId ? undefined : dummyAddressForChainId(sellAsset.chainId)
 
   const maybeQuote = await getBobGatewayQuote({
     config,

--- a/packages/swapper/src/swappers/BobGatewaySwapper/types.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/types.ts
@@ -10,7 +10,16 @@ type BobGatewayUtxoTxMetadata = {
   opReturnData?: string
 }
 
+type BobGatewayTronTxMetadata = {
+  to: string
+  data: string
+  value: string
+  feeLimit: string
+  chain: string
+}
+
 export type BobGatewayMetadata = { orderId: string } & (
-  | { evmTx: BobGatewayEvmTxMetadata; utxoTx?: never }
-  | { utxoTx: BobGatewayUtxoTxMetadata; evmTx?: never }
+  | { evmTx: BobGatewayEvmTxMetadata; utxoTx?: never; tronTx?: never }
+  | { utxoTx: BobGatewayUtxoTxMetadata; evmTx?: never; tronTx?: never }
+  | { tronTx: BobGatewayTronTxMetadata; evmTx?: never; utxoTx?: never }
 )

--- a/packages/swapper/src/swappers/BobGatewaySwapper/utils/constants.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/utils/constants.ts
@@ -8,8 +8,12 @@ import {
   bscChainId,
   btcChainId,
   ethChainId,
+  hyperEvmChainId,
+  plasmaChainId,
+  polygonChainId,
   seiChainId,
   sonicChainId,
+  // tronChainId,
   unichainChainId,
 } from '@shapeshiftoss/caip'
 import type { Address } from 'viem'
@@ -30,6 +34,10 @@ export const chainIdToBobGatewayChainName = {
   [seiChainId]: 'sei',
   [sonicChainId]: 'sonic',
   [unichainChainId]: 'unichain',
+  [plasmaChainId]: 'plasma',
+  [polygonChainId]: 'polygon',
+  [hyperEvmChainId]: 'hyperliquid',
+  // [tronChainId]: 'tron',
 } as const
 
 export const bobGatewayChainNameToChainId = Object.fromEntries(
@@ -41,6 +49,7 @@ export type BobGatewayChainName =
 
 export const DUMMY_EVM_ADDRESS = '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' as Address
 export const DUMMY_BTC_ADDRESS = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq'
+export const DUMMY_TRON_ADDRESS = 'TT2T17KZhoDu47i2E4FWxfG79zdkEWkU9N'
 
 export const BOB_GATEWAY_TOKENSWAP_DEFAULT_GAS_LIMIT = '350000' // EVM→EVM
 export const BOB_GATEWAY_OFFRAMP_DEFAULT_GAS_LIMIT = '550000' // EVM→BTC

--- a/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
@@ -1,12 +1,19 @@
 import type {
-  GatewayOrderStatusV2,
-  GatewayQuoteV2,
+  GatewayOrderStatusV3,
+  GatewayQuoteV3,
   GetQuoteParams,
-  RegisterTxV2,
+  RegisterTxV3,
 } from '@gobob/bob-sdk'
 import { GatewayErrorCode, GatewaySDK, isGatewayError } from '@gobob/bob-sdk'
-import type { AssetId } from '@shapeshiftoss/caip'
-import { ASSET_NAMESPACE, ethChainId, fromAssetId, toAssetId } from '@shapeshiftoss/caip'
+import type { AssetId, ChainId } from '@shapeshiftoss/caip'
+import {
+  ASSET_NAMESPACE,
+  btcChainId,
+  ethChainId,
+  fromAssetId,
+  toAssetId,
+  tronChainId,
+} from '@shapeshiftoss/caip'
 import { evm, isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import type { Asset, AssetsByIdPartial } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
@@ -18,6 +25,7 @@ import {
 } from '@shapeshiftoss/utils'
 import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
+import { TronWeb } from 'tronweb'
 import { getAddress, zeroAddress } from 'viem'
 
 import { getDefaultSlippageDecimalPercentageForSwapper } from '../../../constants'
@@ -41,10 +49,25 @@ import {
   bobGatewayChainNameToChainId,
   chainIdToBobGatewayChainName,
   decimalSlippageToBobBps,
+  DUMMY_BTC_ADDRESS,
+  DUMMY_EVM_ADDRESS,
+  DUMMY_TRON_ADDRESS,
 } from './constants'
+
+export const dummyAddressForChainId = (chainId: ChainId): string => {
+  if (chainId === btcChainId) return DUMMY_BTC_ADDRESS
+  if (chainId === tronChainId) return DUMMY_TRON_ADDRESS
+  return DUMMY_EVM_ADDRESS
+}
 
 export const getBobGatewayClient = (config: SwapperConfig): GatewaySDK => {
   return new GatewaySDK({ basePath: BOB_GATEWAY_BASE_URL, apiKey: config.VITE_BOB_GATEWAY_API_KEY })
+}
+
+export const toTronBase58 = (address: string): string => {
+  if (address.startsWith('T')) return address
+  if (address.startsWith('0x')) return TronWeb.address.fromHex(address.slice(2))
+  return TronWeb.address.fromHex(address)
 }
 
 export const assetIdToBobGatewayToken = (assetId: string): string => {
@@ -84,7 +107,7 @@ export const getBobGatewayQuote = async ({
   amount: string
   affiliateBps: string
   slippageTolerancePercentageDecimal: string | undefined
-}): Promise<Result<GatewayQuoteV2, SwapErrorRight>> => {
+}): Promise<Result<GatewayQuoteV3, SwapErrorRight>> => {
   const slippage = decimalSlippageToBobBps(
     slippageTolerancePercentageDecimal ??
       getDefaultSlippageDecimalPercentageForSwapper(SwapperName.BobGateway),
@@ -100,6 +123,7 @@ export const getBobGatewayQuote = async ({
       toUserAddress: recipient,
       amount,
       maxSlippage: Number(slippage),
+      ownerAddress: sellChainName === 'bitcoin' ? recipient : (sender as string),
       affiliates: getBobGatewayAffiliates(affiliateBps),
     })
 
@@ -155,11 +179,11 @@ export const getBobGatewayQuote = async ({
 
 export const createBobGatewayOrderMetadata = async (
   config: SwapperConfig,
-  gatewayQuote: GatewayQuoteV2,
+  gatewayQuote: GatewayQuoteV3,
 ): Promise<Result<BobGatewayMetadata, SwapErrorRight>> => {
   try {
-    const orderResponse = await getBobGatewayClient(config).api.createOrderV2({
-      gatewayQuoteV2: gatewayQuote,
+    const orderResponse = await getBobGatewayClient(config).api.createOrderV3({
+      gatewayQuoteV3: gatewayQuote,
     })
 
     // onramp (BTC→EVM)
@@ -173,17 +197,38 @@ export const createBobGatewayOrderMetadata = async (
       })
     }
 
-    // offramp (EVM→BTC) and tokenSwap (EVM→EVM) orders share the same tx shape
-    const order = 'offramp' in orderResponse ? orderResponse.offramp : orderResponse.tokenSwap
-    return Ok({
-      orderId: order.orderId,
-      evmTx: {
-        to: order.tx.to,
-        data: order.tx.data,
-        value: order.tx.value,
-        chain: order.tx.chain,
-      },
-    })
+    // offramp (EVM/Tron→BTC) and tokenSwap (EVM/Tron→EVM/Tron)
+    const order = (() => {
+      if ('offramp' in orderResponse) return orderResponse.offramp
+      if ('tokenSwap' in orderResponse) return orderResponse.tokenSwap
+      return undefined
+    })()
+
+    if (order) {
+      const { tx, orderId } = order
+
+      if (tx.type === 'evm') {
+        return Ok({
+          orderId,
+          evmTx: { to: tx.to, data: tx.data, value: tx.value, chain: tx.chain },
+        })
+      }
+
+      if (tx.type === 'tron') {
+        return Ok({
+          orderId,
+          tronTx: {
+            to: tx.to,
+            data: tx.data,
+            value: tx.value,
+            feeLimit: tx.feeLimit,
+            chain: tx.chain,
+          },
+        })
+      }
+    }
+
+    throw new Error('Unknown order type')
   } catch (err) {
     if (isGatewayError(err) && err.code === GatewayErrorCode.InsufficientConfirmedFunds) {
       return Err(
@@ -218,27 +263,29 @@ export const registerBobGatewayTx = async ({
   sellAsset: Asset
   buyAsset: Asset
 }): Promise<void> => {
-  const registerTxV2: RegisterTxV2 = (() => {
+  const registerTxV3: RegisterTxV3 = (() => {
+    const sellChainName = chainIdToBobGatewayChainName[sellAsset.chainId]
+
     // BTC→EVM
-    if (chainIdToBobGatewayChainName[sellAsset.chainId] === 'bitcoin') {
+    if (sellChainName === 'bitcoin') {
       return { onramp: { orderId, bitcoinTxid: txHash } }
     }
 
     // EVM→BTC
     if (chainIdToBobGatewayChainName[buyAsset.chainId] === 'bitcoin') {
-      return { offramp: { orderId, evmTxhash: txHash } }
+      return { offramp: { orderId, srcChain: sellChainName, srcTxHash: txHash } }
     }
 
     // EVM→EVM
-    return { tokenSwap: { orderId, evmTxhash: txHash } }
+    return { tokenSwap: { orderId, srcChain: sellChainName, srcTxHash: txHash } }
   })()
 
-  await getBobGatewayClient(config).api.registerTxV2({ registerTxV2 })
+  await getBobGatewayClient(config).api.registerTxV3({ registerTxV3 })
 }
 
 export const getBobGatewayQuoteFeeData = async (
   input: GetTradeQuoteInput,
-  { assertGetUtxoChainAdapter, assertGetEvmChainAdapter }: SwapperDeps,
+  { assertGetUtxoChainAdapter, assertGetEvmChainAdapter, assertGetTronChainAdapter }: SwapperDeps,
   orderMetadata: BobGatewayMetadata,
 ): Promise<Result<Omit<QuoteFeeData, 'protocolFees'>, SwapErrorRight>> => {
   const { sellAsset, sellAmountIncludingProtocolFeesCryptoBaseUnit } = input
@@ -275,6 +322,18 @@ export const getBobGatewayQuoteFeeData = async (
       return Ok({ networkFeeCryptoBaseUnit })
     }
 
+    if (orderMetadata.tronTx && input.sendAddress) {
+      const contractAddress = contractAddressOrUndefined(sellAsset.assetId)
+
+      const { fast } = await assertGetTronChainAdapter(sellAsset.chainId).getFeeData({
+        to: toTronBase58(orderMetadata.tronTx.to),
+        value: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        chainSpecific: { from: input.sendAddress, contractAddress },
+      })
+
+      return Ok({ networkFeeCryptoBaseUnit: fast.txFee })
+    }
+
     throw new Error('[BobGateway] invalid quote')
   } catch (err) {
     return Err(
@@ -288,9 +347,9 @@ export const getBobGatewayQuoteFeeData = async (
 }
 
 export const getBobGatewayRateNetworkFeeCryptoBaseUnit = async (
-  quote: GatewayQuoteV2,
+  quote: GatewayQuoteV3,
   sellAsset: Asset,
-  { assertGetEvmChainAdapter, assertGetUtxoChainAdapter }: SwapperDeps,
+  { assertGetEvmChainAdapter, assertGetUtxoChainAdapter, assertGetTronChainAdapter }: SwapperDeps,
 ): Promise<string | undefined> => {
   try {
     if ('onramp' in quote) {
@@ -302,6 +361,25 @@ export const getBobGatewayRateNetworkFeeCryptoBaseUnit = async (
       const satsPerByte = Math.max(1, Math.ceil(fast.satsPerKiloByte / 1000))
 
       return bnOrZero(satsPerByte).times(BOB_GATEWAY_ONRAMP_DEFAULT_TX_VSIZE).toFixed(0)
+    }
+
+    if (sellAsset.chainId === tronChainId) {
+      const order = (() => {
+        if ('offramp' in quote) return quote.offramp
+        if ('tokenSwap' in quote) return quote.tokenSwap
+        return undefined
+      })()
+      if (!order) return undefined
+
+      const contractAddress = contractAddressOrUndefined(sellAsset.assetId)
+
+      const { fast } = await assertGetTronChainAdapter(sellAsset.chainId).getFeeData({
+        to: toTronBase58(order.txTo),
+        value: order.inputAmount.amount,
+        chainSpecific: { contractAddress },
+      })
+
+      return fast.txFee
     }
 
     const defaultGasLimit =
@@ -318,7 +396,7 @@ export const getBobGatewayRateNetworkFeeCryptoBaseUnit = async (
   }
 }
 
-export const mapBobGatewayOrderStatusToTxStatus = (status: GatewayOrderStatusV2): TxStatus => {
+export const mapBobGatewayOrderStatusToTxStatus = (status: GatewayOrderStatusV3): TxStatus => {
   if ('inProgress' in status) return TxStatus.Pending
   if ('success' in status) return TxStatus.Confirmed
   if ('failed' in status) return TxStatus.Failed
@@ -332,6 +410,14 @@ const bobGatewayFeeToAssetId = (fee: { address: string; chain: string }): AssetI
 
   if (fee.address.toLowerCase() === zeroAddress) return chainIdToFeeAssetId(chainId)
 
+  if (chainId === tronChainId) {
+    return toAssetId({
+      chainId,
+      assetNamespace: ASSET_NAMESPACE.trc20,
+      assetReference: toTronBase58(fee.address),
+    })
+  }
+
   return toAssetId({
     chainId,
     assetNamespace: ASSET_NAMESPACE.erc20,
@@ -340,7 +426,7 @@ const bobGatewayFeeToAssetId = (fee: { address: string; chain: string }): AssetI
 }
 
 export const parseBobGatewayQuote = (
-  quote: GatewayQuoteV2,
+  quote: GatewayQuoteV3,
   buyAsset: Asset,
   assetsById: AssetsByIdPartial,
 ) => {
@@ -399,12 +485,20 @@ export const parseBobGatewayQuote = (
   }
 }
 
-export const getBobGatewayAllowanceContract = (quote: GatewayQuoteV2, sellAsset: Asset): string => {
-  if (!isEvmChainId(sellAsset.chainId)) return ''
+export const getBobGatewayAllowanceContract = (quote: GatewayQuoteV3, sellAsset: Asset): string => {
+  const isTron = sellAsset.chainId === tronChainId
+  if (!isEvmChainId(sellAsset.chainId) && !isTron) return ''
   if (!contractAddressOrUndefined(sellAsset.assetId)) return ''
-  if ('offramp' in quote) return quote.offramp.txTo
-  if ('tokenSwap' in quote) return quote.tokenSwap.txTo
-  return ''
+
+  const txTo = (() => {
+    if ('offramp' in quote) return quote.offramp.txTo
+    if ('tokenSwap' in quote) return quote.tokenSwap.txTo
+    return ''
+  })()
+  if (!txTo) return ''
+
+  if (isTron) return toTronBase58(txTo)
+  return txTo
 }
 
 export const assertValidTrade = ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2112,8 +2112,8 @@ importers:
         specifier: ^0.1.1-0.2
         version: 0.1.16
       '@gobob/bob-sdk':
-        specifier: 5.6.0
-        version: 5.6.0(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 5.8.1
+        version: 5.8.1(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@mysten/sui':
         specifier: 1.45.2
         version: 1.45.2(typescript@5.8.2)
@@ -4065,8 +4065,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.6.0':
-    resolution: {integrity: sha512-EjolhqPdLB8C1jaDpQoGYLZfe1NyOUdmg9XDBCozBjugfRu79iQ1c5jKxlNzTmLNOTL9SYYQT+8vk7wwentS7w==}
+  '@gobob/bob-sdk@5.8.1':
+    resolution: {integrity: sha512-fF8q3CnWEtUMcc4+WWWMq8dY08qL1kBV+/sn6gVSQv8wGVe95Qg0OLTZm0HbrPyvXjZreDTCIrO7ztmwp+mWxg==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -20131,7 +20131,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.6.0(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@gobob/bob-sdk@5.8.1(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5

--- a/src/state/helpers.ts
+++ b/src/state/helpers.ts
@@ -116,7 +116,8 @@ export const getEnabledSwappers = (
       DebridgeSwap && (!isCrossAccountTrade || isCrossAccountTradeSupported(SwapperName.Debridge)),
     [SwapperName.BobGateway]:
       BobGatewaySwap &&
-      (!isCrossAccountTrade || isCrossAccountTradeSupported(SwapperName.BobGateway)),
+      (!isCrossAccountTrade || isCrossAccountTradeSupported(SwapperName.BobGateway)) &&
+      !isLedgerTronSell,
     [SwapperName.Test]: false,
   }
 }


### PR DESCRIPTION
# Production changes - testing required

## BoB swapper v3

- feat: add bob swapper v3 (#12485)

Upgrades the BoB Gateway swapper integration to v3. Test BoB Gateway swaps end to end (quote, rate, approval, and execution) across supported source chains and confirm quotes, fees, and receive amounts look correct.

# Dev/local only - no production testing required

None - all changes in this release are live in production (`VITE_FEATURE_BOB` and `VITE_FEATURE_BOB_GATEWAY_SWAP` are both `true` in `.env` with no production override).