### PR TITLE
fix(public-api): stop serving bebop solana, and unbreak its dispatch

### DIFF
--- a/packages/public-api/src/constants.ts
+++ b/packages/public-api/src/constants.ts
@@ -72,6 +72,16 @@ export const ENABLED_SWAPPER_NAMES: readonly SwapperName[] = [
   SwapperName.Zrx,
 ]
 
+// Bebop settles solana RFQ orders off-chain via its own api - broadcasting the tx never settles it
+const EXCLUDED_SWAPPER_NAMESPACES: Partial<Record<SwapperName, ReadonlySet<string>>> = {
+  [SwapperName.Bebop]: new Set([CHAIN_NAMESPACE.Solana]),
+}
+
+export const isSwapperExecutableOnSellChain = (
+  swapperName: SwapperName,
+  chainId: string,
+): boolean => !EXCLUDED_SWAPPER_NAMESPACES[swapperName]?.has(fromChainId(chainId).chainNamespace)
+
 // Sanity ceiling catching provider deadline bugs (unit inflation, sentinel far-future dates).
 // Widest legitimate deadline today is chainflip's 6h - raise this if a swapper ever quotes longer.
 export const MAX_QUOTE_DEADLINE_MS = 7 * 24 * 60 * 60 * 1000

--- a/packages/public-api/src/routes/quote/getQuote.ts
+++ b/packages/public-api/src/routes/quote/getQuote.ts
@@ -1,4 +1,5 @@
 import { CHAIN_NAMESPACE, fromChainId } from '@shapeshiftoss/caip'
+import { isEvmChainId } from '@shapeshiftoss/chain-adapters'
 import { viemClientByChainId } from '@shapeshiftoss/contracts'
 import type { GetExactOutputTradeQuoteInput, GetTradeQuoteInput } from '@shapeshiftoss/swapper'
 import {
@@ -15,6 +16,7 @@ import { getAsset } from '../../assets'
 import {
   ENABLED_SWAPPER_NAMES,
   isExecutableSellChainId,
+  isSwapperExecutableOnSellChain,
   MAX_QUOTE_DEADLINE_MS,
 } from '../../constants'
 import { env } from '../../env'
@@ -108,6 +110,14 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       return
     }
 
