### PR TITLE
fix(portfolio): blacklist AICC and PVC airdrop scam tokens

### DIFF
--- a/src/state/blacklist.test.ts
+++ b/src/state/blacklist.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { isBlacklistedAssetId, isSpammyTokenText } from './blacklist'
+
+describe('isBlacklistedAssetId', () => {
+  it('returns true for known scam tokens', () => {
+    expect(isBlacklistedAssetId('eip155:1/erc20:0x66a3c2fa3e467aa586e90912f977e648589cabaf')).toBe(
+      true,
+    )
+    expect(isBlacklistedAssetId('eip155:1/erc20:0x514b9e5467b9eb811519e316263c9099eae546ca')).toBe(
+      true,
+    )
+  })
+
+  it('returns false for legitimate tokens', () => {
+    expect(isBlacklistedAssetId('eip155:1/erc20:0xc770eefad204b5180df6a14ee197d99d808ee52d')).toBe(
+      false,
+    )
+    expect(isBlacklistedAssetId('eip155:1/slip44:60')).toBe(false)
+  })
+
+  it('catches tokens whose names look legitimate to the text heuristics', () => {
+    // These are the reason the id blacklist exists - clean-looking names that pass regex checks
+    expect(isSpammyTokenText('AI Chain Coin')).toBe(false)
+    expect(isSpammyTokenText('Privacy Coin')).toBe(false)
+  })
+})

--- a/src/state/blacklist.ts
+++ b/src/state/blacklist.ts
@@ -71,7 +71,8 @@ export const BLACKLISTED_ASSET_IDS = new Set<AssetId>([
   'eip155:1/erc20:0x514b9e5467b9eb811519e316263c9099eae546ca',
 ])
 
