### PR TITLE
chore(swapper): set Bitcoin refund address for BOB Gateway

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -36,7 +36,7 @@
     "@coral-xyz/anchor": "0.29.0",
     "@cowprotocol/app-data": "^2.3.0",
     "@defuse-protocol/one-click-sdk-typescript": "^0.1.1-0.2",
-    "@gobob/bob-sdk": "5.8.1",
+    "@gobob/bob-sdk": "5.10.0",
     "@mysten/sui": "^1.45.2",
     "@shapeshiftoss/bitcoinjs-lib": "7.0.0-shapeshift.0",
     "@shapeshiftoss/caip": "workspace:^",

--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -36,7 +36,7 @@
     "@coral-xyz/anchor": "0.29.0",
     "@cowprotocol/app-data": "^2.3.0",
     "@defuse-protocol/one-click-sdk-typescript": "^0.1.1-0.2",
-    "@gobob/bob-sdk": "5.10.0",
+    "@gobob/bob-sdk": "5.11.1",
     "@mysten/sui": "^1.45.2",
     "@shapeshiftoss/bitcoinjs-lib": "7.0.0-shapeshift.0",
     "@shapeshiftoss/caip": "workspace:^",

--- a/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
@@ -114,6 +114,7 @@ export const getBobGatewayQuote = async ({
       amount,
       maxSlippage: Number(slippage),
       ownerAddress: sellChainName === 'bitcoin' ? recipient : (sender as string),
+      refundAddress: sellChainName === 'bitcoin' ? recipient : undefined,
       affiliates: getBobGatewayAffiliates(affiliateBps),
     })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2115,8 +2115,8 @@ importers:
         specifier: ^0.1.1-0.2
         version: 0.1.16
       '@gobob/bob-sdk':
