### PR TITLE
feat(public-api): drop the dead browser swap write, send quotedAt

### DIFF
--- a/.env
+++ b/.env
@@ -343,7 +343,6 @@ VITE_TENDERLY_ACCOUNT_SLUG=0xgomes
 VITE_TENDERLY_PROJECT_SLUG=project
 
 # Webservices
-VITE_SWAPS_SERVER_URL=https://api.swap-service.shapeshift.com
 VITE_USER_SERVER_URL=https://api.user-service.shapeshift.com
 VITE_NOTIFICATIONS_SERVER_URL=https://api.notifications-service.shapeshift.com
 VITE_PUBLIC_API_URL=https://api.shapeshift.com

--- a/.env.development
+++ b/.env.development
@@ -97,7 +97,6 @@ VITE_THORCHAIN_MIDGARD_URL=https://dev-api.thorchain.shapeshift.com/midgard/v2
 VITE_MAYACHAIN_MIDGARD_URL=https://dev-api.mayachain.shapeshift.com/midgard/v2
 
 # Webservices
-VITE_SWAPS_SERVER_URL=https://dev-api.swap-service.shapeshift.com
 VITE_USER_SERVER_URL=https://dev-api.user-service.shapeshift.com
 VITE_NOTIFICATIONS_SERVER_URL=https://dev-api.notifications-service.shapeshift.com
 VITE_PUBLIC_API_URL=https://dev-api.shapeshift.com

