### PR TITLE
fix(caip): keep Node's fs out of the browser-reachable module graph

### DIFF
--- a/packages/caip/src/adapters/coinbase/generate.ts
+++ b/packages/caip/src/adapters/coinbase/generate.ts
@@ -1,4 +1,5 @@
-import { getData, parseData, writeFiles } from './utils'
+import { getData, parseData } from './utils'
+import { writeFiles } from './writeFiles'
 
 const main = async () => {
   const coinbaseCurrencies = await getData()

--- a/packages/caip/src/adapters/coinbase/utils.ts
+++ b/packages/caip/src/adapters/coinbase/utils.ts
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import fs from 'fs'
 import toLower from 'lodash/toLower'
 
 import type { AssetId } from '../../index'
@@ -45,15 +44,4 @@ export async function getData(): Promise<CoinbaseCurrency[]> {
     console.error('Get supported coins (coinbase-pay) failed')
     return []
   }
-}
-
-const writeFile = async (data: Record<AssetId, string>) => {
-  const path = './src/adapters/coinbase/generated/'
-  const file = 'adapter.json'
-  await fs.promises.writeFile(`${path}${file}`, JSON.stringify(data, null, 2))
-}
-
-export const writeFiles = async (data: Record<AssetId, string>) => {
-  await writeFile(data)
-  console.info('Generated Coinbase AssetId adapter data.')
 }

--- a/packages/caip/src/adapters/coinbase/writeFiles.ts
+++ b/packages/caip/src/adapters/coinbase/writeFiles.ts
@@ -5,13 +5,13 @@ import fs from 'fs'
 
 import type { AssetId } from '../../index'
 
