### PR TITLE
perf(ton): faster status-to-balance propagation after swaps

### DIFF
--- a/packages/chain-adapters/src/ton/TonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.test.ts
@@ -1,7 +1,7 @@
 import { tonAssetId, tonChainId } from '@shapeshiftoss/caip'
 import { TransferType, TxStatus } from '@shapeshiftoss/unchained-client'
 import { base64ToHex, hexToBase64 } from '@shapeshiftoss/utils'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
 import {
   addressesMatch,
@@ -665,59 +665,6 @@ describe('TonChainAdapter', () => {
     it('should return ton asset ID', () => {
       const adapter = new ChainAdapter({ rpcUrl: 'https://toncenter.com/api/v2/jsonRPC' })
       expect(adapter.getFeeAssetId()).toBe(tonAssetId)
-    })
-  })
-
-  describe('parseTx cache', () => {
-    const HASH = 'a'.repeat(64)
-    const TTL_MS = 4_000
-
-    const makeAdapter = () => {
-      const adapter = new ChainAdapter({ rpcUrl: 'https://toncenter.com/api/v2/jsonRPC' })
-      const impl = vi.spyOn(
-        adapter as unknown as { parseTxImpl: (hash: string, pubkey: string) => Promise<unknown> },
-        'parseTxImpl',
-      )
-      return { adapter, impl }
-    }
-
-    afterEach(() => {
-      vi.useRealTimers()
-    })
-
-    it('should reuse a pending parse past the ttl and start the ttl at resolution', async () => {
-      vi.useFakeTimers()
-      const { adapter, impl } = makeAdapter()
-
-      let resolve!: (tx: unknown) => void
-      impl.mockReturnValue(new Promise(r => (resolve = r)))
-
-      const first = adapter.parseTx(HASH, USER_BOUNCEABLE)
-      vi.advanceTimersByTime(TTL_MS * 3)
-      expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).toBe(first)
-      expect(impl).toHaveBeenCalledTimes(1)
-
-      resolve({ txid: HASH })
-      await first
-
-      vi.advanceTimersByTime(TTL_MS - 1_000)
-      expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).toBe(first)
-      expect(impl).toHaveBeenCalledTimes(1)
-
-      vi.advanceTimersByTime(2_000)
-      impl.mockResolvedValue({ txid: HASH })
-      await expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).resolves.toMatchObject({ txid: HASH })
-      expect(impl).toHaveBeenCalledTimes(2)
-    })
-
-    it('should drop a rejected parse so the next call retries', async () => {
-      const { adapter, impl } = makeAdapter()
-
-      impl.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({ txid: HASH })
-
-      await expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).rejects.toThrow('boom')
-      await expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).resolves.toMatchObject({ txid: HASH })
-      expect(impl).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/chain-adapters/src/ton/TonChainAdapter.test.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.test.ts
@@ -1,7 +1,7 @@
 import { tonAssetId, tonChainId } from '@shapeshiftoss/caip'
 import { TransferType, TxStatus } from '@shapeshiftoss/unchained-client'
 import { base64ToHex, hexToBase64 } from '@shapeshiftoss/utils'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   addressesMatch,
@@ -665,6 +665,59 @@ describe('TonChainAdapter', () => {
     it('should return ton asset ID', () => {
       const adapter = new ChainAdapter({ rpcUrl: 'https://toncenter.com/api/v2/jsonRPC' })
       expect(adapter.getFeeAssetId()).toBe(tonAssetId)
+    })
+  })
+
+  describe('parseTx cache', () => {
+    const HASH = 'a'.repeat(64)
+    const TTL_MS = 4_000
+
+    const makeAdapter = () => {
+      const adapter = new ChainAdapter({ rpcUrl: 'https://toncenter.com/api/v2/jsonRPC' })
+      const impl = vi.spyOn(
+        adapter as unknown as { parseTxImpl: (hash: string, pubkey: string) => Promise<unknown> },
+        'parseTxImpl',
+      )
+      return { adapter, impl }
+    }
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it('should reuse a pending parse past the ttl and start the ttl at resolution', async () => {
+      vi.useFakeTimers()
+      const { adapter, impl } = makeAdapter()
+
+      let resolve!: (tx: unknown) => void
+      impl.mockReturnValue(new Promise(r => (resolve = r)))
+
+      const first = adapter.parseTx(HASH, USER_BOUNCEABLE)
+      vi.advanceTimersByTime(TTL_MS * 3)
+      expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).toBe(first)
+      expect(impl).toHaveBeenCalledTimes(1)
+
+      resolve({ txid: HASH })
+      await first
+
+      vi.advanceTimersByTime(TTL_MS - 1_000)
+      expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).toBe(first)
+      expect(impl).toHaveBeenCalledTimes(1)
+
+      vi.advanceTimersByTime(2_000)
+      impl.mockResolvedValue({ txid: HASH })
+      await expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).resolves.toMatchObject({ txid: HASH })
+      expect(impl).toHaveBeenCalledTimes(2)
+    })
+
+    it('should drop a rejected parse so the next call retries', async () => {
+      const { adapter, impl } = makeAdapter()
+
+      impl.mockRejectedValueOnce(new Error('boom')).mockResolvedValueOnce({ txid: HASH })
+
+      await expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).rejects.toThrow('boom')
+      await expect(adapter.parseTx(HASH, USER_BOUNCEABLE)).resolves.toMatchObject({ txid: HASH })
+      expect(impl).toHaveBeenCalledTimes(2)
     })
   })
 })

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -1238,10 +1238,11 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
     }
   }
 