--- a/packages/public-api/src/routes/status/utils.ts
+++ b/packages/public-api/src/routes/status/utils.ts
@@ -27,8 +27,7 @@ const buildSwapRegistrationBody = (storedQuote: ReturnType<typeof quoteStore.get
       affiliateBps: Number(storedQuote.affiliateBps),
       shapeshiftBps: Number(storedQuote.shapeshiftBps),
       origin: 'api',
-      quoteId: storedQuote.quoteId,
-      quoteCreatedAt: new Date(storedQuote.createdAt).toISOString(),
+      quotedAt: new Date(storedQuote.createdAt).toISOString(),
       metadata: storedQuote.metadata,
     }),
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -287,7 +287,6 @@ const validators = {
   VITE_TENDERLY_API_KEY: str(),
   VITE_FEATURE_NOTIFICATIONS_WEBSERVICES: bool({ default: false }),
   VITE_USER_SERVER_URL: url({ default: '' }),
-  VITE_SWAPS_SERVER_URL: url({ default: '' }),
   VITE_NOTIFICATIONS_SERVER_URL: url({ default: '' }),
   VITE_PUBLIC_API_URL: url({ default: '' }),
   VITE_FEATURE_ADDRESS_BOOK: bool({ default: false }),

--- a/src/lib/tradeExecution.ts
+++ b/src/lib/tradeExecution.ts
@@ -33,7 +33,6 @@ import {
   TradeExecutionEvent,
 } from '@shapeshiftoss/swapper'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
-import axios from 'axios'
 import { EventEmitter } from 'node:events'
 
 import { assertGetCosmosSdkChainAdapter } from './utils/cosmosSdk'
@@ -48,16 +47,9 @@ import { assertGetUtxoChainAdapter } from './utils/utxo'
 
 import { getConfig } from '@/config'
 import { queryClient } from '@/context/QueryClientProvider/queryClient'
-import {
-  readStoredPartnerAddress,
-  readStoredPartnerBps,
-  readStoredShapeshiftBps,
-} from '@/hooks/useAffiliateTracking/useAffiliateTracking'
 import { fetchIsSmartContractAddressQuery } from '@/hooks/useIsSmartContractAddress/useIsSmartContractAddress'
-import { getAffiliateBps } from '@/lib/fees/utils'
 import { poll } from '@/lib/poll/poll'
-import { getOrCreateUser } from '@/lib/user/api'
-import { selectCurrentSwap, selectWalletEnabledAccountIds } from '@/state/slices/selectors'
+import { selectCurrentSwap } from '@/state/slices/selectors'
 import { swapSlice } from '@/state/slices/swapSlice/swapSlice'
 import { selectFirstHopSellAccountId } from '@/state/slices/tradeInputSlice/selectors'
 import { store } from '@/state/store'
@@ -198,54 +190,6 @@ export class TradeExecution {
       }
 
       store.dispatch(swapSlice.actions.upsertSwap(updatedSwap))
-
-      const isWebServicesEnabled = getConfig().VITE_FEATURE_NOTIFICATIONS_WEBSERVICES
-
-      if (isWebServicesEnabled) {
-        try {
-          const walletEnabledAccountIds = selectWalletEnabledAccountIds(store.getState())
-          const userData = await queryClient.fetchQuery<{ id: string }>({
-            queryKey: ['user', walletEnabledAccountIds],
-            queryFn: () => getOrCreateUser({ accountIds: walletEnabledAccountIds }),
-          })
-
-          if (userData) {
-            queryClient.fetchQuery({
-              queryKey: ['createSwap', swap.id],
-              queryFn: () => {
-                const affiliateBps = getAffiliateBps(updatedSwap.sellAsset, updatedSwap.buyAsset)
-                const storedPartnerBps = readStoredPartnerBps()
-
-                return axios.post(`${import.meta.env.VITE_SWAPS_SERVER_URL}/swaps`, {
-                  swapId: swap.id,
-                  sellAsset: updatedSwap.sellAsset,
-                  buyAsset: updatedSwap.buyAsset,
-                  sellAmountCryptoBaseUnit: updatedSwap.sellAmountCryptoBaseUnit,
-                  expectedBuyAmountCryptoBaseUnit: updatedSwap.expectedBuyAmountCryptoBaseUnit,
-                  sellTxHash,
-                  source: updatedSwap.source,
-                  swapperName: updatedSwap.swapperName,
-                  sellAccountId: accountId,
-                  buyAccountId: accountId,
-                  receiveAddress: updatedSwap.receiveAddress,
-                  partnerAddress: readStoredPartnerAddress() ?? undefined,
-                  partnerBps: storedPartnerBps ? Number(storedPartnerBps) : undefined,
-                  affiliateBps: Number(affiliateBps),
-                  shapeshiftBps: Number(readStoredShapeshiftBps() ?? affiliateBps),
-                  userId: userData?.id,
-                  origin: 'web',
-                  isStreaming: updatedSwap.isStreaming,
-                  metadata: updatedSwap.metadata,
-                })
-              },
-              staleTime: 0,
-              gcTime: 0,
-            })
-          }
-        } catch (e) {
-          console.error('Failed to notify swap webservice, chain might not be supported yet', e)
-        }
-      }
 
       const { cancelPolling } = poll({
         fn: async () => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -180,7 +180,6 @@ interface ImportMetaEnv {
   readonly VITE_SOLANA_NODE_URL: string
   readonly VITE_THORCHAIN_MIDGARD_URL: string
   readonly VITE_MAYACHAIN_MIDGARD_URL: string
-  readonly VITE_SWAPS_SERVER_URL: string
   readonly VITE_NOTIFICATIONS_SERVER_URL: string
   readonly VITE_USER_SERVER_URL: string
   readonly VITE_SCROLL_NODE_URL: string


### PR DESCRIPTION
## Description

Follow-up to #12620, which shipped `quoteId` and `quoteCreatedAt` on the swap registration body.

**Renames the field to `quotedAt` and drops `quoteId`.** swap-service registers a swap under `swapId = storedQuote.quoteId`, so the quote's identity is already carried on every api-origin row and a second copy of it earns nothing — the consuming column has been dropped on the swap-service side. `quotedAt` is named deliberately: sitting next to the row's own `createdAt`, a `quoteCreatedAt` invites being read as registration time, and those two are not interchangeable. Registration always happens *after* the sell transaction is broadcast, so comparing a transaction against the wrong one of them inverts the result.

**Removes the browser's direct `POST /swaps` path.** It has been unreachable since swap-service gained its API key guard: the guard rejects any request without `x-api-key` and refuses to boot when `SERVICE_API_KEY` is unset, so there is no environment where a browser request succeeds — including dev, despite `.env.development` enabling the flag. It is also gated off in prod (`VITE_FEATURE_NOTIFICATIONS_WEBSERVICES=false`).

Beyond being dead, it was the last path that read affiliate attribution out of localStorage (`readStoredPartnerAddress`, `readStoredPartnerBps`, `readStoredShapeshiftBps`) and posted it verbatim. The user record it created is already created independently by `useUser`, and the feature flag survives for its other consumer in `preferencesSlice`.

`VITE_SWAPS_SERVER_URL` goes with it, since nothing reads it once that path is gone.

## Testing

- `pnpm test` in `packages/public-api` — 30 passing, unchanged
- `pnpm exec eslint` clean on `src/lib/tradeExecution.ts`, `src/config.ts` and the public-api route
- Verified no remaining references to `VITE_SWAPS_SERVER_URL`, `getOrCreateUser`, `getAffiliateBps`, `readStoredPartner*` or `selectWalletEnabledAccountIds` in `tradeExecution.ts`; `queryClient` and `getConfig` are still used and retained
- No user-visible change: the removed request could only 401, and its result was discarded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Removed the deprecated swap-service configuration.
  - Updated swap registration requests to use the current quote timestamp field and omit the quote ID.
  - Stopped sending swap execution notifications to the external swap service.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->