### PR TITLE
fix(ton): swap-shaped history rows with receive amounts

### DIFF
--- a/packages/chain-adapters/package.json
+++ b/packages/chain-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/chain-adapters",
-  "version": "11.5.0",
+  "version": "11.5.1",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -182,11 +182,8 @@ export const buildJettonTransfers = (
   return transfers
 }
 
-// Merges all of a trace's transfers on this account into swap-shaped legs. Raw message values
-// misstate swap amounts for native TON: sell-side envelopes stack the forward gas budget on top
-// of the swapped amount, and dex payouts bundle the gas refund into the payout. The actual value
-// comes from the proxy TON jetton row where one exists (ston.fi wraps native TON), and from the
-// net native flow across the trace otherwise.
+// Raw message values misstate native swap legs (gas budgets ride the envelope, refunds ride the
+// payout) - swap rows use the proxy TON jetton amount when present, net native flow otherwise
 export const buildTraceTransfers = ({
   txs,
   jettonTransfers,

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -35,6 +35,8 @@ import type {
   TonFeeData,
   TonSignTx,
   TonToken,
+  TonTrace,
+  TonTracesResponse,
   TonTx,
 } from './types'
 
@@ -70,6 +72,7 @@ const PROXY_TON_CONTRACTS = new Set([
 const TRACE_LT_SEARCH_RANGE = 1_000_000_000n
 // Legs of a trace land within this window of its initiator (~5 minutes of logical time)
 const TRACE_COMPLETION_LT_SPAN = 300_000_000n
+const TRACE_BATCH_SIZE = 20
 const TON_HASH_HEX_LENGTH = 64
 export const isHexHash = (str: string): boolean => {
   return str.length === TON_HASH_HEX_LENGTH && /^[0-9a-f]+$/i.test(str)
@@ -210,7 +213,8 @@ export const buildTraceTransfers = ({
   for (const tx of txs) {
     const parsed = parseTonTx(resolveAddresses(tx, addressBook), pubkey, '', assetId, chainId)
     for (const transfer of parsed.transfers) {
-      const key = `${transfer.assetId}-${transfer.from[0]}-${transfer.to[0]}-${transfer.value}-${transfer.type}`
+      // Scoped to the source tx so identical legs from different txs both survive
+      const key = `${tx.hash}-${transfer.assetId}-${transfer.from[0]}-${transfer.to[0]}-${transfer.value}-${transfer.type}`
       if (seen.has(key)) continue
       seen.add(key)
       native.push(transfer)
@@ -761,63 +765,68 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       const pageHashes = new Set(data.transactions.map(tx => tx.hash))
       const pageMaxLt = data.transactions.map(tx => BigInt(tx.lt)).reduce((a, b) => (a > b ? a : b))
 
-      // Rows are emitted complete or not at all: a page can slice through a trace, so groups
-      // initiated by this account are re-fetched over the trace lt window whenever the page
-      // cannot guarantee it contains every leg. Emitted rows overwrite existing ones (pending
-      // rows re-emit until confirmed), so a partial group must never be emitted for an own trace.
-      for (const [traceId, group] of Object.entries(txsByTrace)) {
-        const initiatorInPage = pageHashes.has(traceId)
-
-        const isOwnTrace = await (async () => {
-          if (initiatorInPage) return true
-
-          // Only not-own verdicts are cached: an own verdict must re-inject the initiator tx
+      // Rows are emitted complete or not at all: a page can slice through a trace, and a trace's
+      // initiator (whose account decides whether the trace is ours to merge) may live on another
+      // page. Traces needing resolution are fetched whole in batches - ownership, every leg, and
+      // an is_incomplete flag in one request each - so a partial group is never emitted for an
+      // own trace and never overwrites a complete row.
+      const pendingTraceIds = Object.entries(txsByTrace)
+        .filter(([traceId]) => {
           if (this.traceNotOwnCache.has(`${pubkey}:${traceId}`)) return false
+          if (!pageHashes.has(traceId)) return true
+          const initiator = txsByTrace[traceId].find(t => t.hash === traceId)
+          return Boolean(
+            initiator && BigInt(initiator.lt) + TRACE_COMPLETION_LT_SPAN > pageMaxLt,
+          )
+        })
+        .map(([traceId]) => traceId)
 
-          try {
-            const result = await this.httpApiRequest<TonApiTxResponse>(
-              `/api/v3/transactions?hash=${encodeURIComponent(traceId)}&limit=1`,
-            )
-            const initiator = result.transactions?.[0]
-            const isOwn = Boolean(initiator && addressesMatch(initiator.account, pubkey))
-            if (isOwn && initiator) {
-              group.unshift(initiator)
-              Object.assign(addressBook, result.address_book ?? {})
-            } else {
-              this.traceNotOwnCache.add(`${pubkey}:${traceId}`)
-            }
-            return isOwn
-          } catch {
-            // Degrades to emitting the page legs as-is
-            return false
-          }
-        })()
-
-        if (!isOwnTrace) continue
-
-        const initiator = group.find(t => t.hash === traceId)
-        if (!initiator) continue
-
-        const mayBeSliced =
-          !initiatorInPage || BigInt(initiator.lt) + TRACE_COMPLETION_LT_SPAN > pageMaxLt
-
-        if (!mayBeSliced) continue
+      for (let i = 0; i < pendingTraceIds.length; i += TRACE_BATCH_SIZE) {
+        const batch = pendingTraceIds.slice(i, i + TRACE_BATCH_SIZE)
 
         try {
-          const traceTxs = await this.fetchTraceTxs(pubkey, initiator.lt, traceId)
-          if (traceTxs.txs.length > 0) {
-            txsByTrace[traceId] = traceTxs.txs
-            Object.assign(addressBook, traceTxs.addressBook)
+          const result = await this.fetchTraces(
+            `trace_id=${batch.map(encodeURIComponent).join(',')}&limit=${TRACE_BATCH_SIZE}`,
+          )
+          Object.assign(addressBook, result.address_book ?? {})
+
+          const tracesById = new Map((result.traces ?? []).map(trace => [trace.trace_id, trace]))
+
+          for (const traceId of batch) {
+            const trace = tracesById.get(traceId)
+            // Not indexed (yet) - emit the page legs as-is
+            if (!trace) continue
+
+            const initiator = trace.transactions?.[traceId]
+            if (!initiator || !addressesMatch(initiator.account, pubkey)) {
+              this.traceNotOwnCache.add(`${pubkey}:${traceId}`)
+              continue
+            }
+
+            if (trace.is_incomplete) {
+              delete txsByTrace[traceId]
+              continue
+            }
+
+            txsByTrace[traceId] = this.ownTraceTxs(trace, pubkey)
           }
-        } catch {
-          // Better no row this round than a partial one overwriting a complete row
-          delete txsByTrace[traceId]
+        } catch (error) {
+          console.error('[TON] Failed to resolve traces, dropping affected rows this page', {
+            batch,
+            error,
+          })
+          for (const traceId of batch) delete txsByTrace[traceId]
         }
       }
 
-      const lts = Object.values(txsByTrace)
-        .flat()
-        .map(tx => BigInt(tx.lt))
+      const remainingTxs = Object.values(txsByTrace).flat()
+
+      if (remainingTxs.length === 0) {
+        const emptyCursor = data.transactions.length === pageSize ? String(offset + pageSize) : ''
+        return { cursor: emptyCursor, pubkey, transactions: [], txIds: [] }
+      }
+
+      const lts = remainingTxs.map(tx => BigInt(tx.lt))
       const minLt = lts.reduce((a, b) => (a < b ? a : b)).toString()
       const maxLt = lts.reduce((a, b) => (a > b ? a : b)).toString()
 
@@ -1191,21 +1200,16 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
     }
   }
 
-  private async fetchTraceTxs(
-    pubkey: string,
-    fromLt: string,
-    traceId: string,
-  ): Promise<{ txs: TonTx[]; addressBook: Record<string, { user_friendly: string }> }> {
-    const endLt = (BigInt(fromLt) + TRACE_LT_SEARCH_RANGE).toString()
-    const result = await this.httpApiRequest<TonApiTxResponse>(
-      `/api/v3/transactions?account=${encodeURIComponent(
-        pubkey,
-      )}&start_lt=${fromLt}&end_lt=${endLt}&sort=asc&limit=20`,
-    )
-    return {
-      txs: (result.transactions ?? []).filter(t => (t.trace_id ?? t.hash) === traceId),
-      addressBook: result.address_book ?? {},
-    }
+  // Every leg of every requested trace in a single request - no lt-window or page-size
+  // assumptions, and is_incomplete flags traces still executing
+  private async fetchTraces(params: string): Promise<TonTracesResponse> {
+    return this.httpApiRequest<TonTracesResponse>(`/api/v3/traces?${params}`)
+  }
+
+  private ownTraceTxs(trace: TonTrace, pubkey: string): TonTx[] {
+    return Object.values(trace.transactions ?? {})
+      .filter(t => addressesMatch(t.account, pubkey))
+      .sort((a, b) => (BigInt(a.lt) < BigInt(b.lt) ? -1 : 1))
   }
 
   private async fetchJettonTransfers(
@@ -1290,18 +1294,19 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       const traceId = tx.trace_id ?? txHash
       const endLt = (BigInt(tx.lt) + TRACE_LT_SEARCH_RANGE).toString()
 
-      const [traceTxResult, jettonData] = await Promise.all([
-        this.fetchTraceTxs(pubkey, tx.lt, traceId),
+      const [traceResult, jettonData] = await Promise.all([
+        this.fetchTraces(`tx_hash=${encodeURIComponent(tx.hash)}&limit=1`),
         this.fetchJettonTransfers(pubkey, tx.lt, endLt),
       ])
 
       const addressBook = {
         ...(txResult.address_book ?? {}),
-        ...traceTxResult.addressBook,
+        ...(traceResult.address_book ?? {}),
         ...jettonData.address_book,
       }
 
-      const traceTxs = traceTxResult.txs
+      const trace = traceResult.traces?.[0]
+      const traceTxs = trace ? this.ownTraceTxs(trace, pubkey) : []
       const primaryTx = traceTxs[0] ?? tx
 
       const txsToProcess = traceTxs.length > 0 ? traceTxs : [tx]

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -775,9 +775,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
           if (this.traceNotOwnCache.has(`${pubkey}:${traceId}`)) return false
           if (!pageHashes.has(traceId)) return true
           const initiator = txsByTrace[traceId].find(t => t.hash === traceId)
-          return Boolean(
-            initiator && BigInt(initiator.lt) + TRACE_COMPLETION_LT_SPAN > pageMaxLt,
-          )
+          return Boolean(initiator && BigInt(initiator.lt) + TRACE_COMPLETION_LT_SPAN > pageMaxLt)
         })
         .map(([traceId]) => traceId)
 

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -64,7 +64,10 @@ const PROXY_TON_CONTRACTS = new Set([
   'EQBnGWMCf3-FZZq1W4IWcWiGAc3PHuZ0_H-7sad2oY00o83S',
 ])
 
-const TRACE_LT_SEARCH_RANGE = 1000n
+// Logical time advances ~1e6 per second, and downstream trace legs (dex payouts, excesses) land
+// tens of millions of lts after the initiator - this bounds the search only, results are
+// filtered by trace_id
+const TRACE_LT_SEARCH_RANGE = 1_000_000_000n
 const TON_HASH_HEX_LENGTH = 64
 export const isHexHash = (str: string): boolean => {
   return str.length === TON_HASH_HEX_LENGTH && /^[0-9a-f]+$/i.test(str)

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -785,8 +785,12 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         const batch = pendingTraceIds.slice(i, i + TRACE_BATCH_SIZE)
 
         try {
-          const result = await this.fetchTraces(
-            `trace_id=${batch.map(encodeURIComponent).join(',')}&limit=${TRACE_BATCH_SIZE}`,
+          // Every leg of every requested trace in a single request - no lt-window or page-size
+          // assumptions, and is_incomplete flags traces still executing
+          const result = await this.httpApiRequest<TonTracesResponse>(
+            `/api/v3/traces?trace_id=${batch
+              .map(encodeURIComponent)
+              .join(',')}&limit=${TRACE_BATCH_SIZE}`,
           )
           Object.assign(addressBook, result.address_book ?? {})
 
@@ -1200,12 +1204,6 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
     }
   }
 
-  // Every leg of every requested trace in a single request - no lt-window or page-size
-  // assumptions, and is_incomplete flags traces still executing
-  private async fetchTraces(params: string): Promise<TonTracesResponse> {
-    return this.httpApiRequest<TonTracesResponse>(`/api/v3/traces?${params}`)
-  }
-
   private ownTraceTxs(trace: TonTrace, pubkey: string): TonTx[] {
     return Object.values(trace.transactions ?? {})
       .filter(t => addressesMatch(t.account, pubkey))
@@ -1295,7 +1293,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       const endLt = (BigInt(tx.lt) + TRACE_LT_SEARCH_RANGE).toString()
 
       const [traceResult, jettonData] = await Promise.all([
-        this.fetchTraces(`tx_hash=${encodeURIComponent(tx.hash)}&limit=1`),
+        this.httpApiRequest<TonTracesResponse>(
+          `/api/v3/traces?tx_hash=${encodeURIComponent(tx.hash)}&limit=1`,
+        ),
         this.fetchJettonTransfers(pubkey, tx.lt, endLt),
       ])
 

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -759,9 +759,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       }
 
       const pageHashes = new Set(data.transactions.map(tx => tx.hash))
-      const pageMaxLt = data.transactions
-        .map(tx => BigInt(tx.lt))
-        .reduce((a, b) => (a > b ? a : b))
+      const pageMaxLt = data.transactions.map(tx => BigInt(tx.lt)).reduce((a, b) => (a > b ? a : b))
 
       // Rows are emitted complete or not at all: a page can slice through a trace, so groups
       // initiated by this account are re-fetched over the trace lt window whenever the page

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -182,6 +182,42 @@ export const buildJettonTransfers = (
   return transfers
 }
 
+// Native TON swapped through ston.fi routes travels wrapped as proxy TON - the wallet message
+// value stacks the forward gas budget on top of the swapped amount (partially refunded later as
+// excess), while the proxy jetton row the transfer builder skips carries the actual value
+export const applyProxyTonAmounts = (
+  nativeTransfers: TxTransfer[],
+  jettonTransfers: JettonTransferRecord[],
+  traceId: string,
+  pubkey: string,
+  addressBook: Record<string, { user_friendly: string }>,
+): TxTransfer[] => {
+  const friendly = (addr: string) => addressBook[addr]?.user_friendly ?? addr
+
+  const amounts: Partial<Record<TransferType, string>> = {}
+  for (const transfer of jettonTransfers) {
+    if (transfer.trace_id !== traceId) continue
+    if (!transfer.source || !transfer.destination || !transfer.amount || !transfer.jetton_master)
+      continue
+    if (!isProxyTon(friendly(transfer.jetton_master))) continue
+
+    if (addressesMatch(friendly(transfer.source), pubkey)) {
+      amounts[TransferType.Send] = transfer.amount
+    }
+    if (addressesMatch(friendly(transfer.destination), pubkey)) {
+      amounts[TransferType.Receive] = transfer.amount
+    }
+  }
+
+  return nativeTransfers.map(transfer => {
+    const amount = amounts[transfer.type]
+    if (!amount) return transfer
+    // Only an unambiguous single leg per direction is overridden
+    if (nativeTransfers.filter(t => t.type === transfer.type).length !== 1) return transfer
+    return { ...transfer, value: amount }
+  })
+}
+
 export const parseTonTx = (
   tx: TonTx,
   pubkey: string,
@@ -744,7 +780,15 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
           }
         }
 
-        const allTransfers = [...nativeTransfers, ...jettonTransfers]
+        const adjustedNativeTransfers = applyProxyTonAmounts(
+          nativeTransfers,
+          jettonData.jetton_transfers,
+          traceId,
+          pubkey,
+          jettonAddrBook,
+        )
+
+        const allTransfers = [...adjustedNativeTransfers, ...jettonTransfers]
         const anyAborted = traceGroup.some(t => t.description?.aborted === true)
         const anyActionFailed = traceGroup.some(t => t.description?.action?.success === false)
         const status = anyAborted || anyActionFailed ? TxStatus.Failed : TxStatus.Confirmed
@@ -1199,7 +1243,15 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         }
       }
 
-      const allTransfers = [...nativeTransfers, ...jettonTransfers]
+      const adjustedNativeTransfers = applyProxyTonAmounts(
+        nativeTransfers,
+        jettonData.jetton_transfers,
+        traceId,
+        pubkey,
+        addressBook,
+      )
+
+      const allTransfers = [...adjustedNativeTransfers, ...jettonTransfers]
       const anyAborted = txsToProcess.some(t => t.description?.aborted === true)
       const anyActionFailed = txsToProcess.some(t => t.description?.action?.success === false)
       const status = anyAborted || anyActionFailed ? TxStatus.Failed : TxStatus.Confirmed

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -68,6 +68,8 @@ const PROXY_TON_CONTRACTS = new Set([
 // tens of millions of lts after the initiator - this bounds the search only, results are
 // filtered by trace_id
 const TRACE_LT_SEARCH_RANGE = 1_000_000_000n
+// Legs of a trace land within this window of its initiator (~5 minutes of logical time)
+const TRACE_COMPLETION_LT_SPAN = 300_000_000n
 const TON_HASH_HEX_LENGTH = 64
 export const isHexHash = (str: string): boolean => {
   return str.length === TON_HASH_HEX_LENGTH && /^[0-9a-f]+$/i.test(str)
@@ -227,11 +229,16 @@ export const buildTraceTransfers = ({
       continue
     if (!isProxyTon(friendly(transfer.jetton_master))) continue
 
+    // Summed per direction - split routes move the wrapped amount in multiple legs
     if (addressesMatch(friendly(transfer.source), pubkey)) {
-      proxyAmounts[TransferType.Send] = transfer.amount
+      proxyAmounts[TransferType.Send] = (
+        BigInt(proxyAmounts[TransferType.Send] ?? '0') + BigInt(transfer.amount)
+      ).toString()
     }
     if (addressesMatch(friendly(transfer.destination), pubkey)) {
-      proxyAmounts[TransferType.Receive] = transfer.amount
+      proxyAmounts[TransferType.Receive] = (
+        BigInt(proxyAmounts[TransferType.Receive] ?? '0') + BigInt(transfer.amount)
+      ).toString()
     }
   }
 
@@ -371,6 +378,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
   protected readonly assetId = tonAssetId
   protected readonly rpcUrl: string
   private requestQueue: PQueue
+  private traceNotOwnCache = new Set<string>()
 
   constructor(args: ChainAdapterArgs) {
     this.rpcUrl = args.rpcUrl
@@ -750,25 +758,62 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         ;(txsByTrace[traceId] ??= []).push(tx)
       }
 
-      // Trace legs whose initiator fell on another page would otherwise emit as disconnected
-      // rows - fetch the initiator so the trace still merges into a single row under its id
       const pageHashes = new Set(data.transactions.map(tx => tx.hash))
-      const orphanTraceIds = Object.entries(txsByTrace)
-        .filter(([traceId, group]) => group.length > 1 && !pageHashes.has(traceId))
-        .map(([traceId]) => traceId)
+      const pageMaxLt = data.transactions
+        .map(tx => BigInt(tx.lt))
+        .reduce((a, b) => (a > b ? a : b))
 
-      for (const traceId of orphanTraceIds) {
+      // Rows are emitted complete or not at all: a page can slice through a trace, so groups
+      // initiated by this account are re-fetched over the trace lt window whenever the page
+      // cannot guarantee it contains every leg. Emitted rows overwrite existing ones (pending
+      // rows re-emit until confirmed), so a partial group must never be emitted for an own trace.
+      for (const [traceId, group] of Object.entries(txsByTrace)) {
+        const initiatorInPage = pageHashes.has(traceId)
+
+        const isOwnTrace = await (async () => {
+          if (initiatorInPage) return true
+
+          // Only not-own verdicts are cached: an own verdict must re-inject the initiator tx
+          if (this.traceNotOwnCache.has(`${pubkey}:${traceId}`)) return false
+
+          try {
+            const result = await this.httpApiRequest<TonApiTxResponse>(
+              `/api/v3/transactions?hash=${encodeURIComponent(traceId)}&limit=1`,
+            )
+            const initiator = result.transactions?.[0]
+            const isOwn = Boolean(initiator && addressesMatch(initiator.account, pubkey))
+            if (isOwn && initiator) {
+              group.unshift(initiator)
+              Object.assign(addressBook, result.address_book ?? {})
+            } else {
+              this.traceNotOwnCache.add(`${pubkey}:${traceId}`)
+            }
+            return isOwn
+          } catch {
+            // Degrades to emitting the page legs as-is
+            return false
+          }
+        })()
+
+        if (!isOwnTrace) continue
+
+        const initiator = group.find(t => t.hash === traceId)
+        if (!initiator) continue
+
+        const mayBeSliced =
+          !initiatorInPage || BigInt(initiator.lt) + TRACE_COMPLETION_LT_SPAN > pageMaxLt
+
+        if (!mayBeSliced) continue
+
         try {
-          const result = await this.httpApiRequest<TonApiTxResponse>(
-            `/api/v3/transactions?hash=${encodeURIComponent(traceId)}&limit=1`,
-          )
-          const initiator = result.transactions?.[0]
-          if (initiator && addressesMatch(initiator.account, pubkey)) {
-            txsByTrace[traceId].unshift(initiator)
-            Object.assign(addressBook, result.address_book ?? {})
+          const traceTxs = await this.fetchTraceTxs(pubkey, initiator.lt, traceId)
+          if (traceTxs.txs.length > 0) {
+            txsByTrace[traceId] = traceTxs.txs
+            Object.assign(addressBook, traceTxs.addressBook)
           }
         } catch {
-          // Degrades to the legs emitting as standalone rows
+          // Better no row this round than a partial one overwriting a complete row
+          delete txsByTrace[traceId]
         }
       }
 
@@ -793,13 +838,12 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         const owner = traceGroup.find(t => t.hash === traceId) ?? traceGroup[0]
 
         // Externally-initiated txs are keyed by their message hash - the same id broadcast
-        // returns and parseTx uses, so rows upserted at swap time dedupe with history rows
+        // returns and parseTx uses, so rows upserted at swap time overwrite history rows and
+        // vice versa instead of duplicating
         const isExternalInitiated = !owner.in_msg?.source && Boolean(owner.in_msg?.hash)
         const txid = base64ToHex(
           isExternalInitiated && owner.in_msg?.hash ? owner.in_msg.hash : owner.hash,
         )
-
-        if (knownTxIds?.has(txid)) continue
 
         const allTransfers = buildTraceTransfers({
           txs: traceGroup,
@@ -811,10 +855,12 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
           chainId: this.chainId,
         })
 
-        // e.g. an orphaned excess leg whose initiator lives on another page
+        // e.g. a gas-only excess leg of a foreign trace
         if (allTransfers.length === 0) continue
 
         txIds.push(txid)
+
+        if (knownTxIds?.has(txid)) continue
 
         const parsedOwner = parseTonTx(
           resolveAddresses(owner, jettonAddrBook),
@@ -1147,6 +1193,23 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
     }
   }
 
+  private async fetchTraceTxs(
+    pubkey: string,
+    fromLt: string,
+    traceId: string,
+  ): Promise<{ txs: TonTx[]; addressBook: Record<string, { user_friendly: string }> }> {
+    const endLt = (BigInt(fromLt) + TRACE_LT_SEARCH_RANGE).toString()
+    const result = await this.httpApiRequest<TonApiTxResponse>(
+      `/api/v3/transactions?account=${encodeURIComponent(
+        pubkey,
+      )}&start_lt=${fromLt}&end_lt=${endLt}&sort=asc&limit=20`,
+    )
+    return {
+      txs: (result.transactions ?? []).filter(t => (t.trace_id ?? t.hash) === traceId),
+      addressBook: result.address_book ?? {},
+    }
+  }
+
   private async fetchJettonTransfers(
     pubkey: string,
     startLt: string,
@@ -1230,23 +1293,17 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       const endLt = (BigInt(tx.lt) + TRACE_LT_SEARCH_RANGE).toString()
 
       const [traceTxResult, jettonData] = await Promise.all([
-        this.httpApiRequest<TonApiTxResponse>(
-          `/api/v3/transactions?account=${encodeURIComponent(pubkey)}&start_lt=${
-            tx.lt
-          }&end_lt=${endLt}&sort=asc&limit=20`,
-        ),
+        this.fetchTraceTxs(pubkey, tx.lt, traceId),
         this.fetchJettonTransfers(pubkey, tx.lt, endLt),
       ])
 
       const addressBook = {
         ...(txResult.address_book ?? {}),
-        ...(traceTxResult.address_book ?? {}),
+        ...traceTxResult.addressBook,
         ...jettonData.address_book,
       }
 
-      const traceTxs = (traceTxResult.transactions ?? []).filter(
-        t => (t.trace_id ?? t.hash) === traceId,
-      )
+      const traceTxs = traceTxResult.txs
       const primaryTx = traceTxs[0] ?? tx
 
       const txsToProcess = traceTxs.length > 0 ? traceTxs : [tx]

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -676,11 +676,29 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         }
       }
 
+      // Group by trace so a swap is a single transaction carrying all its legs (jetton send +
+      // native payout), matching parseTx, rather than disconnected send and receive rows
+      const txsByTrace: Record<string, TonTx[]> = {}
+      for (const tx of data.transactions) {
+        const traceId = tx.trace_id ?? tx.hash
+        ;(txsByTrace[traceId] ??= []).push(tx)
+      }
+
       const transactions: Transaction[] = []
       const txIds: string[] = []
 
       for (const tx of data.transactions) {
-        const txid = base64ToHex(tx.hash)
+        const traceId = tx.trace_id ?? tx.hash
+        const traceGroup = txsByTrace[traceId] ?? [tx]
+        const isTraceOwner = jettonOwnerTx[traceId] === tx.hash
+
+        // Absorbed into the trace owner's row
+        if (!isTraceOwner && traceGroup.length > 1) continue
+
+        // Externally-initiated txs are keyed by their message hash - the same id broadcast
+        // returns and parseTx uses, so rows upserted at swap time dedupe with history rows
+        const isExternalInitiated = !tx.in_msg?.source && Boolean(tx.in_msg?.hash)
+        const txid = base64ToHex(isExternalInitiated && tx.in_msg?.hash ? tx.in_msg.hash : tx.hash)
 
         if (knownTxIds?.has(txid)) continue
 
@@ -689,28 +707,49 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         const normalizedTx = resolveAddresses(tx, addressBook)
         const parsedTx = parseTonTx(normalizedTx, pubkey, txid, this.assetId, this.chainId)
 
-        const traceId = tx.trace_id ?? tx.hash
-        const shouldAttachJettons = jettonOwnerTx[traceId] === tx.hash
-        const jettonTransfers = shouldAttachJettons
-          ? buildJettonTransfers(
-              jettonData.jetton_transfers,
-              traceId,
-              pubkey,
-              jettonAddrBook,
-              this.chainId,
-            )
-          : []
+        const jettonTransfers = buildJettonTransfers(
+          jettonData.jetton_transfers,
+          traceId,
+          pubkey,
+          jettonAddrBook,
+          this.chainId,
+        )
 
         const hasJettonSends = jettonTransfers.some(t => t.type === TransferType.Send)
         const hasJettonReceives = jettonTransfers.some(t => t.type === TransferType.Receive)
-        const nativeTransfers = parsedTx.transfers.filter(t => {
-          if (hasJettonSends && t.type === TransferType.Send) return false
-          if (hasJettonReceives && t.type === TransferType.Receive) return false
-          return true
-        })
+
+        const seen = new Set<string>()
+        const nativeTransfers: TxTransfer[] = []
+        for (const traceTx of traceGroup) {
+          const parsed =
+            traceTx === tx
+              ? parsedTx
+              : parseTonTx(
+                  resolveAddresses(traceTx, addressBook),
+                  pubkey,
+                  txid,
+                  this.assetId,
+                  this.chainId,
+                )
+          for (const transfer of parsed.transfers) {
+            if (hasJettonSends && transfer.type === TransferType.Send) continue
+            if (hasJettonReceives && transfer.type === TransferType.Receive) continue
+            const key = `${transfer.assetId}-${transfer.from[0]}-${transfer.to[0]}-${transfer.value}-${transfer.type}`
+            if (seen.has(key)) continue
+            seen.add(key)
+            nativeTransfers.push(transfer)
+          }
+        }
+
         const allTransfers = [...nativeTransfers, ...jettonTransfers]
+        const anyAborted = traceGroup.some(t => t.description?.aborted === true)
+        const anyActionFailed = traceGroup.some(t => t.description?.action?.success === false)
+        const status = anyAborted || anyActionFailed ? TxStatus.Failed : TxStatus.Confirmed
+
         transactions.push({
           ...parsedTx,
+          status,
+          confirmations: status === TxStatus.Confirmed ? 1 : 0,
           transfers: allTransfers,
         })
       }

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -182,19 +182,48 @@ export const buildJettonTransfers = (
   return transfers
 }
 
-// Native TON swapped through ston.fi routes travels wrapped as proxy TON - the wallet message
-// value stacks the forward gas budget on top of the swapped amount (partially refunded later as
-// excess), while the proxy jetton row the transfer builder skips carries the actual value
-export const applyProxyTonAmounts = (
-  nativeTransfers: TxTransfer[],
-  jettonTransfers: JettonTransferRecord[],
-  traceId: string,
-  pubkey: string,
-  addressBook: Record<string, { user_friendly: string }>,
-): TxTransfer[] => {
+// Merges all of a trace's transfers on this account into swap-shaped legs. Raw message values
+// misstate swap amounts for native TON: sell-side envelopes stack the forward gas budget on top
+// of the swapped amount, and dex payouts bundle the gas refund into the payout. The actual value
+// comes from the proxy TON jetton row where one exists (ston.fi wraps native TON), and from the
+// net native flow across the trace otherwise.
+export const buildTraceTransfers = ({
+  txs,
+  jettonTransfers,
+  traceId,
+  pubkey,
+  addressBook,
+  assetId,
+  chainId,
+}: {
+  txs: TonTx[]
+  jettonTransfers: JettonTransferRecord[]
+  traceId: string
+  pubkey: string
+  addressBook: Record<string, { user_friendly: string }>
+  assetId: AssetId
+  chainId: ChainId
+}): TxTransfer[] => {
+  const jetton = buildJettonTransfers(jettonTransfers, traceId, pubkey, addressBook, chainId)
+
+  const seen = new Set<string>()
+  const native: TxTransfer[] = []
+  for (const tx of txs) {
+    const parsed = parseTonTx(resolveAddresses(tx, addressBook), pubkey, '', assetId, chainId)
+    for (const transfer of parsed.transfers) {
+      const key = `${transfer.assetId}-${transfer.from[0]}-${transfer.to[0]}-${transfer.value}-${transfer.type}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      native.push(transfer)
+    }
+  }
+
+  // Plain native transfers keep their per-leg values
+  if (jetton.length === 0) return native
+
   const friendly = (addr: string) => addressBook[addr]?.user_friendly ?? addr
 
-  const amounts: Partial<Record<TransferType, string>> = {}
+  const proxyAmounts: Partial<Record<TransferType, string>> = {}
   for (const transfer of jettonTransfers) {
     if (transfer.trace_id !== traceId) continue
     if (!transfer.source || !transfer.destination || !transfer.amount || !transfer.jetton_master)
@@ -202,20 +231,42 @@ export const applyProxyTonAmounts = (
     if (!isProxyTon(friendly(transfer.jetton_master))) continue
 
     if (addressesMatch(friendly(transfer.source), pubkey)) {
-      amounts[TransferType.Send] = transfer.amount
+      proxyAmounts[TransferType.Send] = transfer.amount
     }
     if (addressesMatch(friendly(transfer.destination), pubkey)) {
-      amounts[TransferType.Receive] = transfer.amount
+      proxyAmounts[TransferType.Receive] = transfer.amount
     }
   }
 
-  return nativeTransfers.map(transfer => {
-    const amount = amounts[transfer.type]
-    if (!amount) return transfer
-    // Only an unambiguous single leg per direction is overridden
-    if (nativeTransfers.filter(t => t.type === transfer.type).length !== 1) return transfer
-    return { ...transfer, value: amount }
-  })
+  // Net native flow across the trace, gas envelopes and excess refunds included (fees excluded)
+  let net = 0n
+  for (const tx of txs) {
+    if (tx.in_msg?.value && tx.in_msg.source) net += BigInt(tx.in_msg.value)
+    for (const outMsg of tx.out_msgs ?? []) {
+      if (outMsg.value) net -= BigInt(outMsg.value)
+    }
+  }
+
+  const hasJettonSend = jetton.some(t => t.type === TransferType.Send)
+  const hasJettonReceive = jetton.some(t => t.type === TransferType.Receive)
+  const sends = native.filter(t => t.type === TransferType.Send)
+  const receives = native.filter(t => t.type === TransferType.Receive)
+
+  const nativeLegs: TxTransfer[] = []
+
+  if (proxyAmounts[TransferType.Send] && sends.length === 1) {
+    nativeLegs.push({ ...sends[0], value: proxyAmounts[TransferType.Send] })
+  } else if (net < 0n && hasJettonReceive && !hasJettonSend && sends.length > 0) {
+    nativeLegs.push({ ...sends[0], value: (-net).toString() })
+  }
+
+  if (proxyAmounts[TransferType.Receive] && receives.length === 1) {
+    nativeLegs.push({ ...receives[0], value: proxyAmounts[TransferType.Receive] })
+  } else if (net > 0n && hasJettonSend && !hasJettonReceive && receives.length > 0) {
+    nativeLegs.push({ ...receives[0], value: net.toString() })
+  }
+
+  return [...nativeLegs, ...jetton]
 }
 
 export const parseTonTx = (
@@ -692,9 +743,41 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         }
       }
 
-      const addressBook = data.address_book ?? {}
+      const addressBook = { ...(data.address_book ?? {}) }
 
-      const lts = data.transactions.map(tx => BigInt(tx.lt))
+      // Group by trace so a swap is a single transaction carrying all its legs (jetton send +
+      // native payout), matching parseTx, rather than disconnected send and receive rows
+      const txsByTrace: Record<string, TonTx[]> = {}
+      for (const tx of data.transactions) {
+        const traceId = tx.trace_id ?? tx.hash
+        ;(txsByTrace[traceId] ??= []).push(tx)
+      }
+
+      // Trace legs whose initiator fell on another page would otherwise emit as disconnected
+      // rows - fetch the initiator so the trace still merges into a single row under its id
+      const pageHashes = new Set(data.transactions.map(tx => tx.hash))
+      const orphanTraceIds = Object.entries(txsByTrace)
+        .filter(([traceId, group]) => group.length > 1 && !pageHashes.has(traceId))
+        .map(([traceId]) => traceId)
+
+      for (const traceId of orphanTraceIds) {
+        try {
+          const result = await this.httpApiRequest<TonApiTxResponse>(
+            `/api/v3/transactions?hash=${encodeURIComponent(traceId)}&limit=1`,
+          )
+          const initiator = result.transactions?.[0]
+          if (initiator && addressesMatch(initiator.account, pubkey)) {
+            txsByTrace[traceId].unshift(initiator)
+            Object.assign(addressBook, result.address_book ?? {})
+          }
+        } catch {
+          // Degrades to the legs emitting as standalone rows
+        }
+      }
+
+      const lts = Object.values(txsByTrace)
+        .flat()
+        .map(tx => BigInt(tx.lt))
       const minLt = lts.reduce((a, b) => (a < b ? a : b)).toString()
       const maxLt = lts.reduce((a, b) => (a > b ? a : b)).toString()
 
@@ -706,95 +789,50 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
 
       const jettonAddrBook = { ...addressBook, ...jettonData.address_book }
 
-      const jettonOwnerTx: Record<string, string> = {}
-      for (const tx of data.transactions) {
-        const traceId = tx.trace_id ?? tx.hash
-        const isInitiator = tx.hash === traceId
-        if (!jettonOwnerTx[traceId] || isInitiator) {
-          jettonOwnerTx[traceId] = tx.hash
-        }
-      }
-
-      // Group by trace so a swap is a single transaction carrying all its legs (jetton send +
-      // native payout), matching parseTx, rather than disconnected send and receive rows
-      const txsByTrace: Record<string, TonTx[]> = {}
-      for (const tx of data.transactions) {
-        const traceId = tx.trace_id ?? tx.hash
-        ;(txsByTrace[traceId] ??= []).push(tx)
-      }
-
       const transactions: Transaction[] = []
       const txIds: string[] = []
 
-      for (const tx of data.transactions) {
-        const traceId = tx.trace_id ?? tx.hash
-        const traceGroup = txsByTrace[traceId] ?? [tx]
-        const isTraceOwner = jettonOwnerTx[traceId] === tx.hash
-
-        // Absorbed into the trace owner's row
-        if (!isTraceOwner && traceGroup.length > 1) continue
+      for (const [traceId, traceGroup] of Object.entries(txsByTrace)) {
+        const owner = traceGroup.find(t => t.hash === traceId) ?? traceGroup[0]
 
         // Externally-initiated txs are keyed by their message hash - the same id broadcast
         // returns and parseTx uses, so rows upserted at swap time dedupe with history rows
-        const isExternalInitiated = !tx.in_msg?.source && Boolean(tx.in_msg?.hash)
-        const txid = base64ToHex(isExternalInitiated && tx.in_msg?.hash ? tx.in_msg.hash : tx.hash)
+        const isExternalInitiated = !owner.in_msg?.source && Boolean(owner.in_msg?.hash)
+        const txid = base64ToHex(
+          isExternalInitiated && owner.in_msg?.hash ? owner.in_msg.hash : owner.hash,
+        )
 
         if (knownTxIds?.has(txid)) continue
 
-        txIds.push(txid)
-
-        const normalizedTx = resolveAddresses(tx, addressBook)
-        const parsedTx = parseTonTx(normalizedTx, pubkey, txid, this.assetId, this.chainId)
-
-        const jettonTransfers = buildJettonTransfers(
-          jettonData.jetton_transfers,
+        const allTransfers = buildTraceTransfers({
+          txs: traceGroup,
+          jettonTransfers: jettonData.jetton_transfers,
           traceId,
           pubkey,
-          jettonAddrBook,
+          addressBook: jettonAddrBook,
+          assetId: this.assetId,
+          chainId: this.chainId,
+        })
+
+        // e.g. an orphaned excess leg whose initiator lives on another page
+        if (allTransfers.length === 0) continue
+
+        txIds.push(txid)
+
+        const parsedOwner = parseTonTx(
+          resolveAddresses(owner, jettonAddrBook),
+          pubkey,
+          txid,
+          this.assetId,
           this.chainId,
         )
 
-        const hasJettonSends = jettonTransfers.some(t => t.type === TransferType.Send)
-        const hasJettonReceives = jettonTransfers.some(t => t.type === TransferType.Receive)
-
-        const seen = new Set<string>()
-        const nativeTransfers: TxTransfer[] = []
-        for (const traceTx of traceGroup) {
-          const parsed =
-            traceTx === tx
-              ? parsedTx
-              : parseTonTx(
-                  resolveAddresses(traceTx, addressBook),
-                  pubkey,
-                  txid,
-                  this.assetId,
-                  this.chainId,
-                )
-          for (const transfer of parsed.transfers) {
-            if (hasJettonSends && transfer.type === TransferType.Send) continue
-            if (hasJettonReceives && transfer.type === TransferType.Receive) continue
-            const key = `${transfer.assetId}-${transfer.from[0]}-${transfer.to[0]}-${transfer.value}-${transfer.type}`
-            if (seen.has(key)) continue
-            seen.add(key)
-            nativeTransfers.push(transfer)
-          }
-        }
-
-        const adjustedNativeTransfers = applyProxyTonAmounts(
-          nativeTransfers,
-          jettonData.jetton_transfers,
-          traceId,
-          pubkey,
-          jettonAddrBook,
-        )
-
-        const allTransfers = [...adjustedNativeTransfers, ...jettonTransfers]
         const anyAborted = traceGroup.some(t => t.description?.aborted === true)
         const anyActionFailed = traceGroup.some(t => t.description?.action?.success === false)
         const status = anyAborted || anyActionFailed ? TxStatus.Failed : TxStatus.Confirmed
 
         transactions.push({
-          ...parsedTx,
+          ...parsedOwner,
           status,
           confirmations: status === TxStatus.Confirmed ? 1 : 0,
           transfers: allTransfers,
@@ -1209,49 +1247,23 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         ...jettonData.address_book,
       }
 
-      const jettonTransfers = buildJettonTransfers(
-        jettonData.jetton_transfers,
-        traceId,
-        pubkey,
-        addressBook,
-        this.chainId,
-      )
-
-      const hasJettonSends = jettonTransfers.some(t => t.type === TransferType.Send)
-      const hasJettonReceives = jettonTransfers.some(t => t.type === TransferType.Receive)
-
-      const nativeTransfers: TxTransfer[] = []
-
       const traceTxs = (traceTxResult.transactions ?? []).filter(
         t => (t.trace_id ?? t.hash) === traceId,
       )
       const primaryTx = traceTxs[0] ?? tx
 
       const txsToProcess = traceTxs.length > 0 ? traceTxs : [tx]
-      const seen = new Set<string>()
 
-      for (const traceTx of txsToProcess) {
-        const normalizedTraceTx = resolveAddresses(traceTx, addressBook)
-        const parsed = parseTonTx(normalizedTraceTx, pubkey, txid, this.assetId, this.chainId)
-        for (const transfer of parsed.transfers) {
-          if (hasJettonSends && transfer.type === TransferType.Send) continue
-          if (hasJettonReceives && transfer.type === TransferType.Receive) continue
-          const key = `${transfer.assetId}-${transfer.from[0]}-${transfer.to[0]}-${transfer.value}-${transfer.type}`
-          if (seen.has(key)) continue
-          seen.add(key)
-          nativeTransfers.push(transfer)
-        }
-      }
-
-      const adjustedNativeTransfers = applyProxyTonAmounts(
-        nativeTransfers,
-        jettonData.jetton_transfers,
+      const allTransfers = buildTraceTransfers({
+        txs: txsToProcess,
+        jettonTransfers: jettonData.jetton_transfers,
         traceId,
         pubkey,
         addressBook,
-      )
+        assetId: this.assetId,
+        chainId: this.chainId,
+      })
 
-      const allTransfers = [...adjustedNativeTransfers, ...jettonTransfers]
       const anyAborted = txsToProcess.some(t => t.description?.aborted === true)
       const anyActionFailed = txsToProcess.some(t => t.description?.action?.success === false)
       const status = anyAborted || anyActionFailed ? TxStatus.Failed : TxStatus.Confirmed

--- a/packages/chain-adapters/src/ton/types.ts
+++ b/packages/chain-adapters/src/ton/types.ts
@@ -93,6 +93,17 @@ export type TonApiTxResponse = {
   address_book?: Record<string, { user_friendly: string }>
 }
 
+export type TonTrace = {
+  trace_id: string
+  is_incomplete?: boolean
+  transactions?: Record<string, TonTx>
+}
+
+export type TonTracesResponse = {
+  traces?: TonTrace[]
+  address_book?: Record<string, { user_friendly: string }>
+}
+
 export type Account = TonAccount
 export type FeeData = TonFeeData
 export type GetFeeDataInput = TonGetFeeDataInput

--- a/packages/chain-adapters/src/ton/types.ts
+++ b/packages/chain-adapters/src/ton/types.ts
@@ -47,6 +47,7 @@ export type TonSignTx = {
 }
 
 export type TonTxMessage = {
+  hash?: string
   source?: string
   destination?: string
   value?: string

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "18.1.0",
+  "version": "18.1.1",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swapper/src/swappers/StonfiSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/StonfiSwapper/endpoints.ts
@@ -1,5 +1,5 @@
 import { toAddressNList } from '@shapeshiftoss/chain-adapters'
-import { TxStatus } from '@shapeshiftoss/unchained-client'
+import { TransferType, TxStatus } from '@shapeshiftoss/unchained-client'
 import { Blockchain } from '@ston-fi/omniston-sdk'
 
 import type { SwapperApi, TradeStatus } from '../../types'
@@ -128,6 +128,24 @@ export const stonfiApi: SwapperApi = {
 
     const { quoteId } = getSwapMetadata(swap.metadata.swapperMetadata, 'stonfi')
 
+    // Settlement precedes toncenter's jetton indexer, and confirmed rows are never re-parsed -
+    // hold confirmation until the receive leg is visible so the confirmed-time parse and upsert
+    // carries both legs of the swap
+    const hasVisibleReceiveLeg = async (): Promise<boolean> => {
+      const adapter = assertGetTonChainAdapter(swap.sellAsset.chainId)
+      const sellAddress = swap.sellAccountId.split(':')[2] ?? ''
+      const addresses = new Set(
+        [sellAddress, swap.receiveAddress].filter((address): address is string => Boolean(address)),
+      )
+
+      for (const address of addresses) {
+        const tx = await adapter.parseTx(sellTxHash, address)
+        if (tx.transfers.some(transfer => transfer.type === TransferType.Receive)) return true
+      }
+
+      return false
+    }
+
     try {
       const tradeStatus = await waitForFirstTradeStatus(
         {
@@ -192,19 +210,27 @@ export const stonfiApi: SwapperApi = {
       if (statusOneOf.tradeSettled) {
         const result = statusOneOf.tradeSettled.result
 
-        if (result === 'TRADE_RESULT_FULLY_FILLED') {
-          return {
+        if (result === 'TRADE_RESULT_FULLY_FILLED' || result === 'TRADE_RESULT_PARTIALLY_FILLED') {
+          const settled: TradeStatus = {
             status: TxStatus.Confirmed,
             buyTxHash: sellTxHash,
-            message: undefined,
+            message:
+              result === 'TRADE_RESULT_PARTIALLY_FILLED'
+                ? 'trade.statuses.partiallyFilled'
+                : undefined,
           }
-        }
 
-        if (result === 'TRADE_RESULT_PARTIALLY_FILLED') {
-          return {
-            status: TxStatus.Confirmed,
-            buyTxHash: sellTxHash,
-            message: 'trade.statuses.partiallyFilled',
+          try {
+            if (await hasVisibleReceiveLeg()) return settled
+
+            return {
+              status: TxStatus.Pending,
+              buyTxHash: undefined,
+              message: 'trade.statuses.receivingFunds',
+            }
+          } catch {
+            // Indexer/API failure must not block completion
+            return settled
           }
         }
 

--- a/packages/swapper/src/swappers/StonfiSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/StonfiSwapper/endpoints.ts
@@ -228,8 +228,13 @@ export const stonfiApi: SwapperApi = {
               buyTxHash: undefined,
               message: 'trade.statuses.receivingFunds',
             }
-          } catch {
+          } catch (error) {
             // Indexer/API failure must not block completion
+            console.error('[Stonfi] Error verifying settlement receive leg:', {
+              sellTxHash,
+              result,
+              error,
+            })
             return settled
           }
         }

--- a/packages/swapper/src/swappers/StonfiSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/StonfiSwapper/endpoints.ts
@@ -147,17 +147,15 @@ export const stonfiApi: SwapperApi = {
 
       const statusOneOf = tradeStatus.status
 
+      // While the trade is in flight the wallet tx may already be confirmed, but the payout leg
+      // hasn't landed - confirming here would parse and upsert a trace without the receive, so
+      // completion waits for settlement
       if (
         statusOneOf.awaitingTransfer ||
         statusOneOf.transferring ||
         statusOneOf.swapping ||
         statusOneOf.receivingFunds
       ) {
-        const chainStatus = await checkTxStatusViaChainAdapter()
-        if (chainStatus.status === TxStatus.Confirmed) {
-          return chainStatus
-        }
-
         if (statusOneOf.awaitingTransfer) {
           return {
             status: TxStatus.Pending,

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -20,7 +20,6 @@ export const clearTxHistoryMigrations = {
   6: clearTxHistory,
   7: clearTxHistory,
   8: clearTxHistory,
-  9: clearTxHistory,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
 export const clearOpportunitiesMigrations = {

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -19,6 +19,8 @@ export const clearTxHistoryMigrations = {
   5: clearTxHistory,
   6: clearTxHistory,
   7: clearTxHistory,
+  // ton history rows re-keyed to message hashes + trace-merged
+  8: clearTxHistory,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
 export const clearOpportunitiesMigrations = {

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -19,9 +19,7 @@ export const clearTxHistoryMigrations = {
   5: clearTxHistory,
   6: clearTxHistory,
   7: clearTxHistory,
-  // ton history rows re-keyed to message hashes + trace-merged
   8: clearTxHistory,
-  // ton swap rows upserted before the jetton indexer caught up are frozen send-only
   9: clearTxHistory,
 } as unknown as Omit<MigrationManifest, '_persist'>
 

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -21,6 +21,8 @@ export const clearTxHistoryMigrations = {
   7: clearTxHistory,
   // ton history rows re-keyed to message hashes + trace-merged
   8: clearTxHistory,
+  // ton swap rows upserted before the jetton indexer caught up are frozen send-only
+  9: clearTxHistory,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
 export const clearOpportunitiesMigrations = {


### PR DESCRIPTION
## Description

TON transaction history misrepresented swaps in every dimension: rows showed only the sent leg, the payout appeared (if at all) as a disconnected "receive" row under an unrelated txid, displayed native amounts were message envelopes rather than swapped values, and Ston.fi swaps reported complete before funds arrived. Root causes and fixes:

**`TRACE_LT_SEARCH_RANGE` was 1000 — no downstream leg was ever findable.** Logical time advances ~1e6/second and dex payout/excess legs land tens of millions of lts after the initiator, so `parseTx`'s trace merge could never contain a receive. Widened to 1e9 (search bound only; results are filtered by `trace_id`).

**Ston.fi confirmation waits for the receive leg.** `checkTradeStatus` short-circuited to Confirmed on wallet-tx confirmation while Omniston still reported the trade in flight — and the confirmed-time `parseTx` upsert is never re-parsed, freezing a send-only row. Completion now requires `tradeSettled` *and* a receive transfer visible in the parsed trace (sell or receive account, covering cross-account swaps). Indexer/API failures confirm rather than block; the tracking-timeout fallback is unchanged.

**History rows are trace-merged, complete-by-construction, and keyed by broadcast hash.** `getTxHistory` groups the page by `trace_id` and emits one row per trace via the same `buildTraceTransfers` used by `parseTx`. Because pagination can slice through a trace, ownership of every out-of-page trace is resolved (one memoized lookup; not-own verdicts cached) and own traces re-fetch their full lt window whenever the page cannot guarantee all legs are present — a partial group is never emitted, so re-emission can only overwrite a row with an identical or better one. Externally-initiated rows are keyed by their message hash (the id broadcast returns and `parseTx` uses), so swap-time upserts and history rows share one identity instead of duplicating. Known txids are now included in the returned `txIds`, activating the history slice's early-stop (TON previously re-paginated the full history every hydration).

**Displayed native amounts are the actual swapped values.** Raw message values misstate native swap legs: sell-side envelopes stack the forward-gas budget on top of the swapped amount, and dex payouts bundle the gas refund into the payout (a 0.5 USDT→TON swap displayed +0.63 TON for a ~0.35 swap). Swap rows now use the proxy-TON jetton amount where one exists (summed per direction — split routes move the wrapped amount in multiple legs), and the net native flow across the trace otherwise. Plain transfers keep per-leg values; jetton↔jetton swaps show no phantom gas leg; gas-only foreign legs no longer emit empty rows.

**Persisted tx history cleared** (migration 8) since row identities and shapes changed.

## Issue (if applicable)

closes #

## Risk

Low-medium, TON-only. Ston.fi swaps now confirm at settlement plus receive-leg visibility (~seconds later than the previous premature confirm). History hydration performs up to a few extra queued toncenter requests per page only when a trace is actually sliced by a page boundary or too fresh to be provably complete. One-time tx-history re-hydration for all users from the migration. No transaction construction, signing, or broadcast changes.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

TON transaction history display and Ston.fi swap status timing only.

## Testing

### Engineering

- Live end-to-end of the real `getTxHistory` with forced page slicing (pageSize 5) against an account holding every observed shape: split traces emit **identical complete rows on both adjacent pages** (idempotent overwrite); single-pool native sell shows the exact pTON trade amount (0.3597, not the 0.4947 envelope); split-route sell shows the summed amount (0.7194, not the 0.8544 envelope); jetton→native shows net flow (0.3505, not the 0.6315 payout+refund); jetton→jetton shows both jetton legs only; plain jetton sends hide envelope/excess; foreign transfers and failed NFT ops unchanged.
- Live `parseTx` against the same swaps by broadcast hash returns the same rows — verified byte-equal txid identity between broadcast hash, `parseTx`, and history rows.
- Net-flow math re-derived by hand from raw message values (payout + excess − envelope).
- A live stuck ton→jusdc swap confirmed via the receive gate immediately after the lt-range fix.
- TON adapter tests: 45 passing.

### Operations

- Swap on TON (native→jetton, jetton→native, jetton→jetton via Ston.fi): status should reach complete only once funds arrive, and history should show **one** row per swap with the actual sent/received amounts — including after reload and deep pagination.
- Plain TON/jetton sends and receives display unchanged.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TON transaction history accuracy by grouping complete traces, deduplicating transfers, and calculating swap-related native asset flows more reliably.
  - Enhanced transaction status reporting across multi-step TON transactions.
  - Prevented swaps from being marked complete until received funds are detected.
  - Improved handling of partially filled swaps and temporary indexing errors.
  - Updated transaction history migration handling to ensure older saved data remains compatible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->