### PR TITLE
fix(keepkey): support ruji deposits and flag unsupported sends

### DIFF
--- a/packages/hdwallet-keepkey/package.json
+++ b/packages/hdwallet-keepkey/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/hdwallet-keepkey",
-  "version": "1.62.41",
+  "version": "1.62.42",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/hdwallet-keepkey/src/thorchain.ts
+++ b/packages/hdwallet-keepkey/src/thorchain.ts
@@ -118,7 +118,7 @@ export async function thorchainSignTx(
         }
 
         const coinAsset = m.value.coins[0].asset
-        if (coinAsset !== 'THOR.RUNE' && coinAsset !== 'THOR.TCY') {
+        if (!['THOR.RUNE', 'THOR.TCY', 'THOR.RUJI'].includes(coinAsset)) {
           throw new Error('THORChain: Unsupported coin asset: ' + coinAsset)
         }
 

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -1302,6 +1302,7 @@
       "broadcastingTransaction": "Broadcasting Transaction",
       "youHaveSent": "You have successfully sent %{amount} %{symbol}",
       "sendFailed": "Send failed",
+      "assetNotSupportedByWallet": "Sending %{asset} is not supported by %{wallet}.",
       "toAddress": "To Address",
       "toAddressOrEns": "To Address or ENS",
       "scanQrCode": "Scan QR Code",

--- a/src/components/Modals/Send/views/Address.tsx
+++ b/src/components/Modals/Send/views/Address.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertIcon,
   Button,
   Flex,
   FormControl,
@@ -29,9 +31,12 @@ import { DialogTitle } from '@/components/Modal/components/DialogTitle'
 import { SelectAssetRoutes } from '@/components/SelectAssets/SelectAssetCommon'
 import { SlideTransition } from '@/components/SlideTransition'
 import { Text } from '@/components/Text'
+import type { TextPropTypes } from '@/components/Text/Text'
 import { useFeatureFlag } from '@/hooks/useFeatureFlag/useFeatureFlag'
 import { useModal } from '@/hooks/useModal/useModal'
+import { useWallet } from '@/hooks/useWallet/useWallet'
 import { parseAddressInputWithChainId } from '@/lib/address/address'
+import { walletSupportsSendingAsset } from '@/lib/utils'
 import {
   selectInternalAccountIdByAddress,
   selectIsAddressInAddressBook,
@@ -84,6 +89,23 @@ export const Address = () => {
   )
 
   const asset = useAppSelector(state => selectAssetById(state, assetId))
+
+  const {
+    state: { wallet, walletInfo },
+  } = useWallet()
+
+  const isSendSupported = useMemo(
+    () => !wallet || !assetId || walletSupportsSendingAsset(assetId, wallet),
+    [assetId, wallet],
+  )
+
+  const notSupportedTranslation: TextPropTypes['translation'] = useMemo(
+    () => [
+      'modals.send.assetNotSupportedByWallet',
+      { asset: asset?.symbol ?? '', wallet: walletInfo?.name ?? '' },
+    ],
+    [asset?.symbol, walletInfo?.name],
+  )
 
   const isInAddressBookFilter = useMemo(
     () => ({ accountAddress: address, chainId: asset?.chainId }),
@@ -247,9 +269,15 @@ export const Address = () => {
 
       <DialogFooter pt={2}>
         <Stack flex={1}>
+          {!isSendSupported && (
+            <Alert status='warning' borderRadius='lg' mb={3}>
+              <AlertIcon />
+              <Text translation={notSupportedTranslation} fontSize='sm' />
+            </Alert>
+          )}
           <Button
             width='full'
-            isDisabled={!address || !input || addressError}
+            isDisabled={!isSendSupported || !address || !input || addressError}
             isLoading={isValidating}
             colorScheme={addressError && !isValidating ? 'red' : 'blue'}
             size='lg'

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -1,5 +1,5 @@
 import type { AssetId, ChainId, ChainNamespace } from '@shapeshiftoss/caip'
-import { fromChainId } from '@shapeshiftoss/caip'
+import { fromChainId, rujiAssetId, tcyAssetId } from '@shapeshiftoss/caip'
 import type { ChainAdapter } from '@shapeshiftoss/chain-adapters'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
 import type { GridPlusHDWallet } from '@shapeshiftoss/hdwallet-gridplus'
@@ -117,6 +117,15 @@ export const isNonEmptyString = (value: string | undefined): value is string =>
 
 type Falsy = false | null | undefined | '' | 0
 export const isTruthy = <T>(value: T | Falsy): value is T => Boolean(value)
+
+// KeepKey firmware reconstructs the THORChain MsgSend it signs and hardcodes the `rune` denom, so
+// it cannot sign transfers of native THORChain assets that aren't RUNE. Deposits are unaffected, as
+// those carry the asset through verbatim.
+export const walletSupportsSendingAsset = (assetId: AssetId, wallet: HDWallet): boolean => {
+  if (isKeepKeyHDWallet(wallet) && [tcyAssetId, rujiAssetId].includes(assetId)) return false
+
+  return true
+}
 
 export const walletCanEditMemo = (wallet: HDWallet): boolean => {
   switch (true) {

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -118,9 +118,6 @@ export const isNonEmptyString = (value: string | undefined): value is string =>
 type Falsy = false | null | undefined | '' | 0
 export const isTruthy = <T>(value: T | Falsy): value is T => Boolean(value)
 
-// KeepKey firmware reconstructs the THORChain MsgSend it signs and hardcodes the `rune` denom, so
-// it cannot sign transfers of native THORChain assets that aren't RUNE. Deposits are unaffected, as
-// those carry the asset through verbatim.
 export const walletSupportsSendingAsset = (assetId: AssetId, wallet: HDWallet): boolean => {
   if (isKeepKeyHDWallet(wallet) && [tcyAssetId, rujiAssetId].includes(assetId)) return false
 


### PR DESCRIPTION
## Description

KeepKey firmware reconstructs the THORChain `MsgSend` it signs and hardcodes the `rune` denom, so it cannot sign transfers of native THORChain assets that aren't RUNE. That is why sending RUJI fails with "failed to sign transaction".

Deposits are unaffected, as those carry the asset through verbatim. So this PR:

- **Enables RUJI deposits** in `hdwallet-keepkey`, alongside the RUNE and TCY already allowed (mirrors the earlier TCY fix in 6f08e44ac2).
- **Surfaces the send limitation upfront** rather than failing at signing time. Selecting RUJI or TCY to send on a KeepKey now shows an inline alert and disables the confirm button.

Sending RUJI/TCY on KeepKey is **not** fixed here, and can't be from the client - it needs a firmware change so `MsgSend` carries the asset's denom rather than hardcoding `rune`.

## Issue (if applicable)

closes #12463

Linear: https://linear.app/shapeshift-dao/issue/SS-5707/unable-to-send-ruji-on-keepkey

Note the original acceptance criteria was "should be able to send Ruji on KK". That isn't achievable from the client - `MsgSend` hardcodes the `rune` denom in firmware - so there is nothing further for us to do here. Closing on the basis that deposits now work and the send limitation is communicated clearly rather than surfacing as a signing failure. If firmware later carries the denom through, lifting the guard is a one-line change in `walletSupportsSendingAsset`.

## Risk

Low, but it does touch signing.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

- **KeepKey + THORChain only.** The `hdwallet-keepkey` change widens an allowlist in the `MsgDeposit` path from `THOR.RUNE`/`THOR.TCY` to also accept `THOR.RUJI`. No signing logic changes; a previously rejected asset is now passed through the same code path TCY already used.
- **`MsgSend` is untouched** and still throws for any non-`rune` denom.
- `walletSupportsSendingAsset` returns `true` for every other wallet and asset, so the send modal is unchanged outside KeepKey + RUJI/TCY.

## Testing

### Engineering

1. Pair a KeepKey (requires `pnpm run hdwallet:build` or a running dev server so the `hdwallet-keepkey` change is compiled into `dist`).
2. **Deposit:** deposit RUJI on THORChain - the device should prompt and sign. Previously threw `THORChain: Unsupported coin asset: THOR.RUJI`.
3. **Send guard:** open Send, pick RUJI (or TCY), and continue to the address step. Expect a warning alert reading "Sending RUJI is not supported by KeepKey." and a disabled button.
4. **Regression:** sending RUNE on KeepKey, and sending RUJI/TCY on any other wallet, should be unaffected.

### Operations

- [x] User-facing change, needs testing

On a KeepKey, choosing to send RUJI or TCY now shows an explanatory message and a disabled button instead of letting you proceed to a "failed to sign transaction" error. RUJI deposits work. No other wallet or asset should behave differently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for sending THOR.RUJI assets through compatible wallets.
  * Added a warning when the selected wallet does not support sending an asset.
  * Disabled the Next button for unsupported wallet and asset combinations.

* **Bug Fixes**
  * Prevented unsupported KeepKey transfers for specific THORChain assets.
  * Added a clear error message identifying the asset and wallet involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->