### PR TITLE
fix(swap-widget): restore redirect-only chains in the asset selector

### DIFF
--- a/packages/swap-widget/src/constants/chains.ts
+++ b/packages/swap-widget/src/constants/chains.ts
@@ -16,11 +16,17 @@ import {
   mayachain,
   megaeth,
   monad,
+  near,
   optimism,
   plasma,
   polygon,
   solana,
+  starknet,
+  sui,
   thorchain,
+  ton,
+  tron,
+  zcash,
 } from '@shapeshiftoss/utils'
 
 import type { ChainId } from '../types'
@@ -43,10 +49,16 @@ const BASE_ASSETS_BY_CHAIN_ID: Record<ChainId, Asset> = {
   [bitcoincash.chainId]: bitcoincash,
   [dogecoin.chainId]: dogecoin,
   [litecoin.chainId]: litecoin,
+  [zcash.chainId]: zcash,
   [atom.chainId]: atom,
   [thorchain.chainId]: thorchain,
   [mayachain.chainId]: mayachain,
   [solana.chainId]: solana,
+  [tron.chainId]: tron,
+  [sui.chainId]: sui,
+  [ton.chainId]: ton,
+  [near.chainId]: near,
+  [starknet.chainId]: starknet,
 }
 
 export const SUPPORTED_CHAIN_IDS_SET: ReadonlySet<ChainId> = new Set(


### PR DESCRIPTION
## Description

The redirect-only chain support added in #12435 shipped with its chains filtered out one layer upstream, so it has never actually been reachable for the six chains it was built for.

`TokenSelectModal` gates on `isWidgetSupportedChainId` and only narrows to executable chains when the redirect is off — that part is correct. But its input comes from `useAssets`, which filters through `BASE_ASSETS_BY_CHAIN_ID` in `constants/chains.ts`, and that map never gained the chains `REDIRECT_ONLY_CHAIN_IDS` introduced in `types/index.ts`. Assets were dropped before the redirect-aware filter ever saw them.

Zcash, Tron, Sui, TON, NEAR and Starknet were therefore unselectable, leaving the redirect reachable only for the cosmos chains. This adds their base assets so the modal's existing filter can do its job.

## Issue (if applicable)

closes #

## Risk

Low.

Purely additive — five new entries in a lookup map plus zcash, and no change to any existing entry, filter, or execution path. Everything downstream of the picker already handled these chains; they just never arrived. No on-chain transaction is introduced or modified: these chains are redirect-only by definition, and selecting one hands off to app.shapeshift.com rather than signing in the widget.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None. No swapper, signing, or broadcast code is touched.

## Testing

### Engineering

Run the widget and open the asset selector with the redirect enabled — Zcash, Tron, Sui, TON, NEAR and Starknet now appear and are selectable, and selecting one routes to the app redirect rather than the in-widget swap flow. With the redirect disabled they remain hidden, as before.

Verified locally by asserting the invariant directly: every chain in `EVM_CHAIN_IDS`, `UTXO_CHAIN_IDS`, `COSMOS_CHAIN_IDS`, `OTHER_CHAIN_IDS` and `REDIRECT_ONLY_CHAIN_IDS` resolves through both `isSupportedChainId` and `getBaseAsset` — 27/27 pass with this change. Reverting the six entries makes 5 of the 6 redirect chains fail on the `isSupportedChainId` line specifically, confirming that map is the layer that was eating them.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

The redirect itself is already gated. With it on, confirm the six chains are offered in the asset picker and that picking one opens app.shapeshift.com with the swap pre-filled.

## Screenshots (if applicable)

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Near, Starknet, Sui, Ton, Tron, and Zcash assets in the swap widget.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->