### PR TITLE
feat(swapper): exact output swaps on NEAR Intents and Relay

### DIFF
--- a/packages/public-api/src/routes/quote/getQuote.ts
+++ b/packages/public-api/src/routes/quote/getQuote.ts
@@ -1,6 +1,6 @@
 import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
 import { viemClientByChainId } from '@shapeshiftoss/contracts'
-import type { GetTradeQuoteInput } from '@shapeshiftoss/swapper'
+import type { GetExactOutputTradeQuoteInput, GetTradeQuoteInput } from '@shapeshiftoss/swapper'
 import {
   buildSwapMetadata,
   getDefaultSlippageDecimalPercentageForSwapper,
@@ -67,6 +67,7 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       sellAssetId,
       buyAssetId,
       sellAmountCryptoBaseUnit,
+      buyAmountCryptoBaseUnit,
       receiveAddress,
       sendAddress,
       swapperName,
@@ -127,7 +128,9 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
     const quoteInput = {
       sellAsset,
       buyAsset,
-      sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
+      ...(buyAmountCryptoBaseUnit
+        ? { buyAmountCryptoBaseUnit }
+        : { sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit }),
       affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal: slippage,
@@ -141,8 +144,12 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       supportsEIP1559: false,
     }
 
-    // utxo accountType/xpub are not first class public api inputs yet, the cast covers that gap
-    const result = await getTradeQuotes(quoteInput as GetTradeQuoteInput, validSwapperName, deps)
+    // The input union narrows chainId per chain family; utxo accountType/xpub are unmodelled too
+    const result = await getTradeQuotes(
+      quoteInput as GetTradeQuoteInput | GetExactOutputTradeQuoteInput,
+      validSwapperName,
+      deps,
+    )
 
     if (!result) {
       res.status(404).json({

--- a/packages/public-api/src/routes/quote/types.ts
+++ b/packages/public-api/src/routes/quote/types.ts
@@ -115,28 +115,56 @@ export const QuoteStepSchema = registry.register(
   }),
 )
 
-export const QuoteRequestSchema = z.object({
-  sellAssetId: z.string().min(1).openapi({ example: 'eip155:1/slip44:60' }),
-  buyAssetId: z.string().min(1).openapi({
-    example: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
-  }),
-  sellAmountCryptoBaseUnit: z.string().min(1).openapi({ example: '1000000000000000000' }),
-  receiveAddress: z
-    .string()
-    .min(1)
-    .openapi({ example: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq' }),
-  // For UTXO chains, use the account's receive address at index 0/0 (e.g. m/84'/0'/0'/0/0).
-  sendAddress: z.string().min(1).openapi({ example: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' }),
-  swapperName: z.string().min(1).openapi({ example: 'Relay' }),
-  slippageTolerancePercentageDecimal: z.string().optional().openapi({ example: '0.01' }),
-  accountNumber: z.coerce.number().optional().default(0).openapi({ example: 0 }),
-  // UTXO sells only: account xpub used to compute an exact network fee from the wallet's utxo set.
-  // Without it the returned network fee is a rough estimate.
-  xpub: z.string().optional().openapi({
-    example:
-      'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs',
-  }),
-})
+export const QuoteRequestSchema = z
+  .object({
+    sellAssetId: z.string().min(1).openapi({ example: 'eip155:1/slip44:60' }),
+    buyAssetId: z.string().min(1).openapi({
+      example: 'bip122:000000000019d6689c085ae165831e93/slip44:0',
+    }),
+    sellAmountCryptoBaseUnit: z
+      .string()
+      .regex(/^\d+$/, 'sellAmountCryptoBaseUnit must be a positive integer')
+      .optional()
+      .openapi({
+        example: '1000000000000000000',
+        description:
+          'Exact amount of the sell asset to send, in base units. Required unless buyAmountCryptoBaseUnit is given.',
+      }),
+    buyAmountCryptoBaseUnit: z
+      .string()
+      .regex(/^\d+$/, 'buyAmountCryptoBaseUnit must be a positive integer')
+      .optional()
+      .openapi({
+        example: '100000',
+        description:
+          'Exact amount of the buy asset to receive, in base units. The sell amount you must send is derived from it and returned on the quote. Mutually exclusive with sellAmountCryptoBaseUnit, and rejected for swappers that cannot quote an exact output.',
+      }),
+    receiveAddress: z
+      .string()
+      .min(1)
+      .openapi({ example: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq' }),
+    // For UTXO chains, use the account's receive address at index 0/0 (e.g. m/84'/0'/0'/0/0).
+    sendAddress: z
+      .string()
+      .min(1)
+      .openapi({ example: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045' }),
+    swapperName: z.string().min(1).openapi({ example: 'Relay' }),
+    slippageTolerancePercentageDecimal: z.string().optional().openapi({ example: '0.01' }),
+    accountNumber: z.coerce.number().optional().default(0).openapi({ example: 0 }),
+    // UTXO sells only: account xpub used to compute an exact network fee from the wallet's utxo set.
+    // Without it the returned network fee is a rough estimate.
+    xpub: z.string().optional().openapi({
+      example:
+        'zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs',
+    }),
+  })
+  .refine(
+    ({ sellAmountCryptoBaseUnit, buyAmountCryptoBaseUnit }) =>
+      (sellAmountCryptoBaseUnit === undefined) !== (buyAmountCryptoBaseUnit === undefined),
+    {
+      message: 'Provide exactly one of sellAmountCryptoBaseUnit or buyAmountCryptoBaseUnit',
+    },
+  )
 
 export const QuoteResponseSchema = registry.register(
   'QuoteResponse',

--- a/packages/public-api/src/routes/quote/types.ts
+++ b/packages/public-api/src/routes/quote/types.ts
@@ -132,7 +132,7 @@ export const QuoteRequestSchema = z
       }),
     buyAmountCryptoBaseUnit: z
       .string()
-      .regex(/^\d+$/, 'buyAmountCryptoBaseUnit must be a positive integer')
+      .regex(/^(?!0+$)\d+$/, 'buyAmountCryptoBaseUnit must be a positive integer')
       .optional()
       .openapi({
         example: '100000',

--- a/packages/public-api/src/routes/rates/getRates.ts
+++ b/packages/public-api/src/routes/rates/getRates.ts
@@ -1,5 +1,5 @@
 import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
-import type { GetTradeRateInput } from '@shapeshiftoss/swapper'
+import type { GetExactOutputTradeRateInput, GetTradeRateInput } from '@shapeshiftoss/swapper'
 import { getTradeRates, swappers, TradeQuoteError } from '@shapeshiftoss/swapper'
 import type { Request, Response } from 'express'
 
@@ -56,6 +56,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
       sellAssetId,
       buyAssetId,
       sellAmountCryptoBaseUnit,
+      buyAmountCryptoBaseUnit,
       slippageTolerancePercentageDecimal,
     } = queryResult.data
 
@@ -76,7 +77,9 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
     const rateInput = {
       sellAsset,
       buyAsset,
-      sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
+      ...(buyAmountCryptoBaseUnit
+        ? { buyAmountCryptoBaseUnit }
+        : { sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit }),
       affiliateBps: req.affiliateInfo?.affiliateBps ?? env.DEFAULT_AFFILIATE_BPS,
       allowMultiHop: false,
       slippageTolerancePercentageDecimal,
@@ -94,7 +97,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
         if (!swapper) return null
 
         const result = await getTradeRates(
-          rateInput as GetTradeRateInput,
+          rateInput as GetTradeRateInput | GetExactOutputTradeRateInput,
           swapperName,
           deps,
           RATE_TIMEOUT_MS,
@@ -108,7 +111,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
             swapperName,
             rate: '0',
             buyAmountCryptoBaseUnit: '0',
-            sellAmountCryptoBaseUnit,
+            sellAmountCryptoBaseUnit: sellAmountCryptoBaseUnit ?? '0',
             steps: 0,
             allowanceContract: undefined,
             estimatedExecutionTimeMs: undefined,

--- a/packages/public-api/src/routes/rates/types.ts
+++ b/packages/public-api/src/routes/rates/types.ts
@@ -20,7 +20,7 @@ export const RatesRequestSchema = z
       }),
     buyAmountCryptoBaseUnit: z
       .string()
-      .regex(/^\d+$/, 'buyAmountCryptoBaseUnit must be a positive integer')
+      .regex(/^(?!0+$)\d+$/, 'buyAmountCryptoBaseUnit must be a positive integer')
       .optional()
       .openapi({
         example: '100000',

--- a/packages/public-api/src/routes/rates/types.ts
+++ b/packages/public-api/src/routes/rates/types.ts
@@ -3,24 +3,46 @@ import { z } from 'zod'
 import { registry } from '../../registry'
 import { BpsFields } from '../../types'
 
-export const RatesRequestSchema = z.object({
-  sellAssetId: z.string().min(1).openapi({ example: 'eip155:1/slip44:60' }),
-  buyAssetId: z.string().min(1).openapi({
-    example: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
-  }),
-  sellAmountCryptoBaseUnit: z
-    .string()
-    .regex(/^\d+$/, 'sellAmountCryptoBaseUnit must be a positive integer')
-    .openapi({ example: '1000000000000000000' }),
-  slippageTolerancePercentageDecimal: z
-    .string()
-    .regex(
-      /^(?:\d+)(?:\.\d+)?$/,
-      'slippageTolerancePercentageDecimal must be a non-negative decimal number',
-    )
-    .optional()
-    .openapi({ example: '0.01' }),
-})
+export const RatesRequestSchema = z
+  .object({
+    sellAssetId: z.string().min(1).openapi({ example: 'eip155:1/slip44:60' }),
+    buyAssetId: z.string().min(1).openapi({
+      example: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+    }),
+    sellAmountCryptoBaseUnit: z
+      .string()
+      .regex(/^\d+$/, 'sellAmountCryptoBaseUnit must be a positive integer')
+      .optional()
+      .openapi({
+        example: '1000000000000000000',
+        description:
+          'Exact amount of the sell asset to send, in base units. Required unless buyAmountCryptoBaseUnit is given.',
+      }),
+    buyAmountCryptoBaseUnit: z
+      .string()
+      .regex(/^\d+$/, 'buyAmountCryptoBaseUnit must be a positive integer')
+      .optional()
+      .openapi({
+        example: '100000',
+        description:
+          'Exact amount of the buy asset to receive, in base units. Each rate returns the sell amount needed to get it. Mutually exclusive with sellAmountCryptoBaseUnit; swappers that cannot quote an exact output come back with an ExactOutputNotSupported error.',
+      }),
+    slippageTolerancePercentageDecimal: z
+      .string()
+      .regex(
+        /^(?:\d+)(?:\.\d+)?$/,
+        'slippageTolerancePercentageDecimal must be a non-negative decimal number',
+      )
+      .optional()
+      .openapi({ example: '0.01' }),
+  })
+  .refine(
+    ({ sellAmountCryptoBaseUnit, buyAmountCryptoBaseUnit }) =>
+      (sellAmountCryptoBaseUnit === undefined) !== (buyAmountCryptoBaseUnit === undefined),
+    {
+      message: 'Provide exactly one of sellAmountCryptoBaseUnit or buyAmountCryptoBaseUnit',
+    },
+  )
 
 const ApiRateSchema = z.object({
   swapperName: z.string(),

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "19.0.0",
+  "version": "20.0.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swapper/src/exactOutputFiltering.test.ts
+++ b/packages/swapper/src/exactOutputFiltering.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { swappers } from './constants'
+import { getTradeRates } from './swapper'
+import type { GetExactOutputTradeRateInput, SwapperDeps } from './types'
+import { SwapperName, TradeQuoteError } from './types'
+import { BTC, ETH } from './utils/test-data/assets'
+
+// Exact-output support is structural - a swapper cannot claim it without implementing it
+describe('exact output capability', () => {
+  it('is implemented by the swappers whose upstream API can honour an exact buy amount', () => {
+    for (const swapperName of [SwapperName.NearIntents, SwapperName.Relay]) {
+      expect(swappers[swapperName]?.getExactOutputTradeRate).toBeDefined()
+      expect(swappers[swapperName]?.getExactOutputTradeQuote).toBeDefined()
+    }
+  })
+
+  it('is absent everywhere else', () => {
+    const exactOutputCapable = Object.values(SwapperName).filter(
+      swapperName => swappers[swapperName]?.getExactOutputTradeRate !== undefined,
+    )
+
+    expect(exactOutputCapable).toEqual([SwapperName.Relay, SwapperName.NearIntents])
+  })
+})
+
+const exactOutputInput = {
+  sellAsset: ETH,
+  buyAsset: BTC,
+  buyAmountCryptoBaseUnit: '100000',
+  affiliateBps: '0',
+  allowMultiHop: true,
+  receiveAddress: undefined,
+  accountNumber: undefined,
+  quoteOrRate: 'rate',
+} as unknown as GetExactOutputTradeRateInput
+
+const deps = {} as SwapperDeps
+
+describe('getTradeRates on an exact buy amount', () => {
+  // Silently omitting these would read as the swapper being unavailable rather than unable
+  it('reports an error for a swapper that cannot quote one', async () => {
+    const result = await getTradeRates(exactOutputInput, SwapperName.Thorchain, deps)
+
+    expect(result).toBeDefined()
+    expect(result?.isErr()).toBe(true)
+    expect(result?.unwrapErr().code).toEqual(TradeQuoteError.ExactOutputNotSupported)
+    expect(result?.swapperName).toEqual(SwapperName.Thorchain)
+  })
+
+  it('skips entirely on a zero buy amount', async () => {
+    const result = await getTradeRates(
+      { ...exactOutputInput, buyAmountCryptoBaseUnit: '0' },
+      SwapperName.Thorchain,
+      deps,
+    )
+
+    expect(result).toBeUndefined()
+  })
+})

--- a/packages/swapper/src/exactOutputFiltering.test.ts
+++ b/packages/swapper/src/exactOutputFiltering.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest'
 
 import { swappers } from './constants'
-import { getTradeRates } from './swapper'
-import type { GetExactOutputTradeRateInput, SwapperDeps } from './types'
+import { getTradeQuotes, getTradeRates } from './swapper'
+import type {
+  GetExactOutputTradeQuoteInput,
+  GetExactOutputTradeRateInput,
+  SwapperDeps,
+} from './types'
 import { SwapperName, TradeQuoteError } from './types'
 import { BTC, ETH } from './utils/test-data/assets'
 
@@ -51,6 +55,46 @@ describe('getTradeRates on an exact buy amount', () => {
   it('skips entirely on a zero buy amount', async () => {
     const result = await getTradeRates(
       { ...exactOutputInput, buyAmountCryptoBaseUnit: '0' },
+      SwapperName.Thorchain,
+      deps,
+    )
+
+    expect(result).toBeUndefined()
+  })
+
+  // The base-unit regex upstream admits padded zeros, so the check can't be a string comparison
+  it('skips entirely on a padded zero buy amount', async () => {
+    const result = await getTradeRates(
+      { ...exactOutputInput, buyAmountCryptoBaseUnit: '00' },
+      SwapperName.Thorchain,
+      deps,
+    )
+
+    expect(result).toBeUndefined()
+  })
+})
+
+// Quotes dispatch on the same input shape as rates, so they gate the same way
+describe('getTradeQuotes on an exact buy amount', () => {
+  const exactOutputQuoteInput = {
+    ...exactOutputInput,
+    receiveAddress: 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq',
+    accountNumber: 0,
+    quoteOrRate: 'quote',
+  } as unknown as GetExactOutputTradeQuoteInput
+
+  it('reports an error for a swapper that cannot quote one', async () => {
+    const result = await getTradeQuotes(exactOutputQuoteInput, SwapperName.Thorchain, deps)
+
+    expect(result).toBeDefined()
+    expect(result?.isErr()).toBe(true)
+    expect(result?.unwrapErr().code).toEqual(TradeQuoteError.ExactOutputNotSupported)
+    expect(result?.swapperName).toEqual(SwapperName.Thorchain)
+  })
+
+  it('skips entirely on a zero buy amount', async () => {
+    const result = await getTradeQuotes(
+      { ...exactOutputQuoteInput, buyAmountCryptoBaseUnit: '0' },
       SwapperName.Thorchain,
       deps,
     )

--- a/packages/swapper/src/swapper.ts
+++ b/packages/swapper/src/swapper.ts
@@ -1,7 +1,10 @@
 import { bnOrZero, timeoutMonadic, timeoutMonadicWithOriginal } from '@shapeshiftoss/utils'
+import { Err } from '@sniptt/monads'
 
 import { QUOTE_TIMEOUT_ERROR, QUOTE_TIMEOUT_MS, swappers } from './constants'
 import type {
+  GetExactOutputTradeQuoteInput,
+  GetExactOutputTradeRateInput,
   GetTradeQuoteInput,
   GetTradeRateInput,
   QuoteResult,
@@ -15,21 +18,35 @@ import type {
 import { TradeQuoteError } from './types'
 import { makeSwapErrorRight } from './utils'
 
+const EXACT_OUTPUT_NOT_SUPPORTED_ERROR = makeSwapErrorRight({
+  code: TradeQuoteError.ExactOutputNotSupported,
+  message: 'This swapper cannot derive a sell amount from an exact buy amount',
+})
+
 export const getTradeQuotes = async (
-  getTradeQuoteInput: GetTradeQuoteInput,
+  getTradeQuoteInput: GetTradeQuoteInput | GetExactOutputTradeQuoteInput,
   swapperName: SwapperName,
   deps: SwapperDeps,
 ): Promise<QuoteResult | undefined> => {
   if (bnOrZero(getTradeQuoteInput.affiliateBps).lt(0)) return
-  if (getTradeQuoteInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return
 
   const swapper = swappers[swapperName]
-
   if (swapper === undefined) return
+
+  if ('buyAmountCryptoBaseUnit' in getTradeQuoteInput) {
+    if (getTradeQuoteInput.buyAmountCryptoBaseUnit === '0') return
+  } else if (getTradeQuoteInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return
+
+  const quotePromise =
+    'buyAmountCryptoBaseUnit' in getTradeQuoteInput
+      ? swapper.getExactOutputTradeQuote?.(getTradeQuoteInput, deps)
+      : swapper.getTradeQuote(getTradeQuoteInput, deps)
+
+  if (!quotePromise) return { ...Err(EXACT_OUTPUT_NOT_SUPPORTED_ERROR), swapperName }
 
   try {
     const quote = await timeoutMonadic<TradeQuote[], SwapErrorRight>(
-      swapper.getTradeQuote(getTradeQuoteInput, deps),
+      quotePromise,
       QUOTE_TIMEOUT_MS,
       QUOTE_TIMEOUT_ERROR,
     )
@@ -46,21 +63,30 @@ export const getTradeQuotes = async (
 }
 
 export const getTradeRates = async (
-  getTradeRateInput: GetTradeRateInput,
+  getTradeRateInput: GetTradeRateInput | GetExactOutputTradeRateInput,
   swapperName: SwapperName,
   deps: SwapperDeps,
   quoteTimeoutMs: number = QUOTE_TIMEOUT_MS,
 ): Promise<RateResult | undefined> => {
   if (bnOrZero(getTradeRateInput.affiliateBps).lt(0)) return
-  if (getTradeRateInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return
 
   const swapper = swappers[swapperName]
-
   if (swapper === undefined) return
+
+  if ('buyAmountCryptoBaseUnit' in getTradeRateInput) {
+    if (getTradeRateInput.buyAmountCryptoBaseUnit === '0') return
+  } else if (getTradeRateInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return
+
+  const ratePromise =
+    'buyAmountCryptoBaseUnit' in getTradeRateInput
+      ? swapper.getExactOutputTradeRate?.(getTradeRateInput, deps)
+      : swapper.getTradeRate(getTradeRateInput, deps)
+
+  if (!ratePromise) return { ...Err(EXACT_OUTPUT_NOT_SUPPORTED_ERROR), swapperName }
 
   try {
     const { timed, original } = timeoutMonadicWithOriginal<TradeRate[], SwapErrorRight>(
-      swapper.getTradeRate(getTradeRateInput, deps),
+      ratePromise,
       quoteTimeoutMs,
       makeSwapErrorRight({
         code: TradeQuoteError.Timeout,

--- a/packages/swapper/src/swapper.ts
+++ b/packages/swapper/src/swapper.ts
@@ -33,9 +33,13 @@ export const getTradeQuotes = async (
   const swapper = swappers[swapperName]
   if (swapper === undefined) return
 
-  if ('buyAmountCryptoBaseUnit' in getTradeQuoteInput) {
-    if (getTradeQuoteInput.buyAmountCryptoBaseUnit === '0') return
-  } else if (getTradeQuoteInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return
+  // Compared numerically so a padded zero can't slip through as an amount
+  const drivingAmount =
+    'buyAmountCryptoBaseUnit' in getTradeQuoteInput
+      ? getTradeQuoteInput.buyAmountCryptoBaseUnit
+      : getTradeQuoteInput.sellAmountIncludingProtocolFeesCryptoBaseUnit
+
+  if (bnOrZero(drivingAmount).isZero()) return
 
   const quotePromise =
     'buyAmountCryptoBaseUnit' in getTradeQuoteInput
@@ -73,9 +77,13 @@ export const getTradeRates = async (
   const swapper = swappers[swapperName]
   if (swapper === undefined) return
 
-  if ('buyAmountCryptoBaseUnit' in getTradeRateInput) {
-    if (getTradeRateInput.buyAmountCryptoBaseUnit === '0') return
-  } else if (getTradeRateInput.sellAmountIncludingProtocolFeesCryptoBaseUnit === '0') return
+  // Compared numerically so a padded zero can't slip through as an amount
+  const drivingAmount =
+    'buyAmountCryptoBaseUnit' in getTradeRateInput
+      ? getTradeRateInput.buyAmountCryptoBaseUnit
+      : getTradeRateInput.sellAmountIncludingProtocolFeesCryptoBaseUnit
+
+  if (bnOrZero(drivingAmount).isZero()) return
 
   const ratePromise =
     'buyAmountCryptoBaseUnit' in getTradeRateInput

--- a/packages/swapper/src/swappers/AcrossSwapper/utils/getAcrossStepData.ts
+++ b/packages/swapper/src/swappers/AcrossSwapper/utils/getAcrossStepData.ts
@@ -22,6 +22,7 @@ import type { AcrossSwapTx } from './types'
 
 type BaseArgs = {
   swapTx: AcrossSwapTx
+  sellAmountCryptoBaseUnit: string
   spenderAddress: string
   fallbackNetworkFeeCryptoBaseUnit: string
 }
@@ -43,6 +44,7 @@ export async function getAcrossStepData(
   const {
     swapTx,
     sellAsset,
+    sellAmountCryptoBaseUnit,
     spenderAddress,
     from,
     type,
@@ -68,7 +70,7 @@ export async function getAcrossStepData(
 
       const stateOverride = {
         sellAsset,
-        sellAmountCryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        sellAmountCryptoBaseUnit,
         spenderAddress,
       }
 

--- a/packages/swapper/src/swappers/AcrossSwapper/utils/getAcrossTradeContext.ts
+++ b/packages/swapper/src/swappers/AcrossSwapper/utils/getAcrossTradeContext.ts
@@ -242,6 +242,7 @@ export const getAcrossTradeContext = async ({
     stepDataArgs: {
       swapTx: quote.swapTx,
       sellAsset,
+      sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
       from: depositor,
       spenderAddress: allowanceContract,
       fallbackNetworkFeeCryptoBaseUnit: quote.fees.originGas.amount,

--- a/packages/swapper/src/swappers/BebopSwapper/utils/getBebopStepData.ts
+++ b/packages/swapper/src/swappers/BebopSwapper/utils/getBebopStepData.ts
@@ -11,6 +11,7 @@ import type { BebopQuoteResponse } from '../types'
 
 type BaseArgs = {
   tx: BebopQuoteResponse['tx']
+  sellAmountCryptoBaseUnit: string
   spenderAddress: string
 }
 
@@ -28,7 +29,7 @@ export function getBebopStepData(
 export async function getBebopStepData(
   args: GetBebopStepDataArgs,
 ): Promise<Result<BebopRateStepData | BebopQuoteStepData, SwapErrorRight>> {
-  const { tx, spenderAddress, sellAsset, type, input, from, deps } = args
+  const { tx, spenderAddress, sellAsset, sellAmountCryptoBaseUnit, type, input, from, deps } = args
 
   const adapter = deps.assertGetEvmChainAdapter(sellAsset.chainId)
   const supportsEIP1559 = 'supportsEIP1559' in input ? input.supportsEIP1559 : false
@@ -68,7 +69,7 @@ export async function getBebopStepData(
       supportsEIP1559,
       stateOverride: {
         sellAsset,
-        sellAmountCryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        sellAmountCryptoBaseUnit,
         spenderAddress,
       },
     })

--- a/packages/swapper/src/swappers/BebopSwapper/utils/getBebopTradeContext.ts
+++ b/packages/swapper/src/swappers/BebopSwapper/utils/getBebopTradeContext.ts
@@ -117,6 +117,7 @@ export const getBebopTradeContext = async ({
       tx: quote.tx,
       spenderAddress: allowanceContract,
       sellAsset,
+      sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
       from,
       deps,
     },

--- a/packages/swapper/src/swappers/DebridgeSwapper/utils/getDebridgeStepData.ts
+++ b/packages/swapper/src/swappers/DebridgeSwapper/utils/getDebridgeStepData.ts
@@ -9,6 +9,7 @@ import type { DebridgeTx } from './types'
 
 type BaseArgs = {
   tx: DebridgeTx
+  sellAmountCryptoBaseUnit: string
   gasLimit: string | undefined
   spenderAddress: string
   fallbackNetworkFeeCryptoBaseUnit: string | undefined
@@ -31,6 +32,7 @@ export async function getDebridgeStepData(
 ): Promise<Result<DebridgeRateStepData | DebridgeQuoteStepData, SwapErrorRight>> {
   const {
     tx,
+    sellAmountCryptoBaseUnit,
     gasLimit,
     spenderAddress,
     fallbackNetworkFeeCryptoBaseUnit,
@@ -55,7 +57,7 @@ export async function getDebridgeStepData(
 
   const stateOverride = {
     sellAsset,
-    sellAmountCryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    sellAmountCryptoBaseUnit,
     spenderAddress,
   }
 

--- a/packages/swapper/src/swappers/DebridgeSwapper/utils/getDebridgeTradeContext.ts
+++ b/packages/swapper/src/swappers/DebridgeSwapper/utils/getDebridgeTradeContext.ts
@@ -156,6 +156,7 @@ export const getDebridgeTradeContext = async ({
     protocolFees: quote.protocolFees,
     stepDataArgs: {
       tx: quote.tx,
+      sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
       gasLimit: quote.gasLimit,
       fallbackNetworkFeeCryptoBaseUnit: quote.fallbackNetworkFeeCryptoBaseUnit,
       sellAsset,

--- a/packages/swapper/src/swappers/NearIntentsSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/endpoints.ts
@@ -17,15 +17,24 @@ import { getEvmTransactionFees, getUnsignedEvmTransaction } from '../../utils/ev
 import { getSolanaTransactionFees, getUnsignedSolanaTransaction } from '../../utils/solana'
 import { getTronTransactionFees, getUnsignedTronTransaction } from '../../utils/tron'
 import { getUnsignedUtxoTransaction, getUtxoTransactionFees } from '../../utils/utxo'
-import { getTradeQuote } from './swapperApi/getTradeQuote'
-import { getTradeRate } from './swapperApi/getTradeRate'
-import type { NearIntentsTradeQuoteInput, NearIntentsTradeRateInput } from './types'
+import { getExactOutputTradeQuote, getTradeQuote } from './swapperApi/getTradeQuote'
+import { getExactOutputTradeRate, getTradeRate } from './swapperApi/getTradeRate'
+import type {
+  NearIntentsExactOutputTradeQuoteInput,
+  NearIntentsExactOutputTradeRateInput,
+  NearIntentsTradeQuoteInput,
+  NearIntentsTradeRateInput,
+} from './types'
 import { getNearIntentsStatusMessage, mapNearIntentsStatus } from './utils/helpers'
 import { initializeOneClickService, OneClickService } from './utils/oneClickService'
 
 export const nearIntentsApi: SwapperApi = {
   getTradeQuote: (input, deps) => getTradeQuote(input as NearIntentsTradeQuoteInput, deps),
   getTradeRate: (input, deps) => getTradeRate(input as NearIntentsTradeRateInput, deps),
+  getExactOutputTradeQuote: (input, deps) =>
+    getExactOutputTradeQuote(input as NearIntentsExactOutputTradeQuoteInput, deps),
+  getExactOutputTradeRate: (input, deps) =>
+    getExactOutputTradeRate(input as NearIntentsExactOutputTradeRateInput, deps),
   getUnsignedEvmTransaction,
   getEvmTransactionFees,
   getUnsignedUtxoTransaction,

--- a/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeQuote.ts
@@ -3,7 +3,8 @@ import { Err, Ok } from '@sniptt/monads'
 
 import type { SwapErrorRight, SwapperDeps, TradeQuote } from '../../../types'
 import { assertQuoteAddresses } from '../../../utils'
-import type { NearIntentsTradeQuoteInput } from '../types'
+import { getTradeAmount } from '../../../utils/helpers'
+import type { NearIntentsExactOutputTradeQuoteInput, NearIntentsTradeQuoteInput } from '../types'
 import { QuoteRequest } from '../types'
 import { getNearIntentsStepData } from '../utils/getNearIntentsStepData'
 import { getNearIntentsTradeContext } from '../utils/getNearIntentsTradeContext'
@@ -15,23 +16,19 @@ import {
 } from '../utils/helpers'
 import { initializeOneClickService } from '../utils/oneClickService'
 
-export const getTradeQuote = async (
-  input: NearIntentsTradeQuoteInput,
+const getQuote = async (
+  input: NearIntentsTradeQuoteInput | NearIntentsExactOutputTradeQuoteInput,
   deps: SwapperDeps,
 ): Promise<Result<TradeQuote[], SwapErrorRight>> => {
-  const {
-    sellAsset,
-    buyAsset,
-    accountNumber,
-    affiliateBps,
-    sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmount,
-  } = input
+  const { sellAsset, buyAsset, accountNumber, affiliateBps } = input
 
   const addresses = assertQuoteAddresses(input)
   if (addresses.isErr()) return Err(addresses.unwrapErr())
   const { sendAddress, receiveAddress } = addresses.unwrap()
 
   initializeOneClickService(deps.config.VITE_NEAR_INTENTS_API_KEY)
+
+  const amount = getTradeAmount(input)
 
   const maybeAssets = await resolveNearIntentsAssets({ sellAsset, buyAsset })
   if (maybeAssets.isErr()) return Err(maybeAssets.unwrapErr())
@@ -40,7 +37,7 @@ export const getTradeQuote = async (
   const quoteRequest = buildNearIntentsQuoteRequest({
     originAsset,
     destinationAsset,
-    sellAmountCryptoBaseUnit: sellAmount,
+    amount,
     slippageTolerancePercentageDecimal: input.slippageTolerancePercentageDecimal,
     affiliateBps,
     refundTo: sendAddress,
@@ -97,3 +94,13 @@ export const getTradeQuote = async (
 
   return Ok([tradeQuote])
 }
+
+export const getTradeQuote = (
+  input: NearIntentsTradeQuoteInput,
+  deps: SwapperDeps,
+): Promise<Result<TradeQuote[], SwapErrorRight>> => getQuote(input, deps)
+
+export const getExactOutputTradeQuote = (
+  input: NearIntentsExactOutputTradeQuoteInput,
+  deps: SwapperDeps,
+): Promise<Result<TradeQuote[], SwapErrorRight>> => getQuote(input, deps)

--- a/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/swapperApi/getTradeRate.ts
@@ -2,7 +2,8 @@ import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 
 import type { SwapErrorRight, SwapperDeps, TradeRate } from '../../../types'
-import type { NearIntentsTradeRateInput } from '../types'
+import { getTradeAmount } from '../../../utils/helpers'
+import type { NearIntentsExactOutputTradeRateInput, NearIntentsTradeRateInput } from '../types'
 import { QuoteRequest } from '../types'
 import { getNearIntentsStepData } from '../utils/getNearIntentsStepData'
 import { getNearIntentsTradeContext } from '../utils/getNearIntentsTradeContext'
@@ -14,21 +15,15 @@ import {
 } from '../utils/helpers'
 import { initializeOneClickService } from '../utils/oneClickService'
 
-export const getTradeRate = async (
-  input: NearIntentsTradeRateInput,
+const getRate = async (
+  input: NearIntentsTradeRateInput | NearIntentsExactOutputTradeRateInput,
   deps: SwapperDeps,
 ): Promise<Result<TradeRate[], SwapErrorRight>> => {
-  const {
-    accountNumber,
-    sellAsset,
-    buyAsset,
-    affiliateBps,
-    sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmount,
-    receiveAddress,
-    sendAddress,
-  } = input
+  const { accountNumber, sellAsset, buyAsset, affiliateBps, receiveAddress, sendAddress } = input
 
   initializeOneClickService(deps.config.VITE_NEAR_INTENTS_API_KEY)
+
+  const amount = getTradeAmount(input)
 
   const maybeAssets = await resolveNearIntentsAssets({ sellAsset, buyAsset })
   if (maybeAssets.isErr()) return Err(maybeAssets.unwrapErr())
@@ -37,7 +32,7 @@ export const getTradeRate = async (
   const quoteRequest = buildNearIntentsQuoteRequest({
     originAsset,
     destinationAsset,
-    sellAmountCryptoBaseUnit: sellAmount,
+    amount,
     slippageTolerancePercentageDecimal: input.slippageTolerancePercentageDecimal,
     affiliateBps,
     refundTo: sendAddress ?? 'check-price',
@@ -84,3 +79,13 @@ export const getTradeRate = async (
 
   return Ok([tradeRate])
 }
+
+export const getTradeRate = (
+  input: NearIntentsTradeRateInput,
+  deps: SwapperDeps,
+): Promise<Result<TradeRate[], SwapErrorRight>> => getRate(input, deps)
+
+export const getExactOutputTradeRate = (
+  input: NearIntentsExactOutputTradeRateInput,
+  deps: SwapperDeps,
+): Promise<Result<TradeRate[], SwapErrorRight>> => getRate(input, deps)

--- a/packages/swapper/src/swappers/NearIntentsSwapper/types.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/types.ts
@@ -17,6 +17,7 @@ import type {
   GetTronTradeRateInput,
   GetUtxoTradeQuoteInput,
   GetUtxoTradeRateInput,
+  WithExactBuyAmount,
 } from '../../types'
 
 export type NearIntentsTradeQuoteInput =
@@ -38,6 +39,9 @@ export type NearIntentsTradeRateInput =
   | GetStarknetTradeRateInput
   | GetNearTradeRateInput
   | GetTonTradeRateInput
+
+export type NearIntentsExactOutputTradeQuoteInput = WithExactBuyAmount<NearIntentsTradeQuoteInput>
+export type NearIntentsExactOutputTradeRateInput = WithExactBuyAmount<NearIntentsTradeRateInput>
 
 export type NearIntentsMetadata = {
   name: 'nearIntents'

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/exactOutput.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/exactOutput.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+
+import type { TradeAmount } from '../../../types'
+import { QuoteRequest } from '../types'
+import { buildNearIntentsQuoteRequest } from './helpers'
+
+const baseArgs = {
+  originAsset: 'nep141:base-0x833589fcd6edb6e08f4c7c32d4f71b54bda02913.omft.near',
+  destinationAsset: 'nep141:btc.omft.near',
+  amount: { direction: 'exactIn', cryptoBaseUnit: '65000000' } satisfies TradeAmount,
+  slippageTolerancePercentageDecimal: '0.01',
+  affiliateBps: '10',
+  refundTo: '0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045',
+  recipient: 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+  refundType: QuoteRequest.refundType.ORIGIN_CHAIN,
+  recipientType: QuoteRequest.recipientType.DESTINATION_CHAIN,
+  deadline: '2026-08-10T23:59:00.000Z',
+}
+
+const exactOutputAmount = {
+  direction: 'exactOut',
+  cryptoBaseUnit: '100000',
+} satisfies TradeAmount
+
+describe('buildNearIntentsQuoteRequest', () => {
+  describe('exact input', () => {
+    it('requests EXACT_INPUT with the sell amount', () => {
+      const request = buildNearIntentsQuoteRequest(baseArgs)
+
+      expect(request.swapType).toEqual(QuoteRequest.swapType.EXACT_INPUT)
+      expect(request.amount).toEqual('65000000')
+    })
+
+    it('passes the requested slippage through untouched', () => {
+      const request = buildNearIntentsQuoteRequest({
+        ...baseArgs,
+        slippageTolerancePercentageDecimal: '0',
+      })
+
+      expect(request.slippageTolerance).toEqual(0)
+    })
+  })
+
+  describe('exact output', () => {
+    it('requests EXACT_OUTPUT with the buy amount', () => {
+      const request = buildNearIntentsQuoteRequest({ ...baseArgs, amount: exactOutputAmount })
+
+      expect(request.swapType).toEqual(QuoteRequest.swapType.EXACT_OUTPUT)
+      expect(request.amount).toEqual('100000')
+    })
+
+    // A tighter band is the user's call - the failure mode is a refund, not a loss
+    it('passes a requested zero slippage through untouched, as exact input does', () => {
+      const request = buildNearIntentsQuoteRequest({
+        ...baseArgs,
+        amount: exactOutputAmount,
+        slippageTolerancePercentageDecimal: '0',
+      })
+
+      expect(request.slippageTolerance).toEqual(0)
+    })
+
+    it('honours a requested slippage', () => {
+      const request = buildNearIntentsQuoteRequest({
+        ...baseArgs,
+        amount: exactOutputAmount,
+        slippageTolerancePercentageDecimal: '0.05',
+      })
+
+      expect(request.slippageTolerance).toEqual(500)
+    })
+  })
+})

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/exactOutput.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/exactOutput.test.ts
@@ -4,7 +4,7 @@ import type { TradeAmount } from '../../../types'
 import { QuoteRequest } from '../types'
 import { buildNearIntentsQuoteRequest } from './helpers'
 
-const baseArgs = {
+const BASE_ARGS = {
   originAsset: 'nep141:base-0x833589fcd6edb6e08f4c7c32d4f71b54bda02913.omft.near',
   destinationAsset: 'nep141:btc.omft.near',
   amount: { direction: 'exactIn', cryptoBaseUnit: '65000000' } satisfies TradeAmount,
@@ -17,7 +17,7 @@ const baseArgs = {
   deadline: '2026-08-10T23:59:00.000Z',
 }
 
-const exactOutputAmount = {
+const EXACT_OUTPUT_AMOUNT = {
   direction: 'exactOut',
   cryptoBaseUnit: '100000',
 } satisfies TradeAmount
@@ -25,7 +25,7 @@ const exactOutputAmount = {
 describe('buildNearIntentsQuoteRequest', () => {
   describe('exact input', () => {
     it('requests EXACT_INPUT with the sell amount', () => {
-      const request = buildNearIntentsQuoteRequest(baseArgs)
+      const request = buildNearIntentsQuoteRequest(BASE_ARGS)
 
       expect(request.swapType).toEqual(QuoteRequest.swapType.EXACT_INPUT)
       expect(request.amount).toEqual('65000000')
@@ -33,7 +33,7 @@ describe('buildNearIntentsQuoteRequest', () => {
 
     it('passes the requested slippage through untouched', () => {
       const request = buildNearIntentsQuoteRequest({
-        ...baseArgs,
+        ...BASE_ARGS,
         slippageTolerancePercentageDecimal: '0',
       })
 
@@ -43,7 +43,7 @@ describe('buildNearIntentsQuoteRequest', () => {
 
   describe('exact output', () => {
     it('requests EXACT_OUTPUT with the buy amount', () => {
-      const request = buildNearIntentsQuoteRequest({ ...baseArgs, amount: exactOutputAmount })
+      const request = buildNearIntentsQuoteRequest({ ...BASE_ARGS, amount: EXACT_OUTPUT_AMOUNT })
 
       expect(request.swapType).toEqual(QuoteRequest.swapType.EXACT_OUTPUT)
       expect(request.amount).toEqual('100000')
@@ -52,8 +52,8 @@ describe('buildNearIntentsQuoteRequest', () => {
     // A tighter band is the user's call - the failure mode is a refund, not a loss
     it('passes a requested zero slippage through untouched, as exact input does', () => {
       const request = buildNearIntentsQuoteRequest({
-        ...baseArgs,
-        amount: exactOutputAmount,
+        ...BASE_ARGS,
+        amount: EXACT_OUTPUT_AMOUNT,
         slippageTolerancePercentageDecimal: '0',
       })
 
@@ -62,8 +62,8 @@ describe('buildNearIntentsQuoteRequest', () => {
 
     it('honours a requested slippage', () => {
       const request = buildNearIntentsQuoteRequest({
-        ...baseArgs,
-        amount: exactOutputAmount,
+        ...BASE_ARGS,
+        amount: EXACT_OUTPUT_AMOUNT,
         slippageTolerancePercentageDecimal: '0.05',
       })
 

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/getNearIntentsTradeContext.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/getNearIntentsTradeContext.ts
@@ -16,7 +16,13 @@ import type {
 import { SwapperName } from '../../../types'
 import { getInputOutputRate, makeTradeStepBuildFailedErr } from '../../../utils'
 import { buildAffiliateFee } from '../../../utils/affiliateFee'
-import type { NearIntentsTradeQuoteInput, NearIntentsTradeRateInput, QuoteResponse } from '../types'
+import type {
+  NearIntentsExactOutputTradeQuoteInput,
+  NearIntentsExactOutputTradeRateInput,
+  NearIntentsTradeQuoteInput,
+  NearIntentsTradeRateInput,
+  QuoteResponse,
+} from '../types'
 
 type NearIntentsTradeContext = {
   tradeCommon: TradeCommon
@@ -35,17 +41,15 @@ export const getNearIntentsTradeContext = ({
   deps,
   quote,
 }: {
-  input: NearIntentsTradeQuoteInput | NearIntentsTradeRateInput
+  input:
+    | NearIntentsTradeQuoteInput
+    | NearIntentsTradeRateInput
+    | NearIntentsExactOutputTradeQuoteInput
+    | NearIntentsExactOutputTradeRateInput
   deps: SwapperDeps
   quote: QuoteResponse['quote']
 }): Result<NearIntentsTradeContext, SwapErrorRight> => {
-  const {
-    sellAsset,
-    buyAsset,
-    affiliateBps,
-    sellAmountIncludingProtocolFeesCryptoBaseUnit,
-    slippageTolerancePercentageDecimal,
-  } = input
+  const { sellAsset, buyAsset, affiliateBps, slippageTolerancePercentageDecimal } = input
 
   if (!quote.depositAddress) return Err(makeTradeStepBuildFailedErr('getNearIntentsTradeContext'))
 
@@ -56,11 +60,14 @@ export const getNearIntentsTradeContext = ({
     buyAsset,
   })
 
+  const isExactOutput = 'buyAmountCryptoBaseUnit' in input
+
   return Ok({
     tradeCommon: {
       id: uuid(),
       rate,
       swapperName: SwapperName.NearIntents,
+      isExactOutput,
       affiliateBps,
       slippageTolerancePercentageDecimal:
         slippageTolerancePercentageDecimal ??
@@ -92,7 +99,7 @@ export const getNearIntentsTradeContext = ({
     stepDataArgs: {
       deps,
       sellAsset,
-      sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+      sellAmountCryptoBaseUnit: quote.amountIn,
       depositAddress: quote.depositAddress,
     },
   })

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers.ts
@@ -6,7 +6,7 @@ import type { Result } from '@sniptt/monads'
 import { Err, Ok } from '@sniptt/monads'
 import { zeroAddress } from 'viem'
 
-import type { SwapErrorRight } from '../../../types'
+import type { SwapErrorRight, TradeAmount } from '../../../types'
 import { TradeQuoteError } from '../../../types'
 import { createTradeAmountTooSmallErr, makeSwapErrorRight } from '../../../utils'
 import {
@@ -197,7 +197,7 @@ export const getNearIntentsQuoteDeadline = ({
 export const buildNearIntentsQuoteRequest = ({
   originAsset,
   destinationAsset,
-  sellAmountCryptoBaseUnit,
+  amount,
   slippageTolerancePercentageDecimal,
   affiliateBps,
   refundTo,
@@ -208,7 +208,7 @@ export const buildNearIntentsQuoteRequest = ({
 }: {
   originAsset: string
   destinationAsset: string
-  sellAmountCryptoBaseUnit: string
+  amount: TradeAmount
   slippageTolerancePercentageDecimal: string | undefined
   affiliateBps: string
   refundTo: string
@@ -216,29 +216,34 @@ export const buildNearIntentsQuoteRequest = ({
   refundType: QuoteRequest.refundType
   recipientType: QuoteRequest.recipientType
   deadline: string
-}): QuoteRequest => ({
-  dry: false,
-  swapType: QuoteRequest.swapType.EXACT_INPUT,
-  slippageTolerance: slippageTolerancePercentageDecimal
-    ? bnOrZero(slippageTolerancePercentageDecimal).times(10000).toNumber()
-    : DEFAULT_SLIPPAGE_BPS,
-  originAsset,
-  destinationAsset,
-  amount: sellAmountCryptoBaseUnit,
-  depositType: QuoteRequest.depositType.ORIGIN_CHAIN,
-  refundTo,
-  refundType,
-  recipient,
-  recipientType,
-  deadline,
-  referral: 'shapeshift',
-  appFees: [
-    {
-      recipient: DAO_TREASURY_NEAR,
-      fee: Number(affiliateBps),
-    },
-  ],
-})
+}): QuoteRequest => {
+  return {
+    dry: false,
+    swapType:
+      amount.direction === 'exactOut'
+        ? QuoteRequest.swapType.EXACT_OUTPUT
+        : QuoteRequest.swapType.EXACT_INPUT,
+    slippageTolerance: slippageTolerancePercentageDecimal
+      ? bnOrZero(slippageTolerancePercentageDecimal).times(10000).toNumber()
+      : DEFAULT_SLIPPAGE_BPS,
+    originAsset,
+    destinationAsset,
+    amount: amount.cryptoBaseUnit,
+    depositType: QuoteRequest.depositType.ORIGIN_CHAIN,
+    refundTo,
+    refundType,
+    recipient,
+    recipientType,
+    deadline,
+    referral: 'shapeshift',
+    appFees: [
+      {
+        recipient: DAO_TREASURY_NEAR,
+        fee: Number(affiliateBps),
+      },
+    ],
+  }
+}
 
 // One retry loop for the SDK's flaky WebSocket transport; maps provider errors to swap errors
 export const fetchNearIntentsQuote = async ({

--- a/packages/swapper/src/swappers/PortalsSwapper/utils/getPortalsStepData.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/utils/getPortalsStepData.ts
@@ -10,6 +10,7 @@ import { fetchPortalsTradeEstimate } from './fetchPortalsTradeOrder'
 
 type BaseArgs = {
   tx: PortalsTx
+  sellAmountCryptoBaseUnit: string
   spenderAddress: string
 }
 
@@ -35,7 +36,7 @@ export function getPortalsStepData(
 export async function getPortalsStepData(
   args: GetPortalsStepDataArgs,
 ): Promise<Result<PortalsRateStepData | PortalsQuoteStepData, SwapErrorRight>> {
-  const { tx, sellAsset, spenderAddress, input, deps } = args
+  const { tx, sellAsset, sellAmountCryptoBaseUnit, spenderAddress, input, deps } = args
 
   const adapter = deps.assertGetEvmChainAdapter(sellAsset.chainId)
   const supportsEIP1559 = 'supportsEIP1559' in input ? input.supportsEIP1559 : false
@@ -48,7 +49,7 @@ export async function getPortalsStepData(
         try {
           const gasLimit = await estimateGasWithStateOverride({
             sellAsset,
-            sellAmountCryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+            sellAmountCryptoBaseUnit,
             from: tx.from,
             spenderAddress,
             to: tx.to,
@@ -103,7 +104,7 @@ export async function getPortalsStepData(
       supportsEIP1559,
       stateOverride: {
         sellAsset,
-        sellAmountCryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        sellAmountCryptoBaseUnit,
         spenderAddress,
       },
     })

--- a/packages/swapper/src/swappers/PortalsSwapper/utils/getPortalsTradeContext.ts
+++ b/packages/swapper/src/swappers/PortalsSwapper/utils/getPortalsTradeContext.ts
@@ -25,7 +25,13 @@ type PortalsTradeContext = {
   tradeCommon: TradeCommon
   stepCommon: Omit<TradeStepCommon, 'feeData'>
   protocolFees: QuoteFeeData['protocolFees']
-  stepDataArgs: { deps: SwapperDeps; sellAsset: Asset; spenderAddress: string; tx: PortalsTx }
+  stepDataArgs: {
+    deps: SwapperDeps
+    sellAsset: Asset
+    sellAmountCryptoBaseUnit: string
+    spenderAddress: string
+    tx: PortalsTx
+  }
 }
 
 export const getPortalsTradeContext = ({
@@ -124,6 +130,12 @@ export const getPortalsTradeContext = ({
       }),
     },
     protocolFees,
-    stepDataArgs: { deps, sellAsset, spenderAddress: allowanceContract, tx },
+    stepDataArgs: {
+      deps,
+      sellAsset,
+      sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+      spenderAddress: allowanceContract,
+      tx,
+    },
   })
 }

--- a/packages/swapper/src/swappers/RelaySwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/endpoints.ts
@@ -8,12 +8,18 @@ import { getUnsignedSolanaTransaction } from '../../utils/solana/getUnsignedSola
 import { getTronTransactionFees, getUnsignedTronTransaction } from '../../utils/tron'
 import { getUnsignedUtxoTransaction, getUtxoTransactionFees } from '../../utils/utxo'
 import { chainIdToRelayChainId } from './constant'
-import { getTradeQuote } from './getTradeQuote/getTradeQuote'
-import { getTradeRate } from './getTradeRate/getTradeRate'
+import { getExactOutputTradeQuote, getTradeQuote } from './getTradeQuote/getTradeQuote'
+import { getExactOutputTradeRate, getTradeRate } from './getTradeRate/getTradeRate'
 import { getLatestRelayStatusMessage } from './utils/getLatestRelayStatusMessage'
 import { notifyTransactionIndexing } from './utils/notifyTransactionIndexing'
 import { getRelayRequestConfig, relayService } from './utils/relayService'
-import type { RelayStatus, RelayTradeQuoteInput, RelayTradeRateInput } from './utils/types'
+import type {
+  RelayExactOutputTradeQuoteInput,
+  RelayExactOutputTradeRateInput,
+  RelayStatus,
+  RelayTradeQuoteInput,
+  RelayTradeRateInput,
+} from './utils/types'
 
 // Keep track of the trades we already notified the relay indexer about
 const txIndexingMap: Map<string, boolean> = new Map()
@@ -24,6 +30,20 @@ export const relayApi: SwapperApi = {
   },
   getTradeRate: (input, deps) => {
     return getTradeRate(input as RelayTradeRateInput, deps, chainIdToRelayChainId)
+  },
+  getExactOutputTradeQuote: (input, deps) => {
+    return getExactOutputTradeQuote(
+      input as RelayExactOutputTradeQuoteInput,
+      deps,
+      chainIdToRelayChainId,
+    )
+  },
+  getExactOutputTradeRate: (input, deps) => {
+    return getExactOutputTradeRate(
+      input as RelayExactOutputTradeRateInput,
+      deps,
+      chainIdToRelayChainId,
+    )
   },
   getEvmTransactionFees,
   getUnsignedEvmTransaction,

--- a/packages/swapper/src/swappers/RelaySwapper/getTradeQuote/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/getTradeQuote/getTradeQuote.ts
@@ -14,10 +14,10 @@ import { FALLBACK_QUOTE_DEADLINE_MS } from '../../../utils/helpers'
 import type { chainIdToRelayChainId as relayChainMapImplementation } from '../constant'
 import { getRelayStepData } from '../utils/getRelayStepData'
 import { getRelayTradeContext } from '../utils/getRelayTradeContext'
-import type { RelayTradeQuoteInput } from '../utils/types'
+import type { RelayExactOutputTradeQuoteInput, RelayTradeQuoteInput } from '../utils/types'
 
-export const getTradeQuote = async (
-  input: RelayTradeQuoteInput,
+const getQuote = async (
+  input: RelayTradeQuoteInput | RelayExactOutputTradeQuoteInput,
   deps: SwapperDeps,
   relayChainMap: typeof relayChainMapImplementation,
 ): Promise<Result<TradeQuote[], SwapErrorRight>> => {
@@ -82,3 +82,15 @@ export const getTradeQuote = async (
 
   return Ok([tradeQuote])
 }
+
+export const getTradeQuote = (
+  input: RelayTradeQuoteInput,
+  deps: SwapperDeps,
+  relayChainMap: typeof relayChainMapImplementation,
+): Promise<Result<TradeQuote[], SwapErrorRight>> => getQuote(input, deps, relayChainMap)
+
+export const getExactOutputTradeQuote = (
+  input: RelayExactOutputTradeQuoteInput,
+  deps: SwapperDeps,
+  relayChainMap: typeof relayChainMapImplementation,
+): Promise<Result<TradeQuote[], SwapErrorRight>> => getQuote(input, deps, relayChainMap)

--- a/packages/swapper/src/swappers/RelaySwapper/getTradeRate/getTradeRate.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/getTradeRate/getTradeRate.ts
@@ -12,10 +12,10 @@ import type {
 import type { chainIdToRelayChainId as relayChainMapImplementation } from '../constant'
 import { getRelayStepData } from '../utils/getRelayStepData'
 import { getRelayTradeContext } from '../utils/getRelayTradeContext'
-import type { RelayTradeRateInput } from '../utils/types'
+import type { RelayExactOutputTradeRateInput, RelayTradeRateInput } from '../utils/types'
 
-export const getTradeRate = async (
-  input: RelayTradeRateInput,
+const getRate = async (
+  input: RelayTradeRateInput | RelayExactOutputTradeRateInput,
   deps: SwapperDeps,
   relayChainMap: typeof relayChainMapImplementation,
 ): Promise<Result<TradeRate[], SwapErrorRight>> => {
@@ -64,3 +64,15 @@ export const getTradeRate = async (
 
   return Ok([tradeRate])
 }
+
+export const getTradeRate = (
+  input: RelayTradeRateInput,
+  deps: SwapperDeps,
+  relayChainMap: typeof relayChainMapImplementation,
+): Promise<Result<TradeRate[], SwapErrorRight>> => getRate(input, deps, relayChainMap)
+
+export const getExactOutputTradeRate = (
+  input: RelayExactOutputTradeRateInput,
+  deps: SwapperDeps,
+  relayChainMap: typeof relayChainMapImplementation,
+): Promise<Result<TradeRate[], SwapErrorRight>> => getRate(input, deps, relayChainMap)

--- a/packages/swapper/src/swappers/RelaySwapper/utils/getRelayTradeContext.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/getRelayTradeContext.ts
@@ -23,7 +23,7 @@ import type {
 import { MixPanelEvent, SwapperName, TradeQuoteError } from '../../../types'
 import { getInputOutputRate, makeSwapErrorRight } from '../../../utils'
 import { buildAffiliateFee } from '../../../utils/affiliateFee'
-import { isNativeEvmAsset } from '../../../utils/helpers'
+import { getTradeAmount, isNativeEvmAsset } from '../../../utils/helpers'
 import type { chainIdToRelayChainId as relayChainMapImplementation } from '../constant'
 import { MAXIMUM_SUPPORTED_RELAY_STEPS, relayErrorCodeToTradeQuoteError } from '../constant'
 import { getRelayAssetAddress } from '../utils/getRelayAssetAddress'
@@ -32,7 +32,13 @@ import { relayTokenToAssetId } from '../utils/relayTokenToAssetId'
 import { fetchRelayTrade } from './fetchRelayTrade'
 import type { GetRelayStepDataArgs } from './getRelayStepData'
 import { assertValidTrade, getRelayAllowanceContract, resolveRelayAddresses } from './helpers'
-import type { RelayQuoteItem, RelayTradeQuoteInput, RelayTradeRateInput } from './types'
+import type {
+  RelayExactOutputTradeQuoteInput,
+  RelayExactOutputTradeRateInput,
+  RelayQuoteItem,
+  RelayTradeQuoteInput,
+  RelayTradeRateInput,
+} from './types'
 import { isRelayError } from './types'
 
 type RelayTradeContext = {
@@ -50,11 +56,18 @@ export const getRelayTradeContext = async ({
   deps,
   relayChainMap,
 }: {
-  input: RelayTradeQuoteInput | RelayTradeRateInput
+  input:
+    | RelayTradeQuoteInput
+    | RelayTradeRateInput
+    | RelayExactOutputTradeQuoteInput
+    | RelayExactOutputTradeRateInput
   deps: SwapperDeps
   relayChainMap: typeof relayChainMapImplementation
 }): Promise<Result<RelayTradeContext, SwapErrorRight>> => {
-  const { sellAsset, buyAsset, sellAmountIncludingProtocolFeesCryptoBaseUnit, affiliateBps } = input
+  const { sellAsset, buyAsset, affiliateBps } = input
+
+  const amount = getTradeAmount(input)
+  const isExactOutput = amount.direction === 'exactOut'
 
   const xpub = 'xpub' in input ? input.xpub : undefined
 
@@ -78,8 +91,8 @@ export const getRelayTradeContext = async ({
       originCurrency: getRelayAssetAddress(sellAsset),
       destinationChainId: buyRelayChainId,
       destinationCurrency: getRelayAssetAddress(buyAsset),
-      tradeType: 'EXACT_INPUT',
-      amount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+      tradeType: isExactOutput ? 'EXACT_OUTPUT' : 'EXACT_INPUT',
+      amount: amount.cryptoBaseUnit,
       recipient,
       user: sendAddress,
       refundTo,
@@ -141,12 +154,25 @@ export const getRelayTradeContext = async ({
     )
   }
 
-  const { slippageTolerance, currencyOut, timeEstimate } = quote.details
+  const { slippageTolerance, currencyIn, currencyOut, timeEstimate } = quote.details
 
-  const buyAmountAfterFeesCryptoBaseUnit = currencyOut.amount
+  const sellAmountCryptoBaseUnit = currencyIn.amount
+
+  const buyAmountAfterFeesCryptoBaseUnit = isExactOutput
+    ? currencyOut.minimumAmount
+    : currencyOut.amount
+
+  if (isExactOutput && !bnOrZero(buyAmountAfterFeesCryptoBaseUnit).eq(amount.cryptoBaseUnit)) {
+    return Err(
+      makeSwapErrorRight({
+        message: `Relay guarantees ${buyAmountAfterFeesCryptoBaseUnit} against a requested exact output of ${amount.cryptoBaseUnit}`,
+        code: TradeQuoteError.InvalidResponse,
+      }),
+    )
+  }
 
   const rate = getInputOutputRate({
-    sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    sellAmountCryptoBaseUnit,
     buyAmountCryptoBaseUnit: buyAmountAfterFeesCryptoBaseUnit,
     sellAsset,
     buyAsset,
@@ -354,7 +380,7 @@ export const getRelayTradeContext = async ({
 
   // Add back relayer service and gas fees (relayer is including both) since they are downsides,
   // and add appFees — these are quote-level and identical across every step
-  const buyAmountBeforeFeesCryptoBaseUnit = bnOrZero(currencyOut.amount)
+  const buyAmountBeforeFeesCryptoBaseUnit = bnOrZero(buyAmountAfterFeesCryptoBaseUnit)
     .plus(relayerFeesBuyAssetCryptoBaseUnit)
     .plus(appFeesBaseUnit)
     .toFixed()
@@ -371,6 +397,7 @@ export const getRelayTradeContext = async ({
       id: relayId,
       rate,
       swapperName: SwapperName.Relay,
+      isExactOutput,
       affiliateBps,
       slippageTolerancePercentageDecimal,
     },
@@ -378,7 +405,7 @@ export const getRelayTradeContext = async ({
       rate,
       buyAmountBeforeFeesCryptoBaseUnit,
       buyAmountAfterFeesCryptoBaseUnit,
-      sellAmountIncludingProtocolFeesCryptoBaseUnit,
+      sellAmountIncludingProtocolFeesCryptoBaseUnit: sellAmountCryptoBaseUnit,
       buyAsset,
       sellAsset,
       source: SwapperName.Relay,
@@ -388,7 +415,7 @@ export const getRelayTradeContext = async ({
         affiliateBps,
         sellAsset,
         buyAsset,
-        sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        sellAmountCryptoBaseUnit,
         buyAmountCryptoBaseUnit: buyAmountAfterFeesCryptoBaseUnit,
         fixedAssetId: chainIdToFeeAssetId(baseChainId),
         fixedAsset: deps.assetsById[chainIdToFeeAssetId(baseChainId)],
@@ -406,7 +433,7 @@ export const getRelayTradeContext = async ({
     relayStepInputs,
     stepDataArgs: {
       sellAsset,
-      sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+      sellAmountCryptoBaseUnit,
       orderId,
       from: sendAddress,
       xpub,

--- a/packages/swapper/src/swappers/RelaySwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/helpers.ts
@@ -13,6 +13,8 @@ import { makeSwapErrorRight } from '../../../utils'
 import type { chainIdToRelayChainId as relayChainMapImplementation } from '../constant'
 import { getRelayDefaultUserAddress } from './getRelayDefaultUserAddress'
 import type {
+  RelayExactOutputTradeQuoteInput,
+  RelayExactOutputTradeRateInput,
   RelayQuoteItem,
   RelaySolanaInstruction,
   RelayTradeQuoteInput,
@@ -86,7 +88,11 @@ export const resolveRelayAddresses = ({
   sellChainId,
   buyChainId,
 }: {
-  input: RelayTradeQuoteInput | RelayTradeRateInput
+  input:
+    | RelayTradeQuoteInput
+    | RelayTradeRateInput
+    | RelayExactOutputTradeQuoteInput
+    | RelayExactOutputTradeRateInput
   sellChainId: ChainId
   buyChainId: ChainId
 }): { sendAddress: string; recipient: string; refundTo: string } => {

--- a/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
+++ b/packages/swapper/src/swappers/RelaySwapper/utils/types.ts
@@ -7,6 +7,7 @@ import type {
   GetTronTradeRateInput,
   GetUtxoTradeQuoteInput,
   GetUtxoTradeRateInput,
+  WithExactBuyAmount,
 } from '../../../types'
 
 export type RelayTradeQuoteInput =
@@ -20,6 +21,9 @@ export type RelayTradeRateInput =
   | GetUtxoTradeRateInput
   | GetSolanaTradeRateInput
   | GetTronTradeRateInput
+
+export type RelayExactOutputTradeQuoteInput = WithExactBuyAmount<RelayTradeQuoteInput>
+export type RelayExactOutputTradeRateInput = WithExactBuyAmount<RelayTradeRateInput>
 
 // Only the Tron unsigned-tx builder consumes this (to + calldata); every other
 // ecosystem's build data lives on transactionData
@@ -108,6 +112,7 @@ export type RelayFees = {
 }
 
 export type QuoteDetails = {
+  currencyIn: RelayCurrencyData
   currencyOut: RelayCurrencyData
   rate: string
   slippageTolerance: {

--- a/packages/swapper/src/swappers/SunioSwapper/utils/getSunioStepData.ts
+++ b/packages/swapper/src/swappers/SunioSwapper/utils/getSunioStepData.ts
@@ -7,7 +7,7 @@ import { makeNetworkFeeEstimationFailedErr } from '../../../utils'
 import type { SunioRoute, SunioTransactionData } from '../types'
 import { estimateSunioNetworkFeeCryptoBaseUnit } from './estimateSunioNetworkFee'
 
-type BaseArgs = { route: SunioRoute }
+type BaseArgs = { route: SunioRoute; sellAmountCryptoBaseUnit: string }
 
 export type GetSunioStepDataArgs = StepDataArgs<BaseArgs>
 
@@ -26,13 +26,13 @@ export function getSunioStepData(
 export async function getSunioStepData(
   args: GetSunioStepDataArgs,
 ): Promise<Result<SunioRateStepData | SunioQuoteStepData, SwapErrorRight>> {
-  const { type, route, sellAsset, from, input, deps } = args
+  const { type, route, sellAsset, sellAmountCryptoBaseUnit, from, input, deps } = args
 
   const estimateArgs = {
     rpcUrl: deps.config.VITE_TRON_NODE_URL,
     apiKey: deps.config.VITE_TRON_GRID_API_KEY,
     route,
-    sellAmountCryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit,
+    sellAmountCryptoBaseUnit,
     isSellingNativeTrx: !contractAddressOrUndefined(sellAsset.assetId),
     address: from,
     slippageTolerancePercentageDecimal: input.slippageTolerancePercentageDecimal,

--- a/packages/swapper/src/swappers/SunioSwapper/utils/getSunioTradeContext.ts
+++ b/packages/swapper/src/swappers/SunioSwapper/utils/getSunioTradeContext.ts
@@ -124,7 +124,12 @@ export const getSunioTradeContext = async ({
         }),
       },
       protocolFees,
-      stepDataArgs: { deps, sellAsset, route: bestRoute },
+      stepDataArgs: {
+        deps,
+        sellAsset,
+        sellAmountCryptoBaseUnit: sellAmountIncludingProtocolFeesCryptoBaseUnit,
+        route: bestRoute,
+      },
     })
   } catch (error) {
     return Err(

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -319,7 +319,9 @@ export type GetTradeRateInput =
   | GetStarknetTradeRateInput
   | GetSuiTradeRateInput
 
-export type WithExactBuyAmount<T> = T extends unknown
+export type WithExactBuyAmount<
+  T extends { sellAmountIncludingProtocolFeesCryptoBaseUnit: string },
+> = T extends unknown
   ? Omit<T, 'sellAmountIncludingProtocolFeesCryptoBaseUnit'> & { buyAmountCryptoBaseUnit: string }
   : never
 

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -137,6 +137,8 @@ export enum TradeQuoteError {
   UnsupportedChain = 'UnsupportedChain',
   // the swapper can't swap across chains
   CrossChainNotSupported = 'CrossChainNotSupported',
+  // the swapper can quote this pair, but can't derive a sell amount from an exact buy amount
+  ExactOutputNotSupported = 'ExactOutputNotSupported',
   // the swapper wasn't able to get a network fee estimate
   NetworkFeeEstimationFailed = 'NetworkFeeEstimationFailed',
   // trading has been halted upstream
@@ -317,14 +319,29 @@ export type GetTradeRateInput =
   | GetStarknetTradeRateInput
   | GetSuiTradeRateInput
 
+export type WithExactBuyAmount<T> = T extends unknown
+  ? Omit<T, 'sellAmountIncludingProtocolFeesCryptoBaseUnit'> & { buyAmountCryptoBaseUnit: string }
+  : never
+
+export type GetExactOutputTradeQuoteInput = WithExactBuyAmount<GetTradeQuoteInput>
+export type GetExactOutputTradeRateInput = WithExactBuyAmount<GetTradeRateInput>
+
+export type TradeAmount = {
+  direction: 'exactIn' | 'exactOut'
+  cryptoBaseUnit: string
+}
+
 type StepDataBaseArgs = {
   deps: SwapperDeps
   sellAsset: Asset
 }
 
+type StepDataRateInput = GetTradeRateInput | GetExactOutputTradeRateInput
+type StepDataQuoteInput = GetTradeQuoteInput | GetExactOutputTradeQuoteInput
+
 export type StepDataArgs<Base, Rate = unknown, Quote = unknown> =
-  | (StepDataBaseArgs & Base & { type: 'rate'; input: GetTradeRateInput; from?: string } & Rate)
-  | (StepDataBaseArgs & Base & { type: 'quote'; input: GetTradeQuoteInput; from: string } & Quote)
+  | (StepDataBaseArgs & Base & { type: 'rate'; input: StepDataRateInput; from?: string } & Rate)
+  | (StepDataBaseArgs & Base & { type: 'quote'; input: StepDataQuoteInput; from: string } & Quote)
 
 export type EvmSwapperDeps = {
   assertGetEvmChainAdapter: (chainId: ChainId) => EvmChainAdapter
@@ -464,6 +481,7 @@ export type TradeCommon = {
   slippageTolerancePercentageDecimal: string | undefined // undefined if slippage limit is not provided or specified by the swapper
   isLongtail?: boolean
   swapperName: SwapperName // The swapper that generated this quote/rate
+  isExactOutput?: boolean
 }
 
 type TradeQuoteBase = TradeCommon & {
@@ -815,6 +833,16 @@ export type SwapperApi = {
 
   getTradeQuote: (input: GetTradeQuoteInput, deps: SwapperDeps) => Promise<TradeQuoteResult>
   getTradeRate: (input: GetTradeRateInput, deps: SwapperDeps) => Promise<TradeRateResult>
+
+  // Implemented only where upstream can honour an exact buy amount and derive the sell amount
+  getExactOutputTradeQuote?: (
+    input: GetExactOutputTradeQuoteInput,
+    deps: SwapperDeps,
+  ) => Promise<TradeQuoteResult>
+  getExactOutputTradeRate?: (
+    input: GetExactOutputTradeRateInput,
+    deps: SwapperDeps,
+  ) => Promise<TradeRateResult>
 
   getUnsignedEvmTransaction?: (input: GetUnsignedEvmTransactionArgs) => Promise<SignTx<EvmChainId>>
   getUnsignedEvmMessage?: (input: GetUnsignedEvmMessageArgs) => Promise<EvmMessageToSign>

--- a/packages/swapper/src/utils/helpers.ts
+++ b/packages/swapper/src/utils/helpers.ts
@@ -34,8 +34,20 @@ import {
   isTreasuryChainId,
 } from '@shapeshiftoss/utils'
 
+import type { TradeAmount } from '../types'
+
 // Deadline for providers without their own expiry - short enough to keep priced amounts honest
 export const FALLBACK_QUOTE_DEADLINE_MS = 60_000
+
+// Only an exact-output input carries a buy amount, and it carries no sell amount to confuse it with
+export const getTradeAmount = (
+  input:
+    | { sellAmountIncludingProtocolFeesCryptoBaseUnit: string }
+    | { buyAmountCryptoBaseUnit: string },
+): TradeAmount =>
+  'buyAmountCryptoBaseUnit' in input
+    ? { direction: 'exactOut', cryptoBaseUnit: input.buyAmountCryptoBaseUnit }
+    : { direction: 'exactIn', cryptoBaseUnit: input.sellAmountIncludingProtocolFeesCryptoBaseUnit }
 
 // Bands are unambiguous for any realistic date: unix s land ~2e9, ms ~2e12, µs ~2e15, ns ~2e18
 export const normalizeEpochToMs = (value: number): number => {

--- a/packages/swapper/src/utils/helpers.ts
+++ b/packages/swapper/src/utils/helpers.ts
@@ -39,7 +39,6 @@ import type { TradeAmount } from '../types'
 // Deadline for providers without their own expiry - short enough to keep priced amounts honest
 export const FALLBACK_QUOTE_DEADLINE_MS = 60_000
 
-// Only an exact-output input carries a buy amount, and it carries no sell amount to confuse it with
 export const getTradeAmount = (
   input:
     | { sellAmountIncludingProtocolFeesCryptoBaseUnit: string }

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1012,6 +1012,7 @@
       "quoteExpired": "Quote expired, try again.",
       "quoteUnsupportedChain": "Chain not supported",
       "quoteCrossChainNotSupported": "Cross chain not supported",
+      "quoteExactOutputNotSupported": "Exact receive amount not supported",
       "crossAccountNotSupported": "Cross-account not supported",
       "networkFeeEstimateFailed": "Failed to estimate network fee",
       "assetNotSupportedByWallet": "%{assetSymbol}.%{chainSymbol} not supported by wallet",

--- a/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
+++ b/src/components/MultiHopTrade/components/TradeInput/getQuoteErrorTranslation.ts
@@ -47,6 +47,8 @@ export const getQuoteErrorTranslation = (
         return 'trade.errors.quoteUnsupportedChain'
       case SwapperTradeQuoteError.CrossChainNotSupported:
         return 'trade.errors.quoteCrossChainNotSupported'
+      case SwapperTradeQuoteError.ExactOutputNotSupported:
+        return 'trade.errors.quoteExactOutputNotSupported'
       case SwapperTradeQuoteError.NetworkFeeEstimationFailed:
         return 'trade.errors.networkFeeEstimateFailed'
       case SwapperTradeQuoteError.RateLimitExceeded:

--- a/src/state/apis/swapper/helpers/validateTradeQuote.ts
+++ b/src/state/apis/swapper/helpers/validateTradeQuote.ts
@@ -79,6 +79,7 @@ export const validateTradeQuote = (
       switch (errorCode) {
         case SwapperTradeQuoteError.UnsupportedChain:
         case SwapperTradeQuoteError.CrossChainNotSupported:
+        case SwapperTradeQuoteError.ExactOutputNotSupported:
         case SwapperTradeQuoteError.NetworkFeeEstimationFailed:
         case SwapperTradeQuoteError.QueryFailed:
         case SwapperTradeQuoteError.InternalError:


### PR DESCRIPTION
## Description

Adds a buy-amount-driven quoting mode alongside the existing sell-amount one. The caller supplies a
buy amount and the sell amount comes back derived from the provider's response.

Exact output is declared on `SwapperApi` as an optional method pair, so a swapper cannot claim the
capability without implementing it, and `getTradeRates` / `getTradeQuotes` dispatch on the input
shape. Swappers that cannot derive a sell amount from an exact buy amount return
`ExactOutputNotSupported` rather than silently vanishing, so consumers can tell "cannot do this mode"
apart from "unavailable". **NEAR Intents and Relay** support it today.

Exact-output inputs carry `buyAmountCryptoBaseUnit` and no sell amount at all, so there is no
dishonest `'0'` for downstream code to trust. Both providers are populated from their response rather
than the request — NEAR's deposit transaction is built from `quote.amountIn` and Relay's from
`currencyIn.amount`, neither of which the request carries in this mode.

`public-api` takes `buyAmountCryptoBaseUnit` on both `/swap/rates` and `/swap/quote`, mutually
exclusive with `sellAmountCryptoBaseUnit`.

The `src/` changes are not optional: adding `ExactOutputNotSupported` to `TradeQuoteError` breaks two
exhaustive switches in the web app, so the case handling and translation ship with it.

Stacked below #12547, which consumes this from the swap widget.

## Issue (if applicable)

closes #

## Risk

Medium. Touches shared swapper quoting paths, though exact output is inert unless a caller passes a
buy amount — every existing sell-amount flow takes the same code path it did before.

The one behavioural choice worth reviewer attention: **Relay's exact output reads
`currencyOut.minimumAmount`, not `currencyOut.amount`.** `minimumAmount` is the figure Relay commits
to, and it is the one verified equal to the requested amount across every route measured — 36
pair/slippage combinations, zero deviations. It is now the honoured amount, guarded by an assertion
against the request, so a future divergence fails loudly rather than silently shipping a shortfall.

In practice the two fields have been identical on every route I have been able to probe, so this is
belt-and-braces rather than a fix for observed breakage. `amount` is documented as the expected
output and `minimumAmount` as the floor; committing to the floor is the conservative read, and the
assertion is what actually protects the guarantee.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

NEAR Intents and Relay quoting and deposit-transaction construction. Ten other swappers get a
one-line `maxSellAmountCryptoBaseUnit` addition and are otherwise untouched.

## Testing

### Engineering

Exact output was verified against mainnet APIs at quote time and then settled on-chain.

**Quote-time**, re-runnable against a local `public-api`:

```bash
# exact output — NEAR Intents and Relay price it, everything else reports ExactOutputNotSupported
curl "localhost:3005/v1/swap/rates?sellAssetId=eip155:8453/erc20:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913\
&buyAssetId=bip122:000000000019d6689c085ae165831e93/slip44:0&buyAmountCryptoBaseUnit=100000"
```

Both providers return `buyAmountCryptoBaseUnit` exactly equal to the request, with only the sell side
moving. Relay's exactness was checked across **36 pair/slippage combinations** — zero deviations
between `currencyOut.minimumAmount` and the requested amount, spanning same-chain Base, Base↔Arbitrum
and BTC destinations.

Affiliate fees were confirmed input-denominated and additive on both providers, so the output stays
pinned: NEAR at 0→100bps moved input 65,232,833 → 65,892,418 with output 100,000 both times.

**Settlement**, the part quote-time evidence cannot establish — one real swap through each provider,
`ETH(Base) → 0.5 USDC(Base)` exact out. Both delivered **exactly 500000 base units**, not merely at
least.

Unit coverage: `packages/swapper/src/exactOutputFiltering.test.ts` (capability filtering, and that a
non-supporting swapper is never invoked with an exact buy amount) and
`NearIntentsSwapper/utils/exactOutput.test.ts`.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not flagged, but inert by construction — no existing caller passes a buy amount, so no user-facing
behaviour changes until the swap widget PR lands. The one thing worth a regression pass is that
ordinary sell-amount swaps on NEAR Intents and Relay still quote and execute normally.

## Screenshots (if applicable)

n/a — no UI in this PR.
