### PR TITLE
feat(public-api): send quote provenance with swap registration

### DIFF
--- a/packages/public-api/src/routes/status/utils.ts
+++ b/packages/public-api/src/routes/status/utils.ts
@@ -27,6 +27,8 @@ const buildSwapRegistrationBody = (storedQuote: ReturnType<typeof quoteStore.get
       affiliateBps: Number(storedQuote.affiliateBps),
       shapeshiftBps: Number(storedQuote.shapeshiftBps),
       origin: 'api',
+      quoteId: storedQuote.quoteId,
+      quoteCreatedAt: new Date(storedQuote.createdAt).toISOString(),
       metadata: storedQuote.metadata,
     }),
   }


### PR DESCRIPTION
## Description

`registerSwapInService` rebuilds the swap-service payload entirely from the stored quote, but the quote's own identity was never part of it — `quoteId` only reached the database inside the `metadata` JSON blob, and the quote's mint time was dropped altogether.

This adds both to the registration body:

- `quoteId` — promoted out of `metadata` so swap-service can store it as a real column
- `quoteCreatedAt` — the quote's `createdAt`, as an ISO 8601 string

`quoteCreatedAt` is deliberately the quote's mint time, not its bind time (`registeredAt`). It records when the quote was issued, which is what lets a swap row be tied back to the quote that authorised it.

Ships ahead of the matching swap-service change, which adds the columns that consume these fields. Safe to merge first: swap-service ignores unrecognised body fields today, so this is inert until that side lands, and merging in the other order would leave swap-service asking for a field nobody sends.

## Testing

- `pnpm test` in `packages/public-api` — 30 passing, unchanged
- Both values come from the already-frozen `StoredQuote`; no new client input is accepted and no existing field changes
- No behaviour change until the swap-service side merges — verify by registering a swap and confirming the two extra fields appear in the `POST /swaps` body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Swap registration requests now include the associated quote ID and quote creation timestamp for improved tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->