-export const isBlacklistedAssetId = (assetId: AssetId) => BLACKLISTED_ASSET_IDS.has(assetId)
+export const isBlacklistedAssetId = (assetId: AssetId): boolean =>
+  BLACKLISTED_ASSET_IDS.has(assetId)
 
 export const BLACKLISTED_COLLECTION_IDS = [
   'eip155:137/erc1155:0x30825b65e775678997c7fbc5831ab492c697448e',

--- a/src/state/blacklist.ts
+++ b/src/state/blacklist.ts
@@ -1,3 +1,5 @@
+import type { AssetId } from '@shapeshiftoss/caip'
+
 const NFT_NAME_BLACKLIST = [
   'voucher',
   'airdrop',
@@ -59,6 +61,17 @@ export const isSpammyNftText = (nftText: string, excludeEmpty?: boolean) => {
 
 export const isSpammyTokenText = (tokenText: string) =>
   TOKEN_TEXT_REGEX_BLACKLIST.some(regex => regex.test(tokenText))
+
+// Known scam/airdrop tokens that slip past both the upstream Moralis spam filter and the text
+// heuristics above. These are dropped at portfolio ingestion time for all users.
+export const BLACKLISTED_ASSET_IDS = new Set<AssetId>([
+  // AI Chain Coin (AICC) - airdropped honeypot
+  'eip155:1/erc20:0x66a3c2fa3e467aa586e90912f977e648589cabaf',
+  // Privacy Coin (PVC) - airdropped honeypot
+  'eip155:1/erc20:0x514b9e5467b9eb811519e316263c9099eae546ca',
+])
+
+export const isBlacklistedAssetId = (assetId: AssetId) => BLACKLISTED_ASSET_IDS.has(assetId)
 
 export const BLACKLISTED_COLLECTION_IDS = [
   'eip155:137/erc1155:0x30825b65e775678997c7fbc5831ab492c697448e',

--- a/src/state/migrations/index.ts
+++ b/src/state/migrations/index.ts
@@ -40,6 +40,7 @@ export const clearPortfolioMigrations = {
   3: clearPortfolio,
   4: clearPortfolio,
   5: clearPortfolio,
+  6: clearPortfolio,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
 export const localWalletMigrations = {
@@ -408,6 +409,7 @@ export const clearAssetsMigrations = {
   357: clearAssets,
   358: clearAssets,
   359: clearAssets,
+  360: clearAssets,
 } as unknown as Omit<MigrationManifest, '_persist'>
 
 export const clearMarketDataMigrations = {

--- a/src/state/slices/portfolioSlice/utils/index.ts
+++ b/src/state/slices/portfolioSlice/utils/index.ts
@@ -128,7 +128,7 @@ import { fetchPortalsAccount, fetchPortalsPlatforms, maybeTokenImage } from '@/l
 import { assertUnreachable, isNativeHDWallet, isTrezorHDWallet, middleEllipsis } from '@/lib/utils'
 import { supportsNear } from '@/lib/utils/near'
 import { supportsTon } from '@/lib/utils/ton'
-import { isSpammyNftText, isSpammyTokenText } from '@/state/blacklist'
+import { isBlacklistedAssetId, isSpammyNftText, isSpammyTokenText } from '@/state/blacklist'
 import type { ReduxState } from '@/state/reducer'
 import type { UpsertAssetsPayload } from '@/state/slices/assetsSlice/assetsSlice'
 
@@ -272,6 +272,7 @@ export const accountToPortfolio: AccountToPortfolio = ({ assetIds, portfolioAcco
           // don't update portfolio if asset is not in the store except for nft assets,
           // nft assets will be dynamically upserted based on the state of the txHistory slice after the portfolio is loaded
           if (!isNft(token.assetId) && !assetIds.includes(token.assetId)) return
+          if (isBlacklistedAssetId(token.assetId)) return
 
           if (isNft(token.assetId)) {
             if ([token.name, token.symbol].some(nftText => isSpammyNftText(nftText, true))) return
@@ -711,7 +712,8 @@ export const makeAssets = async ({
           return isSpammyTokenText(text)
         })
 
-        if (state.assets.byId[token.assetId] || isSpam) return prev
+        if (state.assets.byId[token.assetId] || isSpam || isBlacklistedAssetId(token.assetId))
+          return prev
 
         const minimalAsset: MinimalAsset = token
 

--- a/src/state/slices/txHistorySlice/utils.test.ts
+++ b/src/state/slices/txHistorySlice/utils.test.ts
@@ -1,7 +1,9 @@
+import type { AssetId } from '@shapeshiftoss/caip'
 import { btcAssetId, ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
 import { TransferType } from '@shapeshiftoss/unchained-client'
 import { describe, expect, it } from 'vitest'
 
+import type { Tx } from './txHistorySlice'
 import { getRelatedAssetIds, isSpam } from './utils'
 
 import { BtcSend, EthReceive, EthSend, FOXSend, yearnVaultDeposit } from '@/test/mocks/txs'
@@ -46,9 +48,9 @@ describe('txHistorySlice:utils', () => {
   })
 
   describe('isSpam', () => {
-    const aiccAssetId = 'eip155:1/erc20:0x66a3c2fa3e467aa586e90912f977e648589cabaf'
+    const aiccAssetId: AssetId = 'eip155:1/erc20:0x66a3c2fa3e467aa586e90912f977e648589cabaf'
 
-    const makeAirdrop = (assetId: string) => ({
+    const makeAirdrop = (assetId: AssetId): Tx => ({
       ...EthReceive,
       fee: undefined,
       transfers: [

--- a/src/state/slices/txHistorySlice/utils.test.ts
+++ b/src/state/slices/txHistorySlice/utils.test.ts
@@ -1,7 +1,8 @@
 import { btcAssetId, ethAssetId, foxAssetId } from '@shapeshiftoss/caip'
+import { TransferType } from '@shapeshiftoss/unchained-client'
 import { describe, expect, it } from 'vitest'
 
-import { getRelatedAssetIds } from './utils'
+import { getRelatedAssetIds, isSpam } from './utils'
 
 import { BtcSend, EthReceive, EthSend, FOXSend, yearnVaultDeposit } from '@/test/mocks/txs'
 
@@ -41,6 +42,38 @@ describe('txHistorySlice:utils', () => {
       expect(relatedAssetIds.includes(ethAssetId)).toBeTruthy()
       expect(relatedAssetIds.includes(usdcAssetId)).toBeTruthy()
       expect(relatedAssetIds.includes(yvusdcAssetId)).toBeTruthy()
+    })
+  })
+
+  describe('isSpam', () => {
+    const aiccAssetId = 'eip155:1/erc20:0x66a3c2fa3e467aa586e90912f977e648589cabaf'
+
+    const makeAirdrop = (assetId: string) => ({
+      ...EthReceive,
+      fee: undefined,
+      transfers: [
+        {
+          assetId,
+          from: [EthReceive.pubkey],
+          to: [EthReceive.pubkey],
+          value: '1000000000000000000',
+          type: TransferType.Receive,
+          token: { contract: assetId, decimals: 18, name: 'AI Chain Coin', symbol: 'AICC' },
+        },
+      ],
+    })
+
+    it('marks blacklisted asset ids as spam despite legitimate looking token text', () => {
+      expect(isSpam(makeAirdrop(aiccAssetId))).toBe(true)
+    })
+
+    it('does not mark legitimate token transfers as spam', () => {
+      expect(isSpam(makeAirdrop(foxAssetId))).toBe(false)
+    })
+
+    it('does not mark regular transactions as spam', () => {
+      expect(isSpam(EthReceive)).toBe(false)
+      expect(isSpam(FOXSend)).toBe(false)
     })
   })
 })

--- a/src/state/slices/txHistorySlice/utils.ts
+++ b/src/state/slices/txHistorySlice/utils.ts
@@ -3,7 +3,12 @@ import { isNft } from '@shapeshiftoss/caip'
 
 import type { Tx } from './txHistorySlice'
 
-import { BLACKLISTED_COLLECTION_IDS, isSpammyNftText, isSpammyTokenText } from '@/state/blacklist'
+import {
+  BLACKLISTED_COLLECTION_IDS,
+  isBlacklistedAssetId,
+  isSpammyNftText,
+  isSpammyTokenText,
+} from '@/state/blacklist'
 
 type TxIndex = string
 type TxDescriptor = {
@@ -100,6 +105,8 @@ export const isSpam = (tx: Tx): boolean => {
   if (!tx.transfers.length && !tx.fee) return true
 
   return tx.transfers.some(({ assetId, token }) => {
+    if (isBlacklistedAssetId(assetId)) return true
+
     if (!token) return false
 
     const { name, symbol } = token


### PR DESCRIPTION
## Description

Adds an asset-id blacklist for known scam tokens and checks it at portfolio ingestion and in tx history spam detection, so they're dropped for all users rather than each user hiding them manually.

Seeds it with two airdropped honeypots reported in Discord that slip past both the Moralis `excludeSpam` filter in unchained and our text heuristics, since their names look clean:

- AI Chain Coin (AICC) `eip155:1/erc20:0x66a3c2fa3e467aa586e90912f977e648589cabaf`
- Privacy Coin (PVC) `eip155:1/erc20:0x514b9e5467b9eb811519e316263c9099eae546ca`

The check runs in both the minimal asset upsert and the account balance loop, so it also covers assets already persisted from an earlier session.

It also runs in `isSpam` for tx history, alongside the existing `BLACKLISTED_COLLECTION_IDS` check for NFTs. Without that, the airdrop transactions still showed in activity, and opening one re-upserted the asset into the store via `getTransfers`, where it resurfaced in asset search.

## Issue (if applicable)

N/A, reported in Discord.

## Risk

Low. Only affects which tokens are ingested into the portfolio, and only for the two listed asset ids.

## Testing

### Engineering

- Unit test added for `isBlacklistedAssetId`
- Unit tests added for `isSpam` covering blacklisted ids, legitimate token transfers and regular transactions
- `tsc`, eslint and the portfolio and tx history utils tests pass locally

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Connect a wallet holding AICC or PVC on Ethereum mainnet and confirm neither appears in the dashboard, account balances or transaction history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TdZuK1RPetNRaAyzv3n4CN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added filtering for known scam and honeypot tokens.
  - Blacklisted assets are now excluded from portfolio balances and asset listings.
  - Transactions involving blacklisted assets are now identified as spam.

- **Tests**
  - Added coverage confirming known malicious tokens are blocked while legitimate assets and non-token entries remain supported.
  - Added validation for spam detection across blacklisted, legitimate, and regular transactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