+    if (!isSwapperExecutableOnSellChain(validSwapperName, sellAsset.chainId)) {
+      res.status(400).json({
+        error: `${swapperName} cannot be executed on ${sellAsset.chainId}`,
+        code: 'SWAPPER_UNSUPPORTED_SELL_CHAIN',
+      } satisfies ErrorResponse)
+      return
+    }
+
     const buyAsset = getAsset(buyAssetId)
     if (!buyAsset) {
       res.status(400).json({ error: `Unknown buy asset: ${buyAssetId}` } satisfies ErrorResponse)
@@ -152,8 +162,7 @@ export const getQuote = async (req: Request, res: Response): Promise<void> => {
       xpub,
       quoteOrRate: 'quote' as const,
       chainId: sellAsset.chainId,
-      // Consumers sign themselves - price with legacy gas semantics
-      supportsEIP1559: false,
+      ...(isEvmChainId(sellAsset.chainId) && { supportsEIP1559: false as const }),
     }
 
     // The input union narrows chainId per chain family; utxo accountType/xpub are unmodelled too

--- a/packages/public-api/src/routes/rates/getRates.ts
+++ b/packages/public-api/src/routes/rates/getRates.ts
@@ -4,7 +4,11 @@ import { getTradeRates, swappers, TradeQuoteError } from '@shapeshiftoss/swapper
 import type { Request, Response } from 'express'
 
 import { getAsset } from '../../assets'
-import { ENABLED_SWAPPER_NAMES, isExecutableSellChainId } from '../../constants'
+import {
+  ENABLED_SWAPPER_NAMES,
+  isExecutableSellChainId,
+  isSwapperExecutableOnSellChain,
+} from '../../constants'
 import { env } from '../../env'
 import { registry } from '../../registry'
 import { getSwapperDeps } from '../../swapperDeps'
@@ -103,6 +107,7 @@ export const getRates = async (req: Request, res: Response): Promise<void> => {
       try {
         const swapper = swappers[swapperName]
         if (!swapper) return null
+        if (!isSwapperExecutableOnSellChain(swapperName, sellAsset.chainId)) return null
 
         const result = await getTradeRates(
           rateInput as GetTradeRateInput | GetExactOutputTradeRateInput,


### PR DESCRIPTION
## Description

Two independent defects on Bebop's Solana path, both pre-dating this branch (introduced with #12502). It's the same class of problem CoW Swap was disabled for in #12586, but Bebop stayed enabled.

**1. The quote could never be reached.** `bebopApi.getTradeQuote` dispatches on the key *being present*, not its value (`packages/swapper/src/swappers/BebopSwapper/endpoints.ts:22`):

```ts
return 'supportsEIP1559' in quoteInput
  ? getBebopTradeQuote(quoteInput, deps)      // evm
  : getBebopSolanaTradeQuote(quoteInput, deps)
```

`getQuote` set `supportsEIP1559: false` unconditionally, so a Solana sell with `swapperName: 'Bebop'` routed into the EVM implementation and died. `getRates` already scoped the key to EVM chains, so rates and quotes disagreed: Bebop could serve a Solana rate that no client could then quote. `getQuote` now matches `getRates`.

**2. Even reached, an API client can't execute it.** `getBebopSolanaTradeQuote` does emit `transactionData` — `{ type: 'solana_serialized_tx', serializedTx }` — so it passes the presence assertion added in #12586. But `BebopSolanaMessageToSign` (`packages/swapper/src/types.ts:650`) settles by submitting the signature to *Bebop's* API keyed by the RFQ `quoteId`, and `SolanaMessageExecutionProps` spells out the split: "sign only - the swapper submits the signature to its own api (bebop RFQ orders)" versus "sign and broadcast on chain ... (across)".

Both arrive over the wire as the identical `solana_serialized_tx`. A client can't tell them apart, and broadcasting a Bebop order directly signs it away without ever settling. So fixing the dispatch **alone** would have converted an unreachable-but-safe path into a reachable-and-dangerous one — the exclusion is the load-bearing half here.

Bebop is therefore excluded on Solana in both routes via `isSwapperExecutableOnSellChain`, until the wire can distinguish sign-only from sign-and-broadcast. Its EVM path is untouched. Tracked in SS-5760.

The quote rejection uses `code: 'SWAPPER_UNSUPPORTED_SELL_CHAIN'`, deliberately distinct from `UNSUPPORTED_SELL_CHAIN`: that one means the chain can't be sold by anyone and the client should drop it, whereas here the chain is fine and the client should pick another swapper.

## Issue (if applicable)

closes #

## Risk

Low. Removes a route that could not be completed by any API client, and repairs an input-shaping bug on a path that previously always errored.

- **Bebop Solana rates** no longer appear. They were unfulfillable — a client selecting one hit a failing quote (before this) or an unsettleable order (after a naive dispatch fix).
- **Bebop EVM** is unchanged, verified live.
- **Non-Bebop Solana** is unchanged, verified live — Chainflip/Relay/NEAR Intents/ButterSwap still quote Solana normally.
- The `supportsEIP1559` change only removes the key for non-EVM sells, matching what `getRates` already did.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Bebop on Solana only. No transaction construction changes for any other swapper or chain.

## Testing

### Engineering

Verified end-to-end against a locally built server hitting **real mainnet** endpoints, at `87684c9952`:

| Check | Result |
| --- | --- |
| Bebop in SOL→USDC rates | absent; 8 other swappers still returned |
| Bebop + SOL quote | `400 SWAPPER_UNSUPPORTED_SELL_CHAIN` |
| Bebop ETH→USDC quote | `200`, `transactionData.type: evm` |
| Chainflip SOL→BTC quote | `200`, `transactionData.type: solana_instructions` |
| Integration suite | 44/44 |

```
pnpm run type-check     # exit 0
pnpm exec eslint 'packages/public-api/**/*.ts'   # exit 0
pnpm --filter @shapeshiftoss/public-api build
node --env-file=<env> packages/public-api/dist/server.cjs
API_URL=http://localhost:3001 vitest run --project public-api-integration
```

Defect 1 is reproduced by patching the exclusion out locally and varying only the flag on one SPL pair (USDC to SOL via Bebop):

| `supportsEIP1559` | Result |
| --- | --- |
| unconditional (pre-fix) | `404 No quote available from this swapper` |
| evm-only (fixed) | `200` with `solana_serialized_tx`, buy amount `656874909` |

Native SOL under the fix returns `"Bebop Solana cannot sell native SOL"`, a string that only exists in `getBebopSolanaTradeQuote` - confirming which implementation handled it. Earlier attempts missed this because native and cross-chain pairs have no bebop route, so the misroute hid behind a legitimate `NoRouteFound`.

That same experiment is the case for the exclusion: with the dispatch fixed and nothing else, a client receives a `200` carrying a signable `solana_serialized_tx` that must go to bebop's api rather than the chain. Broadcasting it is the fund-loss path.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Not user-facing in the web app — the app doesn't consume the public API, and its own Bebop Solana execution goes through the swapper's sign-only path, which is unaffected.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)