### PR TITLE
perf(accounts): resume discovery and subscribe txs without the device

### DIFF
--- a/src/components/Layout/Header/NavBar/KeepKey/ChangePassphrase.tsx
+++ b/src/components/Layout/Header/NavBar/KeepKey/ChangePassphrase.tsx
@@ -26,6 +26,7 @@ import { WalletActions } from '@/context/WalletProvider/actions'
 import { useKeepKey } from '@/context/WalletProvider/KeepKeyProvider'
 import { KeyManager } from '@/context/WalletProvider/KeyManager'
 import { useWallet } from '@/hooks/useWallet/useWallet'
+import { clearAccountCaches } from '@/lib/account/clearAccountCaches'
 import { portfolio } from '@/state/slices/portfolioSlice/portfolioSlice'
 import { selectWalletId } from '@/state/slices/selectors'
 import { useAppDispatch, useAppSelector } from '@/state/store'
@@ -84,6 +85,7 @@ export const ChangePassphrase = () => {
     }
     // Clear all previous wallet meta
     appDispatch(portfolio.actions.clearWalletMetadata(walletId))
+    clearAccountCaches()
     // Trigger a refresh of the wallet metadata only once the settings have been applied
     // and the previous wallet meta is gone from the store
     dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: true })

--- a/src/components/MultiHopTrade/components/FiatRamps/FiatRampTradeFooter.tsx
+++ b/src/components/MultiHopTrade/components/FiatRamps/FiatRampTradeFooter.tsx
@@ -85,7 +85,6 @@ export const FiatRampTradeFooter = ({
 }: FiatRampTradeFooterProps) => {
   const buyAsset = 'buyAsset' in props ? props.buyAsset : undefined
   const sellAsset = 'sellAsset' in props ? props.sellAsset : undefined
-  const sellAccountId = 'sellAccountId' in props ? props.sellAccountId : undefined
   const buyAssetFeeAsset = useAppSelector(state =>
     selectFeeAssetById(state, buyAsset?.assetId ?? ''),
   )
@@ -119,13 +118,14 @@ export const FiatRampTradeFooter = ({
   const shouldDisablePreviewButton = useMemo(() => {
     return (
       parentShouldDisablePreviewButton ||
-      (isDiscoveringAccounts && !sellAccountId) ||
+      // A trade cannot be previewed against accounts we have not finished looking for
+      isDiscoveringAccounts ||
       // don't allow executing a quote with errors
       isError ||
       // don't execute trades while in loading state
       isLoading
     )
-  }, [parentShouldDisablePreviewButton, isDiscoveringAccounts, sellAccountId, isError, isLoading])
+  }, [parentShouldDisablePreviewButton, isDiscoveringAccounts, isError, isLoading])
 
   const deltaPercentage = useMemo(() => {
     if (!rate || !marketRate || bnOrZero(marketRate).isZero()) return null

--- a/src/components/MultiHopTrade/components/FiatRamps/FiatRampTradeFooter.tsx
+++ b/src/components/MultiHopTrade/components/FiatRamps/FiatRampTradeFooter.tsx
@@ -257,7 +257,9 @@ export const FiatRampTradeFooter = ({
 
         <ButtonWalletPredicate
           isLoading={isLoading || isDiscoveringAccounts}
-          loadingText={isDiscoveringAccounts ? accountsLoadingText : isLoading ? undefined : buttonText}
+          loadingText={
+            isDiscoveringAccounts ? accountsLoadingText : isLoading ? undefined : buttonText
+          }
           type='submit'
           colorScheme={isError ? 'red' : 'blue'}
           size='lg-multiline'

--- a/src/components/MultiHopTrade/components/FiatRamps/FiatRampTradeFooter.tsx
+++ b/src/components/MultiHopTrade/components/FiatRamps/FiatRampTradeFooter.tsx
@@ -66,6 +66,8 @@ const footerBgProp = {
 }
 const footerPosition: CardFooterProps['position'] = { base: 'sticky', md: 'static' }
 
+const accountsLoadingText = <Text translation='common.accountsLoading' />
+
 export const FiatRampTradeFooter = ({
   children,
   hasUserEnteredAmount,
@@ -255,7 +257,7 @@ export const FiatRampTradeFooter = ({
 
         <ButtonWalletPredicate
           isLoading={isLoading || isDiscoveringAccounts}
-          loadingText={isLoading ? undefined : buttonText}
+          loadingText={isDiscoveringAccounts ? accountsLoadingText : isLoading ? undefined : buttonText}
           type='submit'
           colorScheme={isError ? 'red' : 'blue'}
           size='lg-multiline'

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -558,7 +558,6 @@ export const LimitOrderInput = ({
         quoteStatusTranslation={quoteStatusTranslation}
         rate={limitPrice.buyAssetDenomination}
         marketRate={marketPriceBuyAsset}
-        sellAccountId={sellAccountId}
         shouldDisablePreviewButton={
           !hasUserEnteredAmount ||
           isError ||

--- a/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/components/LimitOrderInput.tsx
@@ -589,7 +589,6 @@ export const LimitOrderInput = ({
     quoteStatusTranslation,
     limitPrice.buyAssetDenomination,
     marketPriceBuyAsset,
-    sellAccountId,
     isReceiveAddressEntryActive,
     networkFeeUserCurrency,
     renderedReceiveAddress,

--- a/src/components/MultiHopTrade/components/LimitOrder/hooks/useLimitOrderReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/components/LimitOrder/hooks/useLimitOrderReceiveAddress.tsx
@@ -76,7 +76,6 @@ export const useLimitOrderReceiveAddress = ({
 
   const isManualReceiveAddressRequired = useIsManualReceiveAddressRequired({
     shouldForceManualAddressEntry: false,
-    sellAccountId,
     buyAsset,
     manualReceiveAddress,
     walletReceiveAddress,

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -161,7 +161,9 @@ export const SharedTradeInputFooter = ({
 
         <ButtonWalletPredicate
           isLoading={isLoading || isDiscoveringAccounts}
-          loadingText={isDiscoveringAccounts ? accountsLoadingText : isLoading ? undefined : buttonText}
+          loadingText={
+            isDiscoveringAccounts ? accountsLoadingText : isLoading ? undefined : buttonText
+          }
           type='submit'
           colorScheme={isError ? 'red' : 'blue'}
           size='lg-multiline'

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -57,7 +57,6 @@ export const SharedTradeInputFooter = ({
   quoteStatusTranslation,
   rate,
   receiveSummaryDetails,
-  sellAccountId,
   sellAsset,
   shouldDisablePreviewButton: parentShouldDisablePreviewButton,
   swapperName,
@@ -80,13 +79,14 @@ export const SharedTradeInputFooter = ({
   const shouldDisablePreviewButton = useMemo(() => {
     return (
       parentShouldDisablePreviewButton ||
-      (isDiscoveringAccounts && !sellAccountId) ||
+      // A trade cannot be previewed against accounts we have not finished looking for
+      isDiscoveringAccounts ||
       // don't allow executing a quote with errors
       isError ||
       // don't execute trades while in loading state
       isLoading
     )
-  }, [parentShouldDisablePreviewButton, isDiscoveringAccounts, sellAccountId, isError, isLoading])
+  }, [parentShouldDisablePreviewButton, isDiscoveringAccounts, isError, isLoading])
 
   const buttonText = useMemo(() => {
     return <Text translation={quoteStatusTranslation} />
@@ -158,7 +158,7 @@ export const SharedTradeInputFooter = ({
         {children}
 
         <ButtonWalletPredicate
-          isLoading={isLoading || (isDiscoveringAccounts && !sellAccountId)}
+          isLoading={isLoading || isDiscoveringAccounts}
           loadingText={isLoading ? undefined : buttonText}
           type='submit'
           colorScheme={isError ? 'red' : 'blue'}

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -30,7 +30,6 @@ type SharedTradeInputFooterProps = {
   quoteStatusTranslation: string | [string, InterpolationOptions]
   rate: string | undefined
   receiveSummaryDetails?: JSX.Element | null
-  sellAccountId: string | undefined
   sellAsset: Asset
   shouldDisablePreviewButton: boolean | undefined
   swapperName: SwapperName | undefined

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeInputFooter/SharedTradeInputFooter.tsx
@@ -47,6 +47,8 @@ const footerBgProp = {
 }
 const footerPosition: CardFooterProps['position'] = { base: 'sticky', md: 'static' }
 
+const accountsLoadingText = <Text translation='common.accountsLoading' />
+
 export const SharedTradeInputFooter = ({
   affiliateBps,
   buyAsset,
@@ -159,7 +161,7 @@ export const SharedTradeInputFooter = ({
 
         <ButtonWalletPredicate
           isLoading={isLoading || isDiscoveringAccounts}
-          loadingText={isLoading ? undefined : buttonText}
+          loadingText={isDiscoveringAccounts ? accountsLoadingText : isLoading ? undefined : buttonText}
           type='submit'
           colorScheme={isError ? 'red' : 'blue'}
           size='lg-multiline'

--- a/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeReceiveAddress.tsx
+++ b/src/components/MultiHopTrade/components/SharedTradeInput/SharedTradeReceiveAddress.tsx
@@ -20,7 +20,6 @@ import { useTranslate } from 'react-polyglot'
 import { AddressInput } from '@/components/Modals/Send/AddressInput/AddressInput'
 import type { SendInput } from '@/components/Modals/Send/Form'
 import { SendFormFields } from '@/components/Modals/Send/SendCommon'
-import { useAccountIds } from '@/components/MultiHopTrade/hooks/useAccountIds'
 import { useIsManualReceiveAddressRequired } from '@/components/MultiHopTrade/hooks/useIsManualReceiveAddressRequired'
 import { Row } from '@/components/Row/Row'
 import { RawText, Text } from '@/components/Text'
@@ -142,7 +141,6 @@ export const SharedTradeReceiveAddress = ({
   onSubmit,
 }: SharedTradeReceiveAddressProps) => {
   const translate = useTranslate()
-  const { sellAssetAccountId } = useAccountIds()
   const receiveAddress = manualReceiveAddress ?? walletReceiveAddress
   const { chainId: buyAssetChainId, assetId: buyAssetAssetId } = buyAsset
   const {
@@ -165,7 +163,6 @@ export const SharedTradeReceiveAddress = ({
 
   const shouldForceDisplayManualAddressEntry = useIsManualReceiveAddressRequired({
     shouldForceManualAddressEntry: Boolean(shouldForceManualAddressEntry),
-    sellAccountId: sellAssetAccountId,
     buyAsset,
     manualReceiveAddress,
     walletReceiveAddress,

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -178,7 +178,6 @@ export const ConfirmSummary = ({
 
   const isManualReceiveAddressRequired = useIsManualReceiveAddressRequired({
     shouldForceManualAddressEntry: false,
-    sellAccountId: sellAssetAccountId,
     buyAsset,
     manualReceiveAddress,
     walletReceiveAddress,

--- a/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
+++ b/src/components/MultiHopTrade/components/TradeInput/components/ConfirmSummary.tsx
@@ -364,7 +364,6 @@ export const ConfirmSummary = ({
       quoteStatusTranslation={quoteStatusTranslation}
       rate={activeQuote?.rate}
       receiveSummaryDetails={receiveSummaryDetails}
-      sellAccountId={sellAssetAccountId}
       sellAsset={sellAsset}
       shouldDisablePreviewButton={shouldDisablePreviewButton}
       swapperName={activeSwapperName}

--- a/src/components/MultiHopTrade/hooks/useIsManualReceiveAddressRequired.tsx
+++ b/src/components/MultiHopTrade/hooks/useIsManualReceiveAddressRequired.tsx
@@ -1,4 +1,3 @@
-import type { AccountId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { useMemo } from 'react'
 
@@ -13,7 +12,6 @@ import { useAppSelector } from '@/state/store'
 
 type UseIsManualReceiveAddressRequiredProps = {
   shouldForceManualAddressEntry: boolean
-  sellAccountId: AccountId | undefined
   buyAsset: Asset
   manualReceiveAddress: string | undefined
   walletReceiveAddress: string | undefined
@@ -22,7 +20,6 @@ type UseIsManualReceiveAddressRequiredProps = {
 
 export const useIsManualReceiveAddressRequired = ({
   shouldForceManualAddressEntry,
-  sellAccountId,
   buyAsset,
   manualReceiveAddress,
   walletReceiveAddress,
@@ -46,7 +43,8 @@ export const useIsManualReceiveAddressRequired = ({
   const shouldForceDisplayManualAddressEntry = useMemo(() => {
     if (isWalletReceiveAddressLoading) return false
     if (!isConnected) return false
-    if (isDiscoveringAccounts && !sellAccountId) return false
+    // A buy-side address we have not looked for yet is not one we know to be missing
+    if (isDiscoveringAccounts) return false
     if (manualReceiveAddress) return false
     if (!walletReceiveAddress) return true
     if (!walletSupportsBuyAssetChain) return true
@@ -63,7 +61,6 @@ export const useIsManualReceiveAddressRequired = ({
     isConnected,
     isWalletReceiveAddressLoading,
     manualReceiveAddress,
-    sellAccountId,
     shouldForceManualAddressEntry,
     walletReceiveAddress,
     walletSupportsBuyAssetChain,

--- a/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
+++ b/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
@@ -123,8 +123,7 @@ export const useDiscoverAccounts = () => {
                   derivedAccountIds.length > 0 &&
                   derivedAccountIds.every(accountId => knownAccountIds.includes(accountId))
 
-                // A number is only known once every accountId account 0 derived is stored for it
-                // too - a manual import can add one utxo script type and leave its siblings out
+                // Known means every accountId account 0 derived, not just one of the script types
                 let resumeFrom = 0
                 while (knownCountByAccountNumber[resumeFrom] >= derivedAccountIds.length)
                   resumeFrom++

--- a/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
+++ b/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
@@ -74,7 +74,11 @@ export const useDiscoverAccounts = () => {
             .map(accountId => currentPortfolio.accountMetadata.byId[accountId]?.bip44Params)
             .filter(isSome)
             .map(bip44Params => bip44Params.accountNumber)
-          const resumeFrom = knownAccountNumbers.length ? Math.max(...knownAccountNumbers) + 1 : 0
+          // Manually imported accounts leave gaps, and a gap means everything above it was never
+          // scanned - resume at the first number missing rather than past the highest present
+          const knownAccountNumberSet = new Set(knownAccountNumbers)
+          let resumeFrom = 0
+          while (knownAccountNumberSet.has(resumeFrom)) resumeFrom++
 
           let accountNumber = 0
           let hasActivity = true

--- a/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
+++ b/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
@@ -1,3 +1,4 @@
+import { fromAccountId } from '@shapeshiftoss/caip'
 import { isGridPlus, isMetaMask } from '@shapeshiftoss/hdwallet-core/wallet'
 import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
 import { isMetaMaskNativeMultichain } from '@shapeshiftoss/hdwallet-metamask-multichain'
@@ -12,6 +13,7 @@ import { useIsSnapInstalled } from '@/hooks/useIsSnapInstalled/useIsSnapInstalle
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { walletSupportsChain } from '@/hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { METAMASK_RDNS } from '@/lib/mipd'
+import { isSome } from '@/lib/utils'
 import { selectWalletRdns } from '@/state/slices/localWalletSlice/selectors'
 import { portfolio } from '@/state/slices/portfolioSlice/portfolioSlice'
 import { store, useAppDispatch, useAppSelector } from '@/state/store'
@@ -64,6 +66,16 @@ export const useDiscoverAccounts = () => {
           const isMultiAccountWallet = wallet.supportsBip44Accounts()
           const currentPortfolio = portfolio.selectors.selectPortfolio(store.getState())
 
+          // Persisted metadata is keyed on the device id, which a passphrase does not change
+          const knownAccountIds = (currentPortfolio.wallet.byId[walletId] ?? []).filter(
+            accountId => fromAccountId(accountId).chainId === chainId,
+          )
+          const knownAccountNumbers = knownAccountIds
+            .map(accountId => currentPortfolio.accountMetadata.byId[accountId]?.bip44Params)
+            .filter(isSome)
+            .map(bip44Params => bip44Params.accountNumber)
+          const resumeFrom = knownAccountNumbers.length ? Math.max(...knownAccountNumbers) + 1 : 0
+
           let accountNumber = 0
           let hasActivity = true
           let isDegraded = false
@@ -98,6 +110,18 @@ export const useDiscoverAccounts = () => {
               }
 
               accountNumber++
+
+              // Account 0 matching what was stored proves the seed, so skip the rest
+              if (accountNumber === 1 && resumeFrom > 1) {
+                const derivedAccountIds = accountIdWithActivityAndMetadata.map(
+                  ({ accountId }) => accountId,
+                )
+                const isSameSeed =
+                  derivedAccountIds.length > 0 &&
+                  derivedAccountIds.every(accountId => knownAccountIds.includes(accountId))
+
+                if (isSameSeed) accountNumber = resumeFrom
+              }
             } catch (error) {
               console.error(`Error discovering accounts for chain ${chainId}:`, error)
               isDegraded = true

--- a/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
+++ b/src/context/AppProvider/hooks/useDiscoverAccounts.tsx
@@ -13,7 +13,6 @@ import { useIsSnapInstalled } from '@/hooks/useIsSnapInstalled/useIsSnapInstalle
 import { useWallet } from '@/hooks/useWallet/useWallet'
 import { walletSupportsChain } from '@/hooks/useWalletSupportsChain/useWalletSupportsChain'
 import { METAMASK_RDNS } from '@/lib/mipd'
-import { isSome } from '@/lib/utils'
 import { selectWalletRdns } from '@/state/slices/localWalletSlice/selectors'
 import { portfolio } from '@/state/slices/portfolioSlice/portfolioSlice'
 import { store, useAppDispatch, useAppSelector } from '@/state/store'
@@ -70,15 +69,15 @@ export const useDiscoverAccounts = () => {
           const knownAccountIds = (currentPortfolio.wallet.byId[walletId] ?? []).filter(
             accountId => fromAccountId(accountId).chainId === chainId,
           )
-          const knownAccountNumbers = knownAccountIds
-            .map(accountId => currentPortfolio.accountMetadata.byId[accountId]?.bip44Params)
-            .filter(isSome)
-            .map(bip44Params => bip44Params.accountNumber)
-          // Manually imported accounts leave gaps, and a gap means everything above it was never
-          // scanned - resume at the first number missing rather than past the highest present
-          const knownAccountNumberSet = new Set(knownAccountNumbers)
-          let resumeFrom = 0
-          while (knownAccountNumberSet.has(resumeFrom)) resumeFrom++
+          const knownCountByAccountNumber = knownAccountIds.reduce<Record<number, number>>(
+            (acc, accountId) => {
+              const bip44Params = currentPortfolio.accountMetadata.byId[accountId]?.bip44Params
+              if (!bip44Params) return acc
+              acc[bip44Params.accountNumber] = (acc[bip44Params.accountNumber] ?? 0) + 1
+              return acc
+            },
+            {},
+          )
 
           let accountNumber = 0
           let hasActivity = true
@@ -116,7 +115,7 @@ export const useDiscoverAccounts = () => {
               accountNumber++
 
               // Account 0 matching what was stored proves the seed, so skip the rest
-              if (accountNumber === 1 && resumeFrom > 1) {
+              if (accountNumber === 1) {
                 const derivedAccountIds = accountIdWithActivityAndMetadata.map(
                   ({ accountId }) => accountId,
                 )
@@ -124,7 +123,13 @@ export const useDiscoverAccounts = () => {
                   derivedAccountIds.length > 0 &&
                   derivedAccountIds.every(accountId => knownAccountIds.includes(accountId))
 
-                if (isSameSeed) accountNumber = resumeFrom
+                // A number is only known once every accountId account 0 derived is stored for it
+                // too - a manual import can add one utxo script type and leave its siblings out
+                let resumeFrom = 0
+                while (knownCountByAccountNumber[resumeFrom] >= derivedAccountIds.length)
+                  resumeFrom++
+
+                if (isSameSeed && resumeFrom > 1) accountNumber = resumeFrom
               }
             } catch (error) {
               console.error(`Error discovering accounts for chain ${chainId}:`, error)

--- a/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
+++ b/src/context/WalletProvider/KeepKey/components/Passphrase.tsx
@@ -12,6 +12,7 @@ import { useCallback, useRef, useState } from 'react'
 import { Text } from '@/components/Text'
 import { WalletActions } from '@/context/WalletProvider/actions'
 import { useWallet } from '@/hooks/useWallet/useWallet'
+import { clearAccountCaches } from '@/lib/account/clearAccountCaches'
 import { selectWalletId } from '@/state/slices/common-selectors'
 import { portfolio } from '@/state/slices/portfolioSlice/portfolioSlice'
 import { useAppDispatch, useAppSelector } from '@/state/store'
@@ -39,6 +40,7 @@ export const KeepKeyPassphrase = () => {
       setError(null)
       // Clear all previous wallet meta
       appDispatch(portfolio.actions.clearWalletMetadata(walletId))
+      clearAccountCaches()
       dispatch({ type: WalletActions.SET_WALLET_MODAL, payload: false })
     } catch (e) {
       setError('modals.keepKey.passphrase.error')

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -1,13 +1,11 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { ethChainId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type { Transaction } from '@shapeshiftoss/chain-adapters'
-import { isGridPlus } from '@shapeshiftoss/hdwallet-core/wallet'
-import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
-import { isTrezor } from '@shapeshiftoss/hdwallet-trezor'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useEffect, useState } from 'react'
 import { useSelector } from 'react-redux'
 
+import { useDiscoverAccounts } from '@/context/AppProvider/hooks/useDiscoverAccounts'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { usePlugins } from '@/context/PluginProvider/PluginProvider'
 import { useWallet } from '@/hooks/useWallet/useWallet'
@@ -35,6 +33,7 @@ export const useTransactionsSubscriber = () => {
   } = useWallet()
   const portfolioAccountMetadata = useSelector(selectPortfolioAccountMetadata)
   const portfolioLoadingStatus = useSelector(selectPortfolioLoadingStatus)
+  const { isFetching: isDiscoveringAccounts } = useDiscoverAccounts()
   const { supportedChains } = usePlugins()
 
   const stakingOpportunitiesById = useSelector(
@@ -138,6 +137,8 @@ export const useTransactionsSubscriber = () => {
   useEffect(() => {
     if (isSubscribed) return
     if (!wallet || !isConnected) return
+    // Discovery upserts an account at a time, and each upsert rebuilds every subscription
+    if (isDiscoveringAccounts) return
 
     const accountIds = Object.keys(portfolioAccountMetadata)
     if (!accountIds.length) return
@@ -153,14 +154,13 @@ export const useTransactionsSubscriber = () => {
 
       // subscribe to new transactions for all supported accounts
       try {
-        const skipDeviceDerivation =
-          (isLedger(wallet) || isGridPlus(wallet) || isTrezor(wallet)) && accountId
         return adapter?.subscribeTxs(
           {
             wallet,
             accountType,
             accountNumber,
-            pubKey: skipDeviceDerivation ? fromAccountId(accountId).account : undefined,
+            // The accountId already carries this - an address, or an xpub for utxo
+            pubKey: accountId ? fromAccountId(accountId).account : undefined,
           },
           msg => {
             const { getAccount } = portfolioApi.endpoints
@@ -190,6 +190,7 @@ export const useTransactionsSubscriber = () => {
   }, [
     dispatch,
     isConnected,
+    isDiscoveringAccounts,
     isSubscribed,
     maybeRefetchOpportunities,
     portfolioAccountMetadata,

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -2,10 +2,9 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import { ethChainId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
 import type { Transaction } from '@shapeshiftoss/chain-adapters'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
 
-import { useDiscoverAccounts } from '@/context/AppProvider/hooks/useDiscoverAccounts'
 import { getChainAdapterManager } from '@/context/PluginProvider/chainAdapterSingleton'
 import { usePlugins } from '@/context/PluginProvider/PluginProvider'
 import { useWallet } from '@/hooks/useWallet/useWallet'
@@ -27,13 +26,12 @@ import { useAppDispatch } from '@/state/store'
 
 export const useTransactionsSubscriber = () => {
   const dispatch = useAppDispatch()
-  const [isSubscribed, setIsSubscribed] = useState<boolean>(false)
+  const subscribedAccountIdsRef = useRef<Set<AccountId>>(new Set())
   const {
     state: { isConnected, wallet },
   } = useWallet()
   const portfolioAccountMetadata = useSelector(selectPortfolioAccountMetadata)
   const portfolioLoadingStatus = useSelector(selectPortfolioLoadingStatus)
-  const { isFetching: isDiscoveringAccounts } = useDiscoverAccounts()
   const { supportedChains } = usePlugins()
 
   const stakingOpportunitiesById = useSelector(
@@ -122,28 +120,30 @@ export const useTransactionsSubscriber = () => {
    * unsubscribe and cleanup logic
    */
   useEffect(() => {
-    // we've disconnected/switched a wallet, unsubscribe transactions
-    if (!isSubscribed) return
-    // this is heavy handed but will ensure we're unsubscribed from everything
-    supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
-    setIsSubscribed(false)
-    // isSubscribed causes spurious unsubscriptions - this will react correctly when portfolioAccountMetadata changes
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [supportedChains, wallet, portfolioAccountMetadata])
+    // we've disconnected/switched a wallet, unsubscribe transactions. Deliberately not reacting
+    // to portfolioAccountMetadata: discovery grows it an account at a time, and tearing every
+    // subscription down on each addition is what made this quadratic
+    return () => {
+      supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
+      subscribedAccountIdsRef.current.clear()
+    }
+  }, [supportedChains, wallet])
 
   /**
    * tx history subscription logic
    */
   useEffect(() => {
-    if (isSubscribed) return
     if (!wallet || !isConnected) return
-    // Discovery upserts an account at a time, and each upsert rebuilds every subscription
-    if (isDiscoveringAccounts) return
 
     const accountIds = Object.keys(portfolioAccountMetadata)
     if (!accountIds.length) return
 
+    // Subscribe what is new rather than the set - discovery adds to it as it goes, and an
+    // account already subscribed does not need doing again
     accountIds.forEach(accountId => {
+      if (subscribedAccountIdsRef.current.has(accountId)) return
+      subscribedAccountIdsRef.current.add(accountId)
+
       const { chainId } = fromAccountId(accountId)
       const adapter = getChainAdapterManager().get(chainId)
 
@@ -160,7 +160,7 @@ export const useTransactionsSubscriber = () => {
             accountType,
             accountNumber,
             // The accountId already carries this - an address, or an xpub for utxo
-            pubKey: accountId ? fromAccountId(accountId).account : undefined,
+            pubKey: fromAccountId(accountId).account,
           },
           msg => {
             const { getAccount } = portfolioApi.endpoints
@@ -182,16 +182,14 @@ export const useTransactionsSubscriber = () => {
           err => console.error(err),
         )
       } catch (e) {
+        // let a failed subscription be retried the next time accounts change
+        subscribedAccountIdsRef.current.delete(accountId)
         console.error(e)
       }
     })
-
-    setIsSubscribed(true)
   }, [
     dispatch,
     isConnected,
-    isDiscoveringAccounts,
-    isSubscribed,
     maybeRefetchOpportunities,
     portfolioAccountMetadata,
     portfolioLoadingStatus,

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -120,12 +120,15 @@ export const useTransactionsSubscriber = () => {
    * unsubscribe and cleanup logic
    */
   useEffect(() => {
+    // The map itself is never replaced, so this is the same one the cleanup would have read
+    const subscribedAccounts = subscribedAccountsRef.current
+
     // we've disconnected/switched a wallet, unsubscribe transactions. Deliberately not reacting
     // to portfolioAccountMetadata: discovery grows it an account at a time, and tearing every
     // subscription down on each addition is what made this quadratic
     return () => {
       supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
-      subscribedAccountsRef.current.clear()
+      subscribedAccounts.clear()
     }
   }, [supportedChains, wallet])
 

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -27,8 +27,6 @@ import { useAppDispatch } from '@/state/store'
 export const useTransactionsSubscriber = () => {
   const dispatch = useAppDispatch()
   const subscribedAccountsRef = useRef<Map<AccountId, SubscribeTxsInput>>(new Map())
-  // subscribeTxs resolves an address before it registers, so one can land after a teardown
-  const generationRef = useRef(0)
   const {
     state: { isConnected, wallet },
   } = useWallet()
@@ -129,7 +127,6 @@ export const useTransactionsSubscriber = () => {
     // to portfolioAccountMetadata: discovery grows it an account at a time, and tearing every
     // subscription down on each addition is what made this quadratic
     return () => {
-      generationRef.current += 1
       supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
       subscribedAccounts.clear()
     }
@@ -151,8 +148,6 @@ export const useTransactionsSubscriber = () => {
 
     const accountIds = Object.keys(portfolioAccountMetadata)
     if (!accountIds.length) return
-
-    const generation = generationRef.current
 
     // Subscribe what is new rather than the set - discovery adds to it as it goes, and an
     // account already subscribed does not need doing again
@@ -182,9 +177,6 @@ export const useTransactionsSubscriber = () => {
         ?.subscribeTxs(
           input,
           msg => {
-            // This subscription registered after its wallet was torn down
-            if (generationRef.current !== generation) return
-
             const { getAccount } = portfolioApi.endpoints
             const { onMessage } = txHistory.actions
 
@@ -203,9 +195,6 @@ export const useTransactionsSubscriber = () => {
           },
           err => console.error(err),
         )
-        .then(() => {
-          if (generationRef.current !== generation) adapter?.unsubscribeTxs(input)
-        })
         // subscribeTxs resolves asynchronously, so a failure surfaces here rather than as a throw
         .catch(e => {
           // let a failed subscription be retried the next time accounts change, unless a newer

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -27,6 +27,8 @@ import { useAppDispatch } from '@/state/store'
 export const useTransactionsSubscriber = () => {
   const dispatch = useAppDispatch()
   const subscribedAccountsRef = useRef<Map<AccountId, SubscribeTxsInput>>(new Map())
+  // subscribeTxs resolves an address before it registers, so one can land after a teardown
+  const generationRef = useRef(0)
   const {
     state: { isConnected, wallet },
   } = useWallet()
@@ -127,6 +129,7 @@ export const useTransactionsSubscriber = () => {
     // to portfolioAccountMetadata: discovery grows it an account at a time, and tearing every
     // subscription down on each addition is what made this quadratic
     return () => {
+      generationRef.current += 1
       supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
       subscribedAccounts.clear()
     }
@@ -148,6 +151,8 @@ export const useTransactionsSubscriber = () => {
 
     const accountIds = Object.keys(portfolioAccountMetadata)
     if (!accountIds.length) return
+
+    const generation = generationRef.current
 
     // Subscribe what is new rather than the set - discovery adds to it as it goes, and an
     // account already subscribed does not need doing again
@@ -177,6 +182,9 @@ export const useTransactionsSubscriber = () => {
         ?.subscribeTxs(
           input,
           msg => {
+            // This subscription registered after its wallet was torn down
+            if (generationRef.current !== generation) return
+
             const { getAccount } = portfolioApi.endpoints
             const { onMessage } = txHistory.actions
 
@@ -195,10 +203,15 @@ export const useTransactionsSubscriber = () => {
           },
           err => console.error(err),
         )
+        .then(() => {
+          if (generationRef.current !== generation) adapter?.unsubscribeTxs(input)
+        })
         // subscribeTxs resolves asynchronously, so a failure surfaces here rather than as a throw
         .catch(e => {
-          // let a failed subscription be retried the next time accounts change
-          subscribedAccountsRef.current.delete(accountId)
+          // let a failed subscription be retried the next time accounts change, unless a newer
+          // one has already claimed this account
+          if (subscribedAccountsRef.current.get(accountId) === input)
+            subscribedAccountsRef.current.delete(accountId)
           console.error(e)
         })
     })

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -120,12 +120,11 @@ export const useTransactionsSubscriber = () => {
    * unsubscribe and cleanup logic
    */
   useEffect(() => {
-    // The map itself is never replaced, so this is the same one the cleanup would have read
+    // .current is never replaced, so the cleanup would read this same map
     const subscribedAccounts = subscribedAccountsRef.current
 
-    // we've disconnected/switched a wallet, unsubscribe transactions. Deliberately not reacting
-    // to portfolioAccountMetadata: discovery grows it an account at a time, and tearing every
-    // subscription down on each addition is what made this quadratic
+    // Deliberately not reacting to portfolioAccountMetadata: discovery grows it an account at a
+    // time, and tearing every subscription down on each addition is what made this quadratic
     return () => {
       supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
       subscribedAccounts.clear()
@@ -138,8 +137,7 @@ export const useTransactionsSubscriber = () => {
   useEffect(() => {
     if (!wallet || !isConnected) return
 
-    // An account that has left the portfolio - disabled by hand, or a seed changed under the
-    // same device id - keeps receiving txs into the store until it is dropped
+    // An account that left the portfolio keeps receiving txs into the store until it is dropped
     subscribedAccountsRef.current.forEach((input, accountId) => {
       if (portfolioAccountMetadata[accountId]) return
       subscribedAccountsRef.current.delete(accountId)
@@ -149,8 +147,6 @@ export const useTransactionsSubscriber = () => {
     const accountIds = Object.keys(portfolioAccountMetadata)
     if (!accountIds.length) return
 
-    // Subscribe what is new rather than the set - discovery adds to it as it goes, and an
-    // account already subscribed does not need doing again
     accountIds.forEach(accountId => {
       if (subscribedAccountsRef.current.has(accountId)) return
 
@@ -195,10 +191,9 @@ export const useTransactionsSubscriber = () => {
           },
           err => console.error(err),
         )
-        // subscribeTxs resolves asynchronously, so a failure surfaces here rather than as a throw
+        // subscribeTxs is async, so a failure lands here rather than in a try/catch
         .catch(e => {
-          // let a failed subscription be retried the next time accounts change, unless a newer
-          // one has already claimed this account
+          // Let it be retried next time accounts change, unless a newer one has claimed this one
           if (subscribedAccountsRef.current.get(accountId) === input)
             subscribedAccountsRef.current.delete(accountId)
           console.error(e)

--- a/src/hooks/useTransactionsSubscriber.ts
+++ b/src/hooks/useTransactionsSubscriber.ts
@@ -1,6 +1,6 @@
 import type { AccountId } from '@shapeshiftoss/caip'
 import { ethChainId, foxAssetId, fromAccountId, fromAssetId } from '@shapeshiftoss/caip'
-import type { Transaction } from '@shapeshiftoss/chain-adapters'
+import type { SubscribeTxsInput, Transaction } from '@shapeshiftoss/chain-adapters'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { useCallback, useEffect, useRef } from 'react'
 import { useSelector } from 'react-redux'
@@ -26,7 +26,7 @@ import { useAppDispatch } from '@/state/store'
 
 export const useTransactionsSubscriber = () => {
   const dispatch = useAppDispatch()
-  const subscribedAccountIdsRef = useRef<Set<AccountId>>(new Set())
+  const subscribedAccountsRef = useRef<Map<AccountId, SubscribeTxsInput>>(new Map())
   const {
     state: { isConnected, wallet },
   } = useWallet()
@@ -125,7 +125,7 @@ export const useTransactionsSubscriber = () => {
     // subscription down on each addition is what made this quadratic
     return () => {
       supportedChains.forEach(chainId => getChainAdapterManager().get(chainId)?.unsubscribeTxs())
-      subscribedAccountIdsRef.current.clear()
+      subscribedAccountsRef.current.clear()
     }
   }, [supportedChains, wallet])
 
@@ -135,14 +135,21 @@ export const useTransactionsSubscriber = () => {
   useEffect(() => {
     if (!wallet || !isConnected) return
 
+    // An account that has left the portfolio - disabled by hand, or a seed changed under the
+    // same device id - keeps receiving txs into the store until it is dropped
+    subscribedAccountsRef.current.forEach((input, accountId) => {
+      if (portfolioAccountMetadata[accountId]) return
+      subscribedAccountsRef.current.delete(accountId)
+      getChainAdapterManager().get(fromAccountId(accountId).chainId)?.unsubscribeTxs(input)
+    })
+
     const accountIds = Object.keys(portfolioAccountMetadata)
     if (!accountIds.length) return
 
     // Subscribe what is new rather than the set - discovery adds to it as it goes, and an
     // account already subscribed does not need doing again
     accountIds.forEach(accountId => {
-      if (subscribedAccountIdsRef.current.has(accountId)) return
-      subscribedAccountIdsRef.current.add(accountId)
+      if (subscribedAccountsRef.current.has(accountId)) return
 
       const { chainId } = fromAccountId(accountId)
       const adapter = getChainAdapterManager().get(chainId)
@@ -152,16 +159,20 @@ export const useTransactionsSubscriber = () => {
       const { accountType, bip44Params } = accountMetadata
       const { accountNumber } = bip44Params
 
+      const input = {
+        wallet,
+        accountType,
+        accountNumber,
+        // The accountId already carries this - an address, or an xpub for utxo
+        pubKey: fromAccountId(accountId).account,
+      }
+
+      subscribedAccountsRef.current.set(accountId, input)
+
       // subscribe to new transactions for all supported accounts
-      try {
-        return adapter?.subscribeTxs(
-          {
-            wallet,
-            accountType,
-            accountNumber,
-            // The accountId already carries this - an address, or an xpub for utxo
-            pubKey: fromAccountId(accountId).account,
-          },
+      adapter
+        ?.subscribeTxs(
+          input,
           msg => {
             const { getAccount } = portfolioApi.endpoints
             const { onMessage } = txHistory.actions
@@ -181,11 +192,12 @@ export const useTransactionsSubscriber = () => {
           },
           err => console.error(err),
         )
-      } catch (e) {
-        // let a failed subscription be retried the next time accounts change
-        subscribedAccountIdsRef.current.delete(accountId)
-        console.error(e)
-      }
+        // subscribeTxs resolves asynchronously, so a failure surfaces here rather than as a throw
+        .catch(e => {
+          // let a failed subscription be retried the next time accounts change
+          subscribedAccountsRef.current.delete(accountId)
+          console.error(e)
+        })
     })
   }, [
     dispatch,
@@ -193,6 +205,8 @@ export const useTransactionsSubscriber = () => {
     maybeRefetchOpportunities,
     portfolioAccountMetadata,
     portfolioLoadingStatus,
+    // The cleanup above unsubscribes on a change here, so this must resubscribe
+    supportedChains,
     wallet,
   ])
 }

--- a/src/lib/account/clearAccountCaches.ts
+++ b/src/lib/account/clearAccountCaches.ts
@@ -10,5 +10,9 @@ const SEED_DEPENDENT_QUERY_KEYS = [
   ['batch-utxo-pubkeys'],
 ]
 
+// Only what has settled: a pass already running is deriving against the seed we are clearing
+// for, and removing it would orphan it and start a second one against the device
 export const clearAccountCaches = () =>
-  SEED_DEPENDENT_QUERY_KEYS.forEach(queryKey => queryClient.removeQueries({ queryKey }))
+  SEED_DEPENDENT_QUERY_KEYS.forEach(queryKey =>
+    queryClient.removeQueries({ queryKey, fetchStatus: 'idle' }),
+  )

--- a/src/lib/account/clearAccountCaches.ts
+++ b/src/lib/account/clearAccountCaches.ts
@@ -4,6 +4,7 @@ import { queryClient } from '@/context/QueryClientProvider/queryClient'
 // so none of them survive a wallet whose seed may have
 const SEED_DEPENDENT_QUERY_KEYS = [
   ['useDiscoverAccounts'],
+  ['accountIdWithActivityAndMetadata'],
   ['evm-address'],
   ['batch-evm-addresses'],
   ['batch-solana-addresses'],

--- a/src/lib/account/clearAccountCaches.ts
+++ b/src/lib/account/clearAccountCaches.ts
@@ -1,0 +1,14 @@
+import { queryClient } from '@/context/QueryClientProvider/queryClient'
+
+// All keyed on the device id, which a passphrase does not change, and all kept indefinitely -
+// so none of them survive a wallet whose seed may have
+const SEED_DEPENDENT_QUERY_KEYS = [
+  ['useDiscoverAccounts'],
+  ['evm-address'],
+  ['batch-evm-addresses'],
+  ['batch-solana-addresses'],
+  ['batch-utxo-pubkeys'],
+]
+
+export const clearAccountCaches = () =>
+  SEED_DEPENDENT_QUERY_KEYS.forEach(queryKey => queryClient.removeQueries({ queryKey }))

--- a/src/lib/account/clearAccountCaches.ts
+++ b/src/lib/account/clearAccountCaches.ts
@@ -5,7 +5,6 @@ import { queryClient } from '@/context/QueryClientProvider/queryClient'
 const SEED_DEPENDENT_QUERY_KEYS = [
   ['useDiscoverAccounts'],
   ['accountIdWithActivityAndMetadata'],
-  ['evm-address'],
   ['batch-evm-addresses'],
   ['batch-solana-addresses'],
   ['batch-utxo-pubkeys'],

--- a/src/lib/account/clearAccountCaches.ts
+++ b/src/lib/account/clearAccountCaches.ts
@@ -1,6 +1,7 @@
 import { queryClient } from '@/context/QueryClientProvider/queryClient'
 
-// All keyed on the device id, which a passphrase does not change
+// All keyed on the device id, which a passphrase does not change. The batch keys are Trezor-only
+// today, and listed so a wallet that gains both batching and a passphrase cannot go stale
 const SEED_DEPENDENT_QUERY_KEYS = [
   ['useDiscoverAccounts'],
   ['accountIdWithActivityAndMetadata'],

--- a/src/lib/account/clearAccountCaches.ts
+++ b/src/lib/account/clearAccountCaches.ts
@@ -1,7 +1,6 @@
 import { queryClient } from '@/context/QueryClientProvider/queryClient'
 
-// All keyed on the device id, which a passphrase does not change, and all kept indefinitely -
-// so none of them survive a wallet whose seed may have
+// All keyed on the device id, which a passphrase does not change
 const SEED_DEPENDENT_QUERY_KEYS = [
   ['useDiscoverAccounts'],
   ['accountIdWithActivityAndMetadata'],
@@ -11,8 +10,7 @@ const SEED_DEPENDENT_QUERY_KEYS = [
   ['batch-utxo-pubkeys'],
 ]
 
-// Only what has settled: a pass already running is deriving against the seed we are clearing
-// for, and removing it would orphan it and start a second one against the device
+// Settled only - a running pass derives against the new seed, and removing it starts a second one
 export const clearAccountCaches = () =>
   SEED_DEPENDENT_QUERY_KEYS.forEach(queryKey =>
     queryClient.removeQueries({ queryKey, fetchStatus: 'idle' }),

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -89,15 +89,23 @@ import { canAddMetaMaskAccount } from '@/hooks/useIsSnapInstalled/useIsSnapInsta
 import { assertGetEvmChainAdapter } from '@/lib/utils/evm'
 
 // Discovery derives a chain at a time, so every evm chain asks for the same address at once.
-// Dropped as soon as it settles - nothing outlives its derivation, so nothing can go stale
-const inFlightAddresses = new Map<number, Promise<string>>()
+// Held against the wallet deriving it, and dropped as soon as it settles - a pass that outlives
+// its wallet cannot hand the next one an address, and nothing survives to go stale
+const inFlightAddresses = new WeakMap<HDWallet, Map<number, Promise<string>>>()
 
-const deriveEvmAddressOnce = (accountNumber: number, derive: () => Promise<string>) => {
-  const pending = inFlightAddresses.get(accountNumber)
+const deriveEvmAddressOnce = (
+  wallet: HDWallet,
+  accountNumber: number,
+  derive: () => Promise<string>,
+) => {
+  const byAccountNumber = inFlightAddresses.get(wallet) ?? new Map<number, Promise<string>>()
+  inFlightAddresses.set(wallet, byAccountNumber)
+
+  const pending = byAccountNumber.get(accountNumber)
   if (pending) return pending
 
-  const derivation = derive().finally(() => inFlightAddresses.delete(accountNumber))
-  inFlightAddresses.set(accountNumber, derivation)
+  const derivation = derive().finally(() => byAccountNumber.delete(accountNumber))
+  byAccountNumber.set(accountNumber, derivation)
 
   return derivation
 }
@@ -225,7 +233,7 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
       const cachedAddress = getCachedBatchAddress({ deviceId, chainId, accountNumber })
       address =
         cachedAddress ||
-        (await deriveEvmAddressOnce(accountNumber, () =>
+        (await deriveEvmAddressOnce(wallet, accountNumber, () =>
           adapter.getAddress({ accountNumber, wallet }),
         ))
     }

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -88,6 +88,9 @@ import { fetchIsSmartContractAddressQuery } from '@/hooks/useIsSmartContractAddr
 import { canAddMetaMaskAccount } from '@/hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { assertGetEvmChainAdapter } from '@/lib/utils/evm'
 
+// Long enough to span a discovery pass, short enough not to outlive the wallet it was derived from
+const EVM_ADDRESS_CACHE_MS = 60_000
+
 const prefetchBatchedEvmAddresses = async ({
   wallet,
   chainId,
@@ -209,15 +212,19 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
     // use address if we have it, there is no need to re-derive an address for every chainId since they all use the same derivation path
     if (!address) {
       const cachedAddress = getCachedBatchAddress({ deviceId, chainId, accountNumber })
-      // Discovery derives a chain at a time, so cache off the path every evm chain shares
+      // Discovery derives a chain at a time, so cache off the path every evm chain shares.
+      // Bounded, and skipped without a deviceId: the id is not seed-derived, so a passphrase
+      // would otherwise be served the address of the seed before it
       address =
         cachedAddress ||
-        (await queryClient.fetchQuery({
-          queryKey: ['evm-address', deviceId, accountNumber],
-          queryFn: () => adapter.getAddress({ accountNumber, wallet }),
-          staleTime: Infinity,
-          gcTime: Infinity,
-        }))
+        (deviceId
+          ? await queryClient.fetchQuery({
+              queryKey: ['evm-address', deviceId, accountNumber],
+              queryFn: () => adapter.getAddress({ accountNumber, wallet }),
+              staleTime: EVM_ADDRESS_CACHE_MS,
+              gcTime: EVM_ADDRESS_CACHE_MS,
+            })
+          : await adapter.getAddress({ accountNumber, wallet }))
     }
     if (!address) continue
 

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -213,8 +213,8 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
     if (!address) {
       const cachedAddress = getCachedBatchAddress({ deviceId, chainId, accountNumber })
       // Discovery derives a chain at a time, so cache off the path every evm chain shares.
-      // Bounded, and skipped without a deviceId: the id is not seed-derived, so a passphrase
-      // would otherwise be served the address of the seed before it
+      // Bounded rather than kept: deviceId does not change with a passphrase, so a longer-lived
+      // entry would hand a second seed the address of the first
       address =
         cachedAddress ||
         (deviceId

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -209,7 +209,15 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
     // use address if we have it, there is no need to re-derive an address for every chainId since they all use the same derivation path
     if (!address) {
       const cachedAddress = getCachedBatchAddress({ deviceId, chainId, accountNumber })
-      address = cachedAddress || (await adapter.getAddress({ accountNumber, wallet }))
+      // Discovery derives a chain at a time, so cache off the path every evm chain shares
+      address =
+        cachedAddress ||
+        (await queryClient.fetchQuery({
+          queryKey: ['evm-address', deviceId, accountNumber],
+          queryFn: () => adapter.getAddress({ accountNumber, wallet }),
+          staleTime: Infinity,
+          gcTime: Infinity,
+        }))
     }
     if (!address) continue
 

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -88,8 +88,19 @@ import { fetchIsSmartContractAddressQuery } from '@/hooks/useIsSmartContractAddr
 import { canAddMetaMaskAccount } from '@/hooks/useIsSnapInstalled/useIsSnapInstalled'
 import { assertGetEvmChainAdapter } from '@/lib/utils/evm'
 
-// Long enough to span a discovery pass, short enough not to outlive the wallet it was derived from
-const EVM_ADDRESS_CACHE_MS = 60_000
+// Discovery derives a chain at a time, so every evm chain asks for the same address at once.
+// Dropped as soon as it settles - nothing outlives its derivation, so nothing can go stale
+const inFlightAddresses = new Map<number, Promise<string>>()
+
+const deriveEvmAddressOnce = (accountNumber: number, derive: () => Promise<string>) => {
+  const pending = inFlightAddresses.get(accountNumber)
+  if (pending) return pending
+
+  const derivation = derive().finally(() => inFlightAddresses.delete(accountNumber))
+  inFlightAddresses.set(accountNumber, derivation)
+
+  return derivation
+}
 
 const prefetchBatchedEvmAddresses = async ({
   wallet,
@@ -212,20 +223,11 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
     // use address if we have it, there is no need to re-derive an address for every chainId since they all use the same derivation path
     if (!address) {
       const cachedAddress = getCachedBatchAddress({ deviceId, chainId, accountNumber })
-      // Discovery derives a chain at a time, so cache off the path every evm chain shares.
-      // Bounded, because a passphrase changes the seed without changing the deviceId keyed on
       address =
         cachedAddress ||
-        (deviceId
-          ? await queryClient.fetchQuery({
-              queryKey: ['evm-address', deviceId, accountNumber],
-              queryFn: () => adapter.getAddress({ accountNumber, wallet }),
-              staleTime: EVM_ADDRESS_CACHE_MS,
-              gcTime: EVM_ADDRESS_CACHE_MS,
-              // A rejected derivation is the user declining on device, not something to retry
-              retry: false,
-            })
-          : await adapter.getAddress({ accountNumber, wallet }))
+        (await deriveEvmAddressOnce(accountNumber, () =>
+          adapter.getAddress({ accountNumber, wallet }),
+        ))
     }
     if (!address) continue
 

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -223,6 +223,8 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
               queryFn: () => adapter.getAddress({ accountNumber, wallet }),
               staleTime: EVM_ADDRESS_CACHE_MS,
               gcTime: EVM_ADDRESS_CACHE_MS,
+              // A rejected derivation is the user declining on device, not something to retry
+              retry: false,
             })
           : await adapter.getAddress({ accountNumber, wallet }))
     }

--- a/src/lib/account/evm.ts
+++ b/src/lib/account/evm.ts
@@ -213,8 +213,7 @@ export const deriveEvmAccountIdsAndMetadata: DeriveAccountIdsAndMetadata = async
     if (!address) {
       const cachedAddress = getCachedBatchAddress({ deviceId, chainId, accountNumber })
       // Discovery derives a chain at a time, so cache off the path every evm chain shares.
-      // Bounded rather than kept: deviceId does not change with a passphrase, so a longer-lived
-      // entry would hand a second seed the address of the first
+      // Bounded, because a passphrase changes the seed without changing the deviceId keyed on
       address =
         cachedAddress ||
         (deviceId

--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -11,6 +11,9 @@ import {
   tronChainId,
 } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
+import { isGridPlus } from '@shapeshiftoss/hdwallet-core/wallet'
+import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
+import { isTrezor } from '@shapeshiftoss/hdwallet-trezor'
 import type { MidgardActionsResponse, ThornodeStatusResponse } from '@shapeshiftoss/swapper'
 import { thorService } from '@shapeshiftoss/swapper'
 import type {
@@ -214,13 +217,14 @@ export const getThorchainFromAddress = async ({
     // And re-throw if no adapter found. "Shouldn't happen but" yadi yadi yada you know the drill
     if (!chainAdapter) throw new Error(`No chain adapter found for chainId: ${chainId}`)
 
+    const skipDeviceDerivation =
+      (isLedger(wallet) || isGridPlus(wallet) || isTrezor(wallet)) && accountId
     const firstReceiveAddress = await chainAdapter.getAddress({
       wallet,
       accountNumber: bip44Params.accountNumber,
       accountType,
       addressIndex: 0,
-      // The accountId carries this, and utxo resolves the xpub to the address at this index
-      pubKey: accountId ? fromAccountId(accountId).account : undefined,
+      pubKey: skipDeviceDerivation ? fromAccountId(accountId).account : undefined,
     })
     return firstReceiveAddress
   }
@@ -263,13 +267,14 @@ export const getThorfiUtxoFromAddresses = async ({
 
     const { accountType, bip44Params } = accountMetadata
 
+    const skipDeviceDerivation =
+      (isLedger(wallet) || isGridPlus(wallet) || isTrezor(wallet)) && accountId
     const firstReceiveAddress = await chainAdapter.getAddress({
       wallet,
       accountNumber: bip44Params.accountNumber,
       accountType,
       addressIndex: 0,
-      // The accountId carries this, and utxo resolves the xpub to the address at this index
-      pubKey: accountId ? fromAccountId(accountId).account : undefined,
+      pubKey: skipDeviceDerivation ? fromAccountId(accountId).account : undefined,
     })
 
     return [firstReceiveAddress]

--- a/src/lib/utils/thorchain/index.ts
+++ b/src/lib/utils/thorchain/index.ts
@@ -11,9 +11,6 @@ import {
   tronChainId,
 } from '@shapeshiftoss/caip'
 import type { HDWallet } from '@shapeshiftoss/hdwallet-core'
-import { isGridPlus } from '@shapeshiftoss/hdwallet-core/wallet'
-import { isLedger } from '@shapeshiftoss/hdwallet-ledger'
-import { isTrezor } from '@shapeshiftoss/hdwallet-trezor'
 import type { MidgardActionsResponse, ThornodeStatusResponse } from '@shapeshiftoss/swapper'
 import { thorService } from '@shapeshiftoss/swapper'
 import type {
@@ -217,14 +214,13 @@ export const getThorchainFromAddress = async ({
     // And re-throw if no adapter found. "Shouldn't happen but" yadi yadi yada you know the drill
     if (!chainAdapter) throw new Error(`No chain adapter found for chainId: ${chainId}`)
 
-    const skipDeviceDerivation =
-      (isLedger(wallet) || isGridPlus(wallet) || isTrezor(wallet)) && accountId
     const firstReceiveAddress = await chainAdapter.getAddress({
       wallet,
       accountNumber: bip44Params.accountNumber,
       accountType,
       addressIndex: 0,
-      pubKey: skipDeviceDerivation ? fromAccountId(accountId).account : undefined,
+      // The accountId carries this, and utxo resolves the xpub to the address at this index
+      pubKey: accountId ? fromAccountId(accountId).account : undefined,
     })
     return firstReceiveAddress
   }
@@ -267,14 +263,13 @@ export const getThorfiUtxoFromAddresses = async ({
 
     const { accountType, bip44Params } = accountMetadata
 
-    const skipDeviceDerivation =
-      (isLedger(wallet) || isGridPlus(wallet) || isTrezor(wallet)) && accountId
     const firstReceiveAddress = await chainAdapter.getAddress({
       wallet,
       accountNumber: bip44Params.accountNumber,
       accountType,
       addressIndex: 0,
-      pubKey: skipDeviceDerivation ? fromAccountId(accountId).account : undefined,
+      // The accountId carries this, and utxo resolves the xpub to the address at this index
+      pubKey: accountId ? fromAccountId(accountId).account : undefined,
     })
 
     return [firstReceiveAddress]


### PR DESCRIPTION
## Description

Cuts the device traffic and subscription churn on connect, and stops discovery re-deriving accounts the portfolio already holds.

**Derive an EVM address once per account number, not once per chain.** `deriveEvmAccountIdsAndMetadata` already reused one address across chainIds, but discovery calls it with a single chainId per query so that reuse never fired. The seven EVM chains ask for the same address within milliseconds of each other, so they now share one in-flight derivation — 21 chain/account derivations collapse to 3 device calls. Nothing is stored: the promise is dropped as soon as it settles, so no derived address can outlive the seed it came from.

**Subscribe txs without asking the device.** Every adapter honours `pubKey` (evm returns it, utxo resolves the xpub through `getAccount`, cosmos returns it) and the accountId already carries exactly that value — but it was behind an allowlist that grew one wallet at a time (`isLedger`, then `isGridPlus`, then `isTrezor`) rather than being generalised. Removing it also kills an O(n²): discovery upserts an account at a time, and each upsert tore down and rebuilt *every* subscription. Subscriptions are now incremental — new accounts are added, and accounts that leave the portfolio are unsubscribed individually.

**Resume discovery past accounts already known.** Account 0 is still derived on every chain and must match what was persisted before anything is skipped, so a different seed under the same device id falls back to a full pass. A number counts as known only once every accountId that account 0 derived is stored for it, so a manual import of one UTXO script type can't skip its siblings.

**Clear derived-account caches when the passphrase changes.** `clearWalletMetadata` empties the portfolio, but the discovery queries are keyed on the device id with `staleTime`/`gcTime: Infinity` — so without this, entering a passphrase emptied the portfolio and left it empty until reload. Only settled queries are cleared; a pass already running is deriving against the new seed and removing it would orphan it and start a second one against the device.

## Issue (if applicable)

closes #

## Risk

Medium. Touches account discovery, tx subscriptions and the KeepKey passphrase path. No on-chain transaction is introduced or modified.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

All chains and all wallets. Hardware wallets (KeepKey especially) see the largest change, since they pay per derivation. Tx subscriptions now pass `pubKey` for every wallet rather than a hardcoded few — the value is the same one the accountId was built from. The passphrase changes are KeepKey-only.

## Testing

### Engineering

Measured on a KeepKey, 14 chains, 28 accounts:

| | device round trips | discovery wall clock | first tx subscription |
|---|---|---|---|
| cold cache | 32 | 26.4s | 36.0s |
| warm | 25 | 14.3s | 23.5s |

Warm subscriptions land before the first device call, straight off the persisted portfolio. thorchain 20.4s → 7.4s, BTC 26.4s → 14.0s. Device time is ~99% of a derivation; unchained adds ~0.6s.

Verified on device:
- account 0 derives on every chain every connect, and `isSameSeed` gates the resume
- the seven EVM chains share one derivation per account number (3 device calls for 21 derivations, cold and warm)
- disabling an account in Manage Accounts unsubscribes exactly that account — `subscriptionId` scoped to its derivation path, three of them for a UTXO account across script types — and re-enabling re-subscribes with no device call
- entering a passphrase derives the new seed's accounts and repopulates the portfolio. All 14 discovery queries were mid-derivation at that moment and were correctly left alone rather than orphaned
- with a new seed, `resumeFrom` is computed from the pre-clear portfolio and would have skipped an account; `isSameSeed` is what prevents it
- no duplicate subscriptions across a full discovery pass

Not yet exercised, worth a reviewer's eye:
- `supportedChains` changing (remote-config load, dev flag toggle) tears subscriptions down and must resubscribe — the subscribe effect now depends on it. Fails silently if wrong.
- a genuinely new account past the resume high-water mark still being discovered
- toggling the passphrase setting off via device settings (the entry path is verified, this one is not)

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

No user-facing UI changes. Everything below is regression testing — the expected result is "same as production, but connecting is faster".

**1. Connect each wallet type** (Native, MetaMask, Ledger, KeepKey, Trezor, WalletConnect, Phantom, Keplr, Coinbase). All accounts that appear on production must still appear, with the same balances.

**2. Reconnect speed.** With a wallet already connected once, disconnect and reconnect. It should reach a usable state noticeably faster than production, and **no accounts may be missing** — compare the account list side by side with production before and after. This is the main change; missing accounts is the failure to watch for.

**3. Transactions arrive, exactly once.** Send and receive on one EVM chain (ETH/Base/Arbitrum) and one UTXO chain (BTC/LTC). Each transaction must appear in history **once**, and the balance must update. Duplicates or a transaction that never appears are both failures.

**4. Disabled accounts stay disabled.** In Manage Accounts, disable an account that has funds. Send a small amount to that account's address. It must **not** reappear in the portfolio. Then re-enable it — it should come back with the correct balance, and a later transaction to it should show up.

**5. Wallet switching.** Connect wallet A, note its accounts, switch to wallet B. B's accounts must fully replace A's, with no leftovers from A. Send a transaction on B and confirm it appears under B. Switch back to A and confirm the same.

**6. New account discovery.** Send funds to the next unused account number on a chain (e.g. if you have Bitcoin Account #0 and #1, fund #2), then disconnect and reconnect. Account #2 must be discovered and appear. This is the case the "resume" optimisation could break.

**7. KeepKey passphrase** (KeepKey only). On a device with passphrase enabled, connect and enter a passphrase. A **different** set of accounts must load — the portfolio must not stay empty and must not show the previous accounts. Disconnect, power-cycle the device, reconnect with a different passphrase and confirm a different set again.

**8. KeepKey passphrase toggle** (KeepKey only). In the KeepKey menu, turn the passphrase setting off, confirm on device. The wallet should reconnect and load accounts. Repeat turning it back on. The portfolio must never be left permanently empty.

**9. Trade input button.** On the trade page while accounts are still loading, the preview button shows a spinner with "Loading Accounts". It must never be clickable while accounts are loading, and must never show a spinner alongside "Preview Trade". Once loading finishes it becomes a normal enabled/disabled Preview Trade button.

**10. Receive-address warning.** Pick a buy asset on a chain your wallet supports and confirm no "no address found" style warning appears while accounts are still loading. Any such warning should only appear after loading completes, and only for chains genuinely unsupported by the wallet.

## Screenshots (if applicable)

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Account discovery now skips previously discovered accounts and finds new accounts more efficiently.
  * Improved EVM address lookup performance through shared in-progress requests.
  * Account data refreshes automatically after KeepKey passphrase changes.

* **Bug Fixes**
  * Trade preview is consistently disabled while accounts are loading, with a clear status message.
  * Transaction subscriptions update reliably as accounts are added or removed.
  * Failed subscription attempts can retry during later account updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->