### PR TITLE
chore: bump swap-widget to 0.5.2 and caip to 8.16.10 for next release

### DIFF
--- a/packages/caip/package.json
+++ b/packages/caip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/caip",
-  "version": "8.16.9",
+  "version": "8.16.10",
   "description": "CAIP Implementation",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",

--- a/packages/swap-widget/package.json
+++ b/packages/swap-widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swap-widget",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Embeddable swap widget using ShapeShift API",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",


### PR DESCRIPTION
## Description

Version bumps to publish the two fixes that landed on develop since the last release:

- `@shapeshiftoss/swap-widget` 0.5.1 → 0.5.2 — picks up #12506 (viem peer floor raised to `^2.45.0`, empty-publish guard)
- `@shapeshiftoss/caip` 8.16.9 → 8.16.10 — picks up #12507 (Node's `fs` kept out of the browser-reachable module graph)

swap-widget externalizes its `dependencies` at build time, so consumers get the caip fix via the published `@shapeshiftoss/caip` package — hence both bumps ship together.

## Issue (if applicable)

closes #

## Risk

Low — version-only changes to two `package.json` files. Publishing happens via the existing `publish-packages.yml` workflow on merge to main.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

Verify the versions aren't already on npm (`npm view @shapeshiftoss/swap-widget version` → 0.5.1, `npm view @shapeshiftoss/caip version` → 8.16.9). The publish workflow picks up both packages once this reaches main.

### Operations

- [x] :checkered_flag: No user-facing changes; nothing to QA.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)