-  async parseTx(txHashOrTx: unknown, pubkey: string): Promise<Transaction> {
+  parseTx(txHashOrTx: unknown, pubkey: string): Promise<Transaction> {
     if (typeof txHashOrTx !== 'string') {
       throw new Error(`[TON] parseTx expects a string tx hash, got ${typeof txHashOrTx}`)
     }
+
     // status poll, history upsert and balance pipeline all parse the same hash within seconds -
     // a short-lived memo collapses them into one network run
     const cacheKey = `${txHashOrTx}:${pubkey}`
@@ -1267,7 +1268,9 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
       const txid = isHexHash(inputHash) ? inputHash : base64ToHex(inputHash)
 
       const txResult = await this.httpApiRequest<TonApiTxResponse>(
-        `/api/v3/transactionsByMessage?msg_hash=${encodeURIComponent(apiHash)}&direction=in&limit=1`,
+        `/api/v3/transactionsByMessage?msg_hash=${encodeURIComponent(
+          apiHash,
+        )}&direction=in&limit=1`,
       )
 
       const tx = txResult.transactions?.[0]

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -73,8 +73,13 @@ const TRACE_LT_SEARCH_RANGE = 1_000_000_000n
 // Legs of a trace land within this window of its initiator (~5 minutes of logical time)
 const TRACE_COMPLETION_LT_SPAN = 300_000_000n
 const TRACE_BATCH_SIZE = 20
+// Toncenter free tier allows ~1 req/sec; 429s are retried with Retry-After
+const TON_REQUEST_QUEUE_INTERVAL_MS = 1_100
 // Shorter than the 5s status poll interval so each poll still observes fresh chain state
 const PARSE_TX_CACHE_TTL_MS = 4_000
+// TTL starts at resolution - pending parses are reused as-is so a queue backlog can't
+// trigger duplicate network runs for the same hash
+type ParseTxCacheEntry = { resolvedAt?: number; promise: Promise<Transaction> }
 const TON_HASH_HEX_LENGTH = 64
 export const isHexHash = (str: string): boolean => {
   return str.length === TON_HASH_HEX_LENGTH && /^[0-9a-f]+$/i.test(str)
@@ -385,14 +390,13 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
   protected readonly rpcUrl: string
   private requestQueue: PQueue
   private traceNotOwnCache = new Set<string>()
-  private parseTxCache = new Map<string, { at: number; promise: Promise<Transaction> }>()
+  private parseTxCache = new Map<string, ParseTxCacheEntry>()
 
   constructor(args: ChainAdapterArgs) {
     this.rpcUrl = args.rpcUrl
-    // Toncenter free tier allows ~1 req/sec; 429s are retried with Retry-After
     this.requestQueue = new PQueue({
       intervalCap: 1,
-      interval: 1100,
+      interval: TON_REQUEST_QUEUE_INTERVAL_MS,
       concurrency: 1,
     })
   }
@@ -1247,19 +1251,33 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
     // a short-lived memo collapses them into one network run
     const cacheKey = `${txHashOrTx}:${pubkey}`
     const cached = this.parseTxCache.get(cacheKey)
-    if (cached && Date.now() - cached.at < PARSE_TX_CACHE_TTL_MS) return cached.promise
+    if (
+      cached &&
+      (cached.resolvedAt === undefined || Date.now() - cached.resolvedAt < PARSE_TX_CACHE_TTL_MS)
+    ) {
+      return cached.promise
+    }
 
-    const promise = this.parseTxImpl(txHashOrTx, pubkey)
-    this.parseTxCache.set(cacheKey, { at: Date.now(), promise })
-    promise.catch(() => this.parseTxCache.delete(cacheKey))
+    const entry: ParseTxCacheEntry = { promise: this.parseTxImpl(txHashOrTx, pubkey) }
+    this.parseTxCache.set(cacheKey, entry)
+    entry.promise.then(
+      () => {
+        entry.resolvedAt = Date.now()
+      },
+      () => {
+        if (this.parseTxCache.get(cacheKey) === entry) this.parseTxCache.delete(cacheKey)
+      },
+    )
 
     if (this.parseTxCache.size > 50) {
-      for (const [key, entry] of this.parseTxCache) {
-        if (Date.now() - entry.at >= PARSE_TX_CACHE_TTL_MS) this.parseTxCache.delete(key)
+      for (const [key, e] of this.parseTxCache) {
+        if (e.resolvedAt !== undefined && Date.now() - e.resolvedAt >= PARSE_TX_CACHE_TTL_MS) {
+          this.parseTxCache.delete(key)
+        }
       }
     }
 
-    return promise
+    return entry.promise
   }
 
   private async parseTxImpl(inputHash: string, pubkey: string): Promise<Transaction> {

--- a/packages/chain-adapters/src/ton/TonChainAdapter.ts
+++ b/packages/chain-adapters/src/ton/TonChainAdapter.ts
@@ -73,6 +73,8 @@ const TRACE_LT_SEARCH_RANGE = 1_000_000_000n
 // Legs of a trace land within this window of its initiator (~5 minutes of logical time)
 const TRACE_COMPLETION_LT_SPAN = 300_000_000n
 const TRACE_BATCH_SIZE = 20
+// Shorter than the 5s status poll interval so each poll still observes fresh chain state
+const PARSE_TX_CACHE_TTL_MS = 4_000
 const TON_HASH_HEX_LENGTH = 64
 export const isHexHash = (str: string): boolean => {
   return str.length === TON_HASH_HEX_LENGTH && /^[0-9a-f]+$/i.test(str)
@@ -383,13 +385,14 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
   protected readonly rpcUrl: string
   private requestQueue: PQueue
   private traceNotOwnCache = new Set<string>()
+  private parseTxCache = new Map<string, { at: number; promise: Promise<Transaction> }>()
 
   constructor(args: ChainAdapterArgs) {
     this.rpcUrl = args.rpcUrl
-    // Toncenter free tier: ~1 req/sec, but we use 2s to be safe
+    // Toncenter free tier allows ~1 req/sec; 429s are retried with Retry-After
     this.requestQueue = new PQueue({
       intervalCap: 1,
-      interval: 2000,
+      interval: 1100,
       concurrency: 1,
     })
   }
@@ -1236,34 +1239,49 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
   }
 
   async parseTx(txHashOrTx: unknown, pubkey: string): Promise<Transaction> {
-    try {
-      if (typeof txHashOrTx !== 'string') {
-        throw new Error(`[TON] parseTx expects a string tx hash, got ${typeof txHashOrTx}`)
-      }
-      const inputHash = txHashOrTx
+    if (typeof txHashOrTx !== 'string') {
+      throw new Error(`[TON] parseTx expects a string tx hash, got ${typeof txHashOrTx}`)
+    }
+    // status poll, history upsert and balance pipeline all parse the same hash within seconds -
+    // a short-lived memo collapses them into one network run
+    const cacheKey = `${txHashOrTx}:${pubkey}`
+    const cached = this.parseTxCache.get(cacheKey)
+    if (cached && Date.now() - cached.at < PARSE_TX_CACHE_TTL_MS) return cached.promise
 
+    const promise = this.parseTxImpl(txHashOrTx, pubkey)
+    this.parseTxCache.set(cacheKey, { at: Date.now(), promise })
+    promise.catch(() => this.parseTxCache.delete(cacheKey))
+
+    if (this.parseTxCache.size > 50) {
+      for (const [key, entry] of this.parseTxCache) {
+        if (Date.now() - entry.at >= PARSE_TX_CACHE_TTL_MS) this.parseTxCache.delete(key)
+      }
+    }
+
+    return promise
+  }
+
+  private async parseTxImpl(inputHash: string, pubkey: string): Promise<Transaction> {
+    try {
       const apiHash = isHexHash(inputHash) ? hexToBase64(inputHash) : inputHash
       const txid = isHexHash(inputHash) ? inputHash : base64ToHex(inputHash)
 
-      const msgResult = await this.httpApiRequest<{
-        messages?: {
-          hash: string
-          in_msg_tx_hash?: string
-          source?: string
-          destination?: string
-          value?: string
-          created_at?: string
-        }[]
-      }>(`/api/v3/messages?hash=${encodeURIComponent(apiHash)}`)
+      const txResult = await this.httpApiRequest<TonApiTxResponse>(
+        `/api/v3/transactionsByMessage?msg_hash=${encodeURIComponent(apiHash)}&direction=in&limit=1`,
+      )
 
-      if (!msgResult.messages || msgResult.messages.length === 0) {
-        throw new Error('Message not found')
-      }
+      const tx = txResult.transactions?.[0]
 
-      const msg = msgResult.messages[0]
-      const txHash = msg.in_msg_tx_hash
+      if (!tx) {
+        // Distinguish a known-but-unprocessed message (pending) from an unknown one
+        const msgResult = await this.httpApiRequest<{
+          messages?: { hash: string; in_msg_tx_hash?: string }[]
+        }>(`/api/v3/messages?hash=${encodeURIComponent(apiHash)}`)
 
-      if (!txHash) {
+        if (!msgResult.messages || msgResult.messages.length === 0) {
+          throw new Error('Message not found')
+        }
+
         return {
           txid,
           blockHeight: 0,
@@ -1277,17 +1295,7 @@ export class ChainAdapter implements IChainAdapter<KnownChainIds.TonMainnet> {
         }
       }
 
-      const txResult = await this.httpApiRequest<TonApiTxResponse>(
-        `/api/v3/transactions?hash=${encodeURIComponent(txHash)}&limit=1`,
-      )
-
-      const tx = txResult.transactions?.[0]
-
-      if (!tx) {
-        throw new Error(`Transaction not found: ${txHash}`)
-      }
-
-      const traceId = tx.trace_id ?? txHash
+      const traceId = tx.trace_id ?? tx.hash
       const endLt = (BigInt(tx.lt) + TRACE_LT_SEARCH_RANGE).toString()
 
       const [traceResult, jettonData] = await Promise.all([

--- a/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
@@ -289,7 +289,7 @@ export const useSwapActionSubscriber = () => {
         dispatch(
           getAccount.initiate(
             { accountId: swap.sellAccountId, upsertOnFetch: true },
-            { forceRefetch: true },
+            { forceRefetch: true, subscribe: false },
           ),
         )
 
@@ -297,7 +297,7 @@ export const useSwapActionSubscriber = () => {
           dispatch(
             getAccount.initiate(
               { accountId: swap.buyAccountId, upsertOnFetch: true },
-              { forceRefetch: true },
+              { forceRefetch: true, subscribe: false },
             ),
           )
         }

--- a/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
+++ b/src/hooks/useActionCenterSubscribers/useSwapActionSubscriber.tsx
@@ -281,6 +281,27 @@ export const useSwapActionSubscriber = () => {
           }),
         )
 
+        const { getAccount } = portfolioApi.endpoints
+
+        // Balance refetches fire before the history parses - they share rate-limited request
+        // queues on second-class chains and balances are what the user is waiting on
+        // See: https://github.com/shapeshift/web/issues/12092 for the buy-side refetch
+        dispatch(
+          getAccount.initiate(
+            { accountId: swap.sellAccountId, upsertOnFetch: true },
+            { forceRefetch: true },
+          ),
+        )
+
+        if (swap.buyAccountId && swap.buyAccountId !== swap.sellAccountId) {
+          dispatch(
+            getAccount.initiate(
+              { accountId: swap.buyAccountId, upsertOnFetch: true },
+              { forceRefetch: true },
+            ),
+          )
+        }
+
         // Parse and upsert Txs for second-class chains
         const sellChainId = fromAccountId(swap.sellAccountId).chainId
         const isSellSecondClassChain = SECOND_CLASS_CHAINS.includes(sellChainId as KnownChainIds)
@@ -303,7 +324,11 @@ export const useSwapActionSubscriber = () => {
           }
         }
 
-        if (buyTxHash && swap.buyAccountId) {
+        // Same-chain swaps on the same account already upserted this exact tx above
+        const isBuyTxDistinct =
+          buyTxHash && (buyTxHash !== swap.sellTxHash || swap.buyAccountId !== swap.sellAccountId)
+
+        if (isBuyTxDistinct && swap.buyAccountId) {
           const buyChainId = fromAccountId(swap.buyAccountId).chainId
           const isBuySecondClassChain = SECOND_CLASS_CHAINS.includes(buyChainId as KnownChainIds)
 
@@ -324,29 +349,6 @@ export const useSwapActionSubscriber = () => {
               console.error('Failed to parse and upsert buy Tx:', error)
             }
           }
-        }
-
-        const { getAccount } = portfolioApi.endpoints
-
-        // Always refresh sell account balance after swap completion
-        // This ensures balances are up-to-date even if WebSocket subscriptions miss the update
-        dispatch(
-          getAccount.initiate(
-            { accountId: swap.sellAccountId, upsertOnFetch: true },
-            { forceRefetch: true },
-          ),
-        )
-
-        // Always refresh buy account balance after swap completion (if different from sell)
-        // This fixes cross-chain swaps where the destination chain's balance wasn't updating
-        // See: https://github.com/shapeshift/web/issues/12092
-        if (swap.buyAccountId && swap.buyAccountId !== swap.sellAccountId) {
-          dispatch(
-            getAccount.initiate(
-              { accountId: swap.buyAccountId, upsertOnFetch: true },
-              { forceRefetch: true },
-            ),
-          )
         }
 
         if (


### PR DESCRIPTION
## Description

Stacked on #12522. From on-chain settlement to visible balances took 30–60s for TON swaps. Traced end to end, nearly all of it was redundant work serialized on the rate-limited toncenter request queue (1 request per 2s):

- Each 5s status poll after settlement ran the receive gate → up to 2 × `parseTx`, each costing 4 queued requests (~8s), so polls backed up behind each other.
- On Confirmed, the subscriber parsed the sell tx *again* (~8s), then the buy tx — for a same-account TON swap the identical hash and address (~8s of duplicate work) — and only then dispatched the balance refetches, which queued behind everything.

Fixes:

- **`parseTx` memoized for 4s** (deliberately below the 5s poll interval, so every poll still sees fresh chain state): the gate's parse, the confirmed-time history upsert, and any buy-side parse of the same hash collapse into a single network run. In-flight promises are shared; failures evict.
- **One lookup instead of two**: `parseTx` resolves the receiving transaction with a single `transactionsByMessage?direction=in` call, replacing the `messages` lookup + tx-by-hash pair. The two-step path survives only to classify pending (message known, not yet processed) vs unknown.
- **Queue spacing 2s → 1.1s**: toncenter's free tier allows ~1 req/sec, and 429s already retry honoring `Retry-After` — the 2s spacing was double-safety margin paid on every request.
- **Subscriber ordering**: balance refetches now fire *before* the history parses (they share the same rate-limited queues on second-class chains, and balances are what the user is actually waiting on), and the buy-side parse is skipped when it's the same tx on the same account.

Net effect for a same-account TON swap: settlement → balances drops from ~30–60s to roughly one poll cycle plus a handful of queued requests (~10s), and the history row appears from the memoized parse at effectively no extra queue cost.

## Issue (if applicable)

closes #

## Risk

Low. TON adapter + swap subscriber ordering only. The 4s memo cannot serve stale data across poll cycles by construction. Faster queue spacing is within toncenter's documented rate with retry handling already in place. Subscriber reordering changes no logic, only dispatch order; the skipped buy parse was a byte-identical duplicate.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

TON status polling, history upsert timing, and post-swap balance refresh latency. No transaction construction or broadcast changes.

## Testing

### Engineering

- Live `parseTx` via the collapsed `transactionsByMessage` path returns byte-identical rows for both reference swaps (USDT→TON net 0.3505; TON→jUSDC 0.3597/0.5026).
- `transactionsByMessage?direction=in` probed live against a real broadcast hash — returns the receiving transaction directly.
- TON adapter tests: 45 passing; tsc clean.

### Operations

- Do a TON swap: status should flip to complete and balances update within ~1–2 poll cycles of on-chain settlement, with the history row appearing at the same time.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction status handling, including clearer pending and unknown transaction results.
  * Reduced delays when checking transaction updates.
  * Improved swap confirmation updates by refreshing affected balances promptly.
  * Prevented duplicate processing when buy and sell transactions are identical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->