-const writeFile = async (data: Record<AssetId, string>) => {
+const writeFile = async (data: Record<AssetId, string>): Promise<void> => {
   const path = './src/adapters/coinbase/generated/'
   const file = 'adapter.json'
   await fs.promises.writeFile(`${path}${file}`, JSON.stringify(data, null, 2))
 }
 
-export const writeFiles = async (data: Record<AssetId, string>) => {
+export const writeFiles = async (data: Record<AssetId, string>): Promise<void> => {
   await writeFile(data)
   console.info('Generated Coinbase AssetId adapter data.')
 }

--- a/packages/caip/src/adapters/coinbase/writeFiles.ts
+++ b/packages/caip/src/adapters/coinbase/writeFiles.ts
@@ -1,0 +1,17 @@
+// Codegen-only, run by generate.ts. `fs` lives here rather than in `utils.ts` so
+// that re-exporting from `utils.ts` can never pull a Node built-in into the graph
+// browser bundlers reach from the package entry.
+import fs from 'fs'
+
+import type { AssetId } from '../../index'
+
+const writeFile = async (data: Record<AssetId, string>) => {
+  const path = './src/adapters/coinbase/generated/'
+  const file = 'adapter.json'
+  await fs.promises.writeFile(`${path}${file}`, JSON.stringify(data, null, 2))
+}
+
+export const writeFiles = async (data: Record<AssetId, string>) => {
+  await writeFile(data)
+  console.info('Generated Coinbase AssetId adapter data.')
+}

--- a/packages/caip/src/adapters/coincap/generate.ts
+++ b/packages/caip/src/adapters/coincap/generate.ts
@@ -2,7 +2,8 @@ import dotenv from 'dotenv'
 import path from 'path'
 
 import { getCoincapAssetUrl } from './index'
-import { fetchData, parseData, writeFiles } from './utils'
+import { fetchData, parseData } from './utils'
+import { writeFiles } from './writeFiles'
 
 dotenv.config({ path: path.resolve(process.cwd(), '../../.env') })
 

--- a/packages/caip/src/adapters/coincap/utils.test.ts
+++ b/packages/caip/src/adapters/coincap/utils.test.ts
@@ -6,7 +6,8 @@ import realFs from 'fs'
 import { describe, expect, it, vi } from 'vitest'
 
 import { bitcoinAssetMap, cosmosAssetMap } from '../../utils'
-import { parseData, parseEthData, writeFiles } from './utils'
+import { parseData, parseEthData } from './utils'
+import { writeFiles } from './writeFiles'
 
 const makeEthMockCoincapResponse = () => ({
   id: 'ethereum',

--- a/packages/caip/src/adapters/coincap/utils.ts
+++ b/packages/caip/src/adapters/coincap/utils.ts
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import fs from 'fs'
 
 import type { AssetNamespace } from '../../assetId/assetId'
 import { toAssetId } from '../../assetId/assetId'
@@ -87,15 +86,6 @@ const COINCAP_CHAIN_MAP: Record<string, { chainId: ChainId; assetNamespace: Asse
     chainId: avalancheChainId,
     assetNamespace: 'erc20',
   },
-}
-
-export const writeFiles = async (data: Record<string, Record<string, string>>) => {
-  const path = './src/adapters/coincap/generated/'
-  const file = '/adapter.json'
-  const writeFile = async ([k, v]: [string, unknown]) =>
-    await fs.promises.writeFile(`${path}${k}${file}`.replace(':', '_'), JSON.stringify(v))
-  await Promise.all(Object.entries(data).map(writeFile))
-  console.info('Generated CoinCap AssetId adapter data.')
 }
 
 export const fetchData = async (URL: string) =>

--- a/packages/caip/src/adapters/coincap/writeFiles.ts
+++ b/packages/caip/src/adapters/coincap/writeFiles.ts
@@ -3,10 +3,10 @@
 // browser bundlers reach from the package entry.
 import fs from 'fs'
 
-export const writeFiles = async (data: Record<string, Record<string, string>>) => {
+export const writeFiles = async (data: Record<string, Record<string, string>>): Promise<void> => {
   const path = './src/adapters/coincap/generated/'
   const file = '/adapter.json'
-  const writeFile = async ([k, v]: [string, unknown]) =>
+  const writeFile = async ([k, v]: [string, unknown]): Promise<void> =>
     await fs.promises.writeFile(`${path}${k}${file}`.replace(':', '_'), JSON.stringify(v))
   await Promise.all(Object.entries(data).map(writeFile))
   console.info('Generated CoinCap AssetId adapter data.')

--- a/packages/caip/src/adapters/coincap/writeFiles.ts
+++ b/packages/caip/src/adapters/coincap/writeFiles.ts
@@ -1,0 +1,13 @@
+// Codegen-only, run by generate.ts. `fs` lives here rather than in `utils.ts` so
+// that re-exporting from `utils.ts` can never pull a Node built-in into the graph
+// browser bundlers reach from the package entry.
+import fs from 'fs'
+
+export const writeFiles = async (data: Record<string, Record<string, string>>) => {
+  const path = './src/adapters/coincap/generated/'
+  const file = '/adapter.json'
+  const writeFile = async ([k, v]: [string, unknown]) =>
+    await fs.promises.writeFile(`${path}${k}${file}`.replace(':', '_'), JSON.stringify(v))
+  await Promise.all(Object.entries(data).map(writeFile))
+  console.info('Generated CoinCap AssetId adapter data.')
+}

--- a/packages/caip/src/adapters/coingecko/generate.ts
+++ b/packages/caip/src/adapters/coingecko/generate.ts
@@ -1,5 +1,6 @@
 import { coingeckoUrl } from './index'
-import { fetchData, parseData, writeFiles } from './utils'
+import { fetchData, parseData } from './utils'
+import { writeFiles } from './writeFiles'
 
 const main = async () => {
   const data = await fetchData(coingeckoUrl)

--- a/packages/caip/src/adapters/coingecko/utils.test.ts
+++ b/packages/caip/src/adapters/coingecko/utils.test.ts
@@ -2,7 +2,8 @@ import realFs from 'fs'
 import { describe, expect, it, vi } from 'vitest'
 
 import { bitcoinAssetMap, cosmosAssetMap } from '../../utils'
-import { parseData, writeFiles } from './utils'
+import { parseData } from './utils'
+import { writeFiles } from './writeFiles'
 
 const makeEthMockCoingeckoResponse = () => ({
   id: 'ethereum',

--- a/packages/caip/src/adapters/coingecko/utils.ts
+++ b/packages/caip/src/adapters/coingecko/utils.ts
@@ -1,5 +1,4 @@
 import axios from 'axios'
-import fs from 'fs'
 
 import type { AssetId } from '../../assetId/assetId'
 import { toAssetId } from '../../assetId/assetId'
@@ -112,7 +111,7 @@ export type CoingeckoCoin = {
   platforms: Record<string, string>
 }
 
-type AssetMap = Record<ChainId, Record<AssetId, string>>
+export type AssetMap = Record<ChainId, Record<AssetId, string>>
 
 export const fetchData = async (URL: string) => (await axios.get<CoingeckoCoin[]>(URL)).data
 
@@ -721,15 +720,4 @@ export const parseData = (coins: CoingeckoCoin[]): AssetMap => {
     [thorchainChainId]: thorchainAssetMap,
     [mayachainChainId]: mayachainAssetMap,
   }
-}
-
-export const writeFiles = async (data: AssetMap) => {
-  await Promise.all(
-    Object.entries(data).map(async ([chainId, assets]) => {
-      const dirPath = `./src/adapters/coingecko/generated/${chainId}`.replace(':', '_')
-      await fs.promises.mkdir(dirPath, { recursive: true })
-      await fs.promises.writeFile(`${dirPath}/adapter.json`, JSON.stringify(assets))
-    }),
-  )
-  console.info('Generated CoinGecko AssetId adapter data.')
 }

--- a/packages/caip/src/adapters/coingecko/writeFiles.ts
+++ b/packages/caip/src/adapters/coingecko/writeFiles.ts
@@ -5,9 +5,9 @@ import fs from 'fs'
 
 import type { AssetMap } from './utils'
 
-export const writeFiles = async (data: AssetMap) => {
+export const writeFiles = async (data: AssetMap): Promise<void> => {
   await Promise.all(
-    Object.entries(data).map(async ([chainId, assets]) => {
+    Object.entries(data).map(async ([chainId, assets]): Promise<void> => {
       const dirPath = `./src/adapters/coingecko/generated/${chainId}`.replace(':', '_')
       await fs.promises.mkdir(dirPath, { recursive: true })
       await fs.promises.writeFile(`${dirPath}/adapter.json`, JSON.stringify(assets))

--- a/packages/caip/src/adapters/coingecko/writeFiles.ts
+++ b/packages/caip/src/adapters/coingecko/writeFiles.ts
@@ -1,0 +1,17 @@
+// Codegen-only, run by generate.ts. `index.ts` re-exports from `utils.ts`, so
+// keeping `fs` here rather than there is what keeps Node built-ins out of the
+// module graph browser bundlers reach from the package entry.
+import fs from 'fs'
+
+import type { AssetMap } from './utils'
+
+export const writeFiles = async (data: AssetMap) => {
+  await Promise.all(
+    Object.entries(data).map(async ([chainId, assets]) => {
+      const dirPath = `./src/adapters/coingecko/generated/${chainId}`.replace(':', '_')
+      await fs.promises.mkdir(dirPath, { recursive: true })
+      await fs.promises.writeFile(`${dirPath}/adapter.json`, JSON.stringify(assets))
+    }),
+  )
+  console.info('Generated CoinGecko AssetId adapter data.')
+}


### PR DESCRIPTION
## Description

`@shapeshiftoss/caip` cannot be consumed from a browser bundler today. In a Next.js app it fails with:

```
Module not found: Can't resolve 'fs'
Import trace:
  @shapeshiftoss/caip/dist/esm/adapters/coingecko/utils.js
  @shapeshiftoss/caip/dist/esm/adapters/coingecko/index.js
  @shapeshiftoss/caip/dist/esm/adapters/index.js
  @shapeshiftoss/swap-widget/dist/index.js
```

The cause is a single edge. `adapters/coingecko/index.ts:56` re-exports from `./utils`:

```ts
export { fetchData as fetchCoingeckoData, parseData as parseCoingeckoData } from './utils'
```

and `utils.ts` imported `fs` for `writeFiles` — a codegen helper whose only caller is `generate.ts`. That one re-export puts `import fs from 'fs'` into the graph every browser bundler reaches from the package entry.

I walked the published ESM graph from `dist/esm/index.js` to check the blast radius. 82 modules are reachable, and exactly one of them imports a Node built-in:

```
=== as published (8.16.9) ===
modules reachable from dist/esm/index.js: 82
reachable modules importing a Node built-in: 1
  adapters/coingecko/utils.js  imports  fs

=== with this change ===
reachable modules importing a Node built-in: 0
```

This PR moves `writeFiles` into a codegen-only `writeFiles.ts` in each adapter directory. `generate.ts` imports it from the new path.

The coincap and coinbase `utils.ts` files import `fs` for the same reason, but nothing re-exports them, so theirs is latent rather than live. They get the same treatment here so that re-exporting from them later can't reintroduce the bug.

Worth noting why this is invisible in this repo: `packages/swap-widget/devDependencies` includes `vite-plugin-node-polyfills`, so the dev server and demo build polyfill `fs` silently. Consumers who don't polyfill Node built-ins — the default for Next.js, and the right posture for browser bundles — get a hard failure.

**No public API change.** `fetchCoingeckoData` and `parseCoingeckoData` still export from `utils.ts`, and `writeFiles` was never exposed in any barrel. The only non-mechanical edit is making the `AssetMap` type exported so `writeFiles.ts` can import it as a type.

One thing left deliberately undone: the compiled `generate.js` and `writeFiles.js` still land in `dist`, exactly as the compiled `.test.js` files already do. They're just unreachable from `index.js`, which is what bundlers care about. If you'd rather keep them out of the tarball entirely, excluding `src/**/generate.ts` and `src/**/writeFiles.ts` from `tsconfig.{esm,cjs}.json` would do it — at the cost of no longer type-checking the codegen, which is why I didn't assume it.

## Issue (if applicable)

None — reported from an external integration.

## Risk

Low, and contained to `packages/caip`. Pure code movement: no logic changes, no public export changes, no dependency or lockfile changes. `writeFiles` bodies are moved verbatim.

The failure mode if something were wrong is loud and immediate — `pnpm generate:coingecko` / `generate:coincap` would fail to resolve `writeFiles`, and the two moved test suites cover its behaviour.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None. The moved code is build-time asset-map codegen and is never reachable at runtime.

## Testing

### Engineering

```bash
# codegen still works end to end — this is the real exercise of the moved code
cd packages/caip
pnpm generate:coingecko
pnpm generate:coincap
git status   # generated adapter.json files unchanged

# the two suites that cover writeFiles
pnpm test src/adapters/coingecko/utils.test.ts src/adapters/coincap/utils.test.ts
```

`vi.mock('fs')` in those suites is module-scoped, so it still intercepts the import from its new location.

Verified on my side: no Node built-in imports remain anywhere in `packages/caip/src` outside `generate.ts` and the new `writeFiles.ts` files; `writeFiles` appears in no barrel; and all touched files pass Prettier 3.0.3 with the options from `.eslintrc`.

I could not run ESLint, `tsc`, or Vitest locally — that needs a full monorepo install and I only had a shallow clone — so CI is the real check on those.

### Operations

No user-facing change. Regression surface is the CoinGecko/CoinCap/Coinbase asset-id adapter maps, which the codegen commands above regenerate byte-identically.

## Screenshots (if applicable)

n/a

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized adapter generation so data fetching/parsing is kept separate from generated-file writing for Coinbase, CoinCap, and CoinGecko.
  * Updated module structure and exports to improve clarity without changing generation behavior.
* **Tests**
  * Adjusted adapter test imports to match the updated generation helper locations.
* **Developer Tools**
  * Added clearer return typing for generation helpers and exposed the CoinGecko asset map type for better reuse during code generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->