-        specifier: 5.10.0
-        version: 5.10.0(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 5.11.1
+        version: 5.11.1(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@mysten/sui':
         specifier: 1.45.2
         version: 1.45.2(typescript@5.8.2)
@@ -4059,8 +4059,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.10.0':
-    resolution: {integrity: sha512-OSCJ3qVZ9SKyEa57VFLuQ4Q/BIXt88ijcJeVgvhY4UReXBf4+dd7ocwdP523N8mRHIqmgm+OpHwZMFff9g2QRQ==}
+  '@gobob/bob-sdk@5.11.1':
+    resolution: {integrity: sha512-D+Y2Uk9khJJyOA3fFe3RlVQrY0CtBizDVbyX0mxCkW40ee21sMm8rbmPmjI1wYMVadRDX4EM7V0u9Ccm3b341g==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -19677,7 +19677,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.10.0(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@gobob/bob-sdk@5.11.1(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5
@@ -25199,14 +25199,14 @@ snapshots:
 
   '@shapeshiftoss/blockbook@9.3.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)':
     dependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
   '@shapeshiftoss/blockbook@9.3.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)':
     dependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -25551,9 +25551,9 @@ snapshots:
       axios: 1.13.6(debug@4.4.3)
       bignumber.js: 9.3.1
       ethers: 6.11.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      isomorphic-ws: 4.0.1(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       viem: 2.43.5(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@ethersproject/address'
       - '@ethersproject/contracts'
@@ -27884,7 +27884,7 @@ snapshots:
     dependencies:
       '@trezor/utils': 9.5.0(tslib@2.8.1)
       tslib: 2.8.1
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -36822,10 +36822,6 @@ snapshots:
     dependencies:
       ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
-  isomorphic-ws@4.0.1(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
-    dependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-
   isomorphic-ws@4.0.1(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
@@ -36838,9 +36834,9 @@ snapshots:
     dependencies:
       ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
-  isomorphic-ws@5.0.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
+  isomorphic-ws@5.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)):
     dependencies:
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
   isows@1.0.6(ws@8.18.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
@@ -42382,11 +42378,11 @@ snapshots:
   web3-providers-ws@4.0.8-dev.a0d6730.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       '@types/ws': 8.5.3
-      isomorphic-ws: 5.0.0(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
+      isomorphic-ws: 5.0.0(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))
       web3-errors: 1.1.4-dev.a0d6730.0
       web3-types: 1.3.1-dev.a0d6730.0
       web3-utils: 4.0.8-dev.a0d6730.0
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2115,8 +2115,8 @@ importers:
         specifier: ^0.1.1-0.2
         version: 0.1.16
       '@gobob/bob-sdk':
-        specifier: 5.8.1
-        version: 5.8.1(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+        specifier: 5.10.0
+        version: 5.10.0(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
       '@mysten/sui':
         specifier: 1.45.2
         version: 1.45.2(typescript@5.8.2)
@@ -4059,8 +4059,8 @@ packages:
   '@gobob/bob-sdk@3.1.7-alpha0':
     resolution: {integrity: sha512-1qdKAYEigbqNt9x/0jYKeeC/d0u1lh6GluHaBIxp2Pt6p2+4fUVFnDdtGo5pMcgft7Bvo8/tdmlFBTzb3BEc5g==}
 
-  '@gobob/bob-sdk@5.8.1':
-    resolution: {integrity: sha512-fF8q3CnWEtUMcc4+WWWMq8dY08qL1kBV+/sn6gVSQv8wGVe95Qg0OLTZm0HbrPyvXjZreDTCIrO7ztmwp+mWxg==}
+  '@gobob/bob-sdk@5.10.0':
+    resolution: {integrity: sha512-OSCJ3qVZ9SKyEa57VFLuQ4Q/BIXt88ijcJeVgvhY4UReXBf4+dd7ocwdP523N8mRHIqmgm+OpHwZMFff9g2QRQ==}
 
   '@gobob/sats-wagmi@0.3.23':
     resolution: {integrity: sha512-7YAcQXo20v/SKNBv4Jhv9SYJJ9fzXUSC1ntUKwR0hjdCV9Kj0ivIRmGKvZwb8fqwgNYEaL4R5PbrMWnvFNTRgQ==}
@@ -13144,6 +13144,14 @@ packages:
       typescript:
         optional: true
 
+  ox@0.14.20:
+    resolution: {integrity: sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==}
+    peerDependencies:
+      typescript: '>=5.4.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   ox@0.14.33:
     resolution: {integrity: sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==}
     peerDependencies:
@@ -15873,6 +15881,14 @@ packages:
 
   viem@2.46.3:
     resolution: {integrity: sha512-2LJS+Hyh2sYjHXQtzfv1kU9pZx9dxFzvoU/ZKIcn0FNtOU0HQuIICuYdWtUDFHaGXbAdVo8J1eCvmjkL9JVGwg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  viem@2.49.0:
+    resolution: {integrity: sha512-vaasyOBFiCWYtw9JD8iRoaHPppk14kQH140qgVmrxkDEgv4qTX9Hwi6F+wF+s3Y7SStV5OtnN2ulJev+NQ7KDw==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -19661,7 +19677,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@gobob/bob-sdk@5.8.1(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
+  '@gobob/bob-sdk@5.10.0(@tanstack/react-query@5.69.0(react@19.2.4))(bufferutil@4.1.0)(eslint@8.57.1)(react-dom@18.2.0(patch_hash=472f33b26781cbf66543b4c1cdf5be1c2ea4cd7232403bb255cd75e280bf3158)(react@19.2.4))(react@19.2.4)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)':
     dependencies:
       '@bitcoinerlab/secp256k1': 1.2.0
       '@eslint/eslintrc': 3.3.5
@@ -19675,7 +19691,7 @@ snapshots:
       bitcoinjs-lib: 6.1.7
       global: 4.4.0
       globals: 17.6.0
-      viem: 2.55.11(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
+      viem: 2.49.0(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76)
     transitivePeerDependencies:
       - '@tanstack/react-query'
       - bufferutil
@@ -25513,8 +25529,8 @@ snapshots:
       '@yfi/sdk': 1.2.0(@ethersproject/abi@5.8.0)(@ethersproject/address@5.8.0)(@ethersproject/bignumber@5.8.0)(@ethersproject/bytes@5.8.0)(@ethersproject/contracts@5.8.0)(@ethersproject/providers@5.8.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       bignumber.js: 9.3.1
       ethers: 5.7.2(bufferutil@4.1.0)(utf-8-validate@5.0.10)
-      isomorphic-ws: 4.0.1(ws@8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      isomorphic-ws: 4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     transitivePeerDependencies:
       - '@ethersproject/abi'
       - '@ethersproject/address'
@@ -26526,7 +26542,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.2.2)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.2.2)
       '@solana/subscribable': 5.5.1(typescript@5.2.2)
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -26539,7 +26555,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.2.2)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.2.2)
       '@solana/subscribable': 5.5.1(typescript@5.2.2)
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     optionalDependencies:
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -26552,7 +26568,7 @@ snapshots:
       '@solana/functional': 5.5.1(typescript@5.8.2)
       '@solana/rpc-subscriptions-spec': 5.5.1(typescript@5.8.2)
       '@solana/subscribable': 5.5.1(typescript@5.8.2)
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.8.2
     transitivePeerDependencies:
@@ -32210,7 +32226,7 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.8.0
       eventemitter3: 5.0.1
-      ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -36814,6 +36830,10 @@ snapshots:
     dependencies:
       ws: 8.19.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
 
+  isomorphic-ws@4.0.1(ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
+    dependencies:
+      ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+
   isomorphic-ws@5.0.0(ws@8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)):
     dependencies:
       ws: 8.17.1(bufferutil@4.1.0)(utf-8-validate@5.0.10)
@@ -38517,6 +38537,21 @@ snapshots:
       eventemitter3: 5.0.1
     optionalDependencies:
       typescript: 5.2.2
+    transitivePeerDependencies:
+      - zod
+
+  ox@0.14.20(typescript@5.8.2)(zod@3.25.76):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.2)(zod@3.25.76)
+      eventemitter3: 5.0.1
+    optionalDependencies:
+      typescript: 5.8.2
     transitivePeerDependencies:
       - zod
 
@@ -41807,6 +41842,23 @@ snapshots:
       ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
     optionalDependencies:
       typescript: 5.2.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
+  viem@2.49.0(bufferutil@4.1.0)(typescript@5.8.2)(utf-8-validate@5.0.10)(zod@3.25.76):
+    dependencies:
+      '@noble/curves': 1.9.1
+      '@noble/hashes': 1.8.0
+      '@scure/bip32': 1.7.0
+      '@scure/bip39': 1.6.0
+      abitype: 1.2.3(typescript@5.8.2)(zod@3.25.76)
+      isows: 1.0.7(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      ox: 0.14.20(typescript@5.8.2)(zod@3.25.76)
+      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+    optionalDependencies:
+      typescript: 5.8.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate


### PR DESCRIPTION
## Description

Adds `refundAddress` to BOB Gateway quote requests when selling Bitcoin. Uses recipient address, matching existing Bitcoin `ownerAddress` behavior, while leaving non-Bitcoin requests unchanged.

## Issue (if applicable)

N/A

## Risk

Low. Change affects BOB Gateway quote requests for Bitcoin sells only. It does not alter transaction construction, wallet signing, or contract interactions.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

BOB Gateway Bitcoin sell quotes and refund routing may be affected. No wallet-specific or contract interactions changed.

## Testing

### Engineering

- `pnpm run lint --fix` — passes with 9 pre-existing warnings.
- `pnpm run type-check` — blocked by pre-existing `NativeHDWallet` / `_supportsRobinhood` errors in EVM chain adapter tests on `develop`.
- Verify Bitcoin sell quote request includes `refundAddress` equal to recipient address.
- Verify non-Bitcoin sell quote request leaves `refundAddress` undefined.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Request a BOB Gateway quote selling Bitcoin. Confirm quote succeeds and refund destination matches recipient address. Confirm non-Bitcoin BOB Gateway quotes remain unchanged.

## Screenshots (if applicable)

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Bitcoin sell transactions by providing the correct refund address when requesting quotes.
  * Updated quote integration support for improved compatibility.
  * No changes to other swap flows or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->