### PR TITLE
fix(swap-widget): allow release-widget.shapeshift.com in vite preview

### DIFF
--- a/packages/swap-widget/vite.config.ts
+++ b/packages/swap-widget/vite.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
   preview: {
     port: Number(process.env.PORT) || 3000,
     host: true,
-    allowedHosts: ['dev-widget.shapeshift.com', 'widget.shapeshift.com'],
+    allowedHosts: [
+      'dev-widget.shapeshift.com',
+      'release-widget.shapeshift.com',
+      'widget.shapeshift.com',
+    ],
   },
 })


### PR DESCRIPTION
## Description

The swap widget release deployment serves the built app via `vite preview`, which rejects any `Host` header not in `preview.allowedHosts`:

```
Blocked request. This host ("release-widget.shapeshift.com") is not allowed.
```

Adds `release-widget.shapeshift.com` to the allowlist alongside the existing dev and prod hosts, so the release environment can serve the widget.

## Issue (if applicable)

closes #

## Risk

Near zero. Build/serve config only — one entry added to `preview.allowedHosts` in `packages/swap-widget/vite.config.ts`. No runtime, protocol, transaction, wallet or contract code is touched. It only widens which `Host` headers `vite preview` will answer to.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

```
pnpm --filter @shapeshiftoss/swap-widget build
PORT=3000 pnpm --filter @shapeshiftoss/swap-widget preview
curl -s -o /dev/null -w '%{http_code}\n' -H 'Host: release-widget.shapeshift.com' http://localhost:3000/   # 200
curl -s -H 'Host: nope.example.com' http://localhost:3000/                                                 # still blocked
```

Existing `dev-widget.shapeshift.com` / `widget.shapeshift.com` deployments are unaffected. The release deploy needs a rebuild/redeploy to pick this up.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Infra/config only — nothing user-facing to test beyond `release-widget.shapeshift.com` loading the widget instead of returning the blocked-host error.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview access for the widget when hosted at `release-widget.shapeshift.com`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->