### PR TITLE
ci: build swap-widget in PR checks

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -50,6 +50,9 @@ jobs:
       - name: Build Packages
         run: pnpm run build:packages
 
+      - name: Build swap-widget
+        run: pnpm --filter @shapeshiftoss/swap-widget build
+
       - name: Lint
         run: pnpm run lint
 


### PR DESCRIPTION
## Description

`swap-widget` is the only publishable package CI never compiles.

- It is absent from `tsconfig.packages.json`, so **Build Packages** skips it
- `packages/swap-widget/**` sits in the root `tsconfig.json` `exclude` list, so **Type Check** skips it

Lint and Test *do* cover it, which is why the gap isn't obvious. Every other publishable package is in the tsc solution build:

```
$ comm -23 <public packages> <tsconfig.packages.json references>
swap-widget
```

Until now the package was compiled for the first time in `publish-packages.yml`, which runs on push to `main`. A type error in `packages/swap-widget/src` would therefore pass CI green, merge to `develop`, and only surface at publish time — after the version bump had already landed.

This adds one step to the Static job, mirroring the equivalent step that already exists in `publish-packages.yml`. The package's own `build` script is `rm -rf dist && tsc && tsup`, so this restores both type-check and build coverage in a single step.

## Issue (if applicable)

closes #

Related: [SS-5768](https://linear.app/shapeshift-dao/issue/SS-5768/widget-make-optional-peer-dependencies-actually-optional) (separate concern — the widget's optional peer dependencies aren't actually optional).

## Risk

Near zero. CI-only change; no application code, no dependency changes, no on-chain behaviour.

The realistic risk is the opposite direction: the step could fail on `develop` if the widget is already broken. It isn't — verified below.

Cost is ~15s of Static job wall-clock (tsc + tsup, of which ~10s is the dts build).

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

Verified against merged `develop` (`b9f6222355`), running the steps in the same order the Static job does:

```
pnpm install --frozen-lockfile
pnpm run build:packages
pnpm --filter @shapeshiftoss/swap-widget build   # new step
  → ESM dist/index.js  194.36 KB
  → DTS dist/index.d.ts 6.77 KB
  → Build success, exit 0
```

Confirmed the step has teeth, and that the gap it closes is real. With a deliberate type error appended to `packages/swap-widget/src/config/appkit.ts`:

```ts
const __ciCanary: number = "not a number"
```

| check | result |
|---|---|
| `pnpm run type-check` (existing) | **passes clean** — misses it entirely |
| `pnpm --filter @shapeshiftoss/swap-widget build` (new) | **fails** — `TS2322: Type 'string' is not assignable to type 'number'`, exit 2 |

The canary was reverted; it is not part of this diff.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

CI-only change with no user-facing impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
