### PR TITLE
fix(trade): make the sell balance selectable and copyable

### DIFF
--- a/src/components/AccountDropdown/AccountChildOption.tsx
+++ b/src/components/AccountDropdown/AccountChildOption.tsx
@@ -10,6 +10,7 @@ import type { AccountId } from '@shapeshiftoss/caip'
 import { useCallback, useMemo } from 'react'
 
 import { Amount } from '@/components/Amount/Amount'
+import { InlineCopyButton } from '@/components/InlineCopyButton'
 import { RawText } from '@/components/Text'
 import { trimWithEndEllipsis } from '@/lib/utils'
 
@@ -34,13 +35,16 @@ export const AccountChildOption = forwardRef<AccountChildRowProps, 'button'>(
           <RawText fontWeight='bold' whiteSpace='nowrap' flex={1}>
             {truncatedTitle}
           </RawText>
-          <Amount.Crypto
-            whiteSpace='nowrap'
-            color='text.subtle'
-            fontWeight='medium'
-            value={cryptoBalance}
-            symbol={symbol}
-          />
+          {/* Menu items are buttons, so render the copy control as a span to avoid nesting buttons */}
+          <InlineCopyButton value={cryptoBalance} as='span'>
+            <Amount.Crypto
+              whiteSpace='nowrap'
+              color='text.subtle'
+              fontWeight='medium'
+              value={cryptoBalance}
+              symbol={symbol}
+            />
+          </InlineCopyButton>
         </Stack>
         {children}
       </MenuItemOption>

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -69,6 +69,8 @@ type MenuOptionsProps = {
   onClick: (accountId: AccountId) => void
 }
 
+const transparentBg = { bg: 'transparent' }
+
 const MenuOptions = ({
   accountIdsByNumberAndType,
   asset,
@@ -289,6 +291,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
           gap={1}
           justifyContent='space-between'
           flexWrap='wrap'
+          width='full'
         >
           {label ? (
             label
@@ -327,14 +330,16 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
       return (
         <Box px={2} my={2} {...boxProps}>
           <Button
-            as='div'
             size='sm'
             variant='ghost'
             color='text.base'
+            {...buttonProps}
+            as='div'
+            bg='transparent'
             cursor='default'
             userSelect='text'
-            _hover={{ bg: 'transparent' }}
-            {...buttonProps}
+            _hover={transparentBg}
+            _active={transparentBg}
           >
             {buttonContent}
           </Button>

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -57,8 +57,6 @@ export type AccountDropdownProps = {
   boxProps?: BoxProps
   showLabel?: boolean
   label?: JSX.Element
-  // When set, a copy button for this value is shown next to the dropdown trigger
-  copyValue?: string
 }
 
 type MenuOptionsProps = {
@@ -177,7 +175,6 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
     boxProps,
     showLabel = true,
     label,
-    copyValue,
   }) => {
     const isConnected = useIsWalletConnected()
 
@@ -342,46 +339,37 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
       )
     }
 
-    // The trigger is a real button, so its text can't be selected. Offer a copy button instead.
-    const menu = (
-      <Menu isLazy closeOnSelect={true} autoSelect={false} flip>
-        <MenuButton
-          iconSpacing={1}
-          as={Button}
-          size='sm'
-          rightIcon={rightIcon}
-          variant='ghost'
-          color='text.base'
-          {...buttonProps}
-        >
-          {buttonContent}
-        </MenuButton>
-        <MenuList
-          minWidth='fit-content'
-          maxHeight='200px'
-          overflowY='auto'
-          zIndex={modalChildZIndex}
-        >
-          <MenuOptions
-            accountIdsByNumberAndType={accountIdsByNumberAndType}
-            asset={asset}
-            autoSelectHighestBalance={autoSelectHighestBalance}
-            disabled={disabled}
-            listProps={listProps}
-            selectedAccountId={selectedAccountId}
-            onClick={handleClick}
-          />
-        </MenuList>
-      </Menu>
-    )
-
     return (
       <Box px={2} my={2} {...boxProps}>
-        {copyValue !== undefined ? (
-          <InlineCopyButton value={copyValue}>{menu}</InlineCopyButton>
-        ) : (
-          menu
-        )}
+        <Menu isLazy closeOnSelect={true} autoSelect={false} flip>
+          <MenuButton
+            iconSpacing={1}
+            as={Button}
+            size='sm'
+            rightIcon={rightIcon}
+            variant='ghost'
+            color='text.base'
+            {...buttonProps}
+          >
+            {buttonContent}
+          </MenuButton>
+          <MenuList
+            minWidth='fit-content'
+            maxHeight='200px'
+            overflowY='auto'
+            zIndex={modalChildZIndex}
+          >
+            <MenuOptions
+              accountIdsByNumberAndType={accountIdsByNumberAndType}
+              asset={asset}
+              autoSelectHighestBalance={autoSelectHighestBalance}
+              disabled={disabled}
+              listProps={listProps}
+              selectedAccountId={selectedAccountId}
+              onClick={handleClick}
+            />
+          </MenuList>
+        </Menu>
       </Box>
     )
   },

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -259,10 +259,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
       [accountMetadata, selectedAccountId],
     )
 
-    const rightIcon = useMemo(
-      () => (isDropdownDisabled ? null : <ChevronDownIcon />),
-      [isDropdownDisabled],
-    )
+    const rightIcon = useMemo(() => <ChevronDownIcon />, [])
 
     /**
      * for UTXO-based chains, we can have many accounts for a single account number
@@ -296,6 +293,52 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
     if (!Object.keys(accountIdsByNumberAndType).length) return null
     if (!accountLabel) return null
 
+    const buttonContent = (
+      <Flex
+        direction='row'
+        alignItems='center'
+        gap={1}
+        justifyContent='space-between'
+        flexWrap='wrap'
+      >
+        {label ? (
+          label
+        ) : (
+          <>
+            <RawText fontWeight='medium'>
+              {translate('accounts.accountNumber', { accountNumber })}
+            </RawText>
+            {showLabel && (
+              <Text fontWeight='medium' color='text.subtle'>
+                {accountLabel}
+              </Text>
+            )}
+          </>
+        )}
+      </Flex>
+    )
+
+    // Nothing to pick from (single account, or selection explicitly disabled): render the label as
+    // plain, selectable text rather than a disabled button, so users can still copy their balance
+    if (isDropdownDisabled) {
+      return (
+        <Box px={2} my={2} {...boxProps}>
+          <Button
+            as='div'
+            size='sm'
+            variant='ghost'
+            color='text.base'
+            cursor='default'
+            userSelect='text'
+            _hover={{ bg: 'transparent' }}
+            {...buttonProps}
+          >
+            {buttonContent}
+          </Button>
+        </Box>
+      )
+    }
+
     return (
       <Box px={2} my={2} {...boxProps}>
         <Menu isLazy closeOnSelect={true} autoSelect={false} flip>
@@ -306,31 +349,9 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
             rightIcon={rightIcon}
             variant='ghost'
             color='text.base'
-            isDisabled={isDropdownDisabled}
             {...buttonProps}
           >
-            <Flex
-              direction='row'
-              alignItems='center'
-              gap={1}
-              justifyContent='space-between'
-              flexWrap='wrap'
-            >
-              {label ? (
-                label
-              ) : (
-                <>
-                  <RawText fontWeight='medium'>
-                    {translate('accounts.accountNumber', { accountNumber })}
-                  </RawText>
-                  {showLabel && (
-                    <Text fontWeight='medium' color='text.subtle'>
-                      {accountLabel}
-                    </Text>
-                  )}
-                </>
-              )}
-            </Flex>
+            {buttonContent}
           </MenuButton>
           <MenuList
             minWidth='fit-content'

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -57,6 +57,8 @@ export type AccountDropdownProps = {
   boxProps?: BoxProps
   showLabel?: boolean
   label?: JSX.Element
+  // When set, a copy button for this value is shown next to the dropdown trigger
+  copyValue?: string
 }
 
 type MenuOptionsProps = {
@@ -175,6 +177,7 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
     boxProps,
     showLabel = true,
     label,
+    copyValue,
   }) => {
     const isConnected = useIsWalletConnected()
 
@@ -339,37 +342,46 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
       )
     }
 
+    // The trigger is a real button, so its text can't be selected. Offer a copy button instead.
+    const menu = (
+      <Menu isLazy closeOnSelect={true} autoSelect={false} flip>
+        <MenuButton
+          iconSpacing={1}
+          as={Button}
+          size='sm'
+          rightIcon={rightIcon}
+          variant='ghost'
+          color='text.base'
+          {...buttonProps}
+        >
+          {buttonContent}
+        </MenuButton>
+        <MenuList
+          minWidth='fit-content'
+          maxHeight='200px'
+          overflowY='auto'
+          zIndex={modalChildZIndex}
+        >
+          <MenuOptions
+            accountIdsByNumberAndType={accountIdsByNumberAndType}
+            asset={asset}
+            autoSelectHighestBalance={autoSelectHighestBalance}
+            disabled={disabled}
+            listProps={listProps}
+            selectedAccountId={selectedAccountId}
+            onClick={handleClick}
+          />
+        </MenuList>
+      </Menu>
+    )
+
     return (
       <Box px={2} my={2} {...boxProps}>
-        <Menu isLazy closeOnSelect={true} autoSelect={false} flip>
-          <MenuButton
-            iconSpacing={1}
-            as={Button}
-            size='sm'
-            rightIcon={rightIcon}
-            variant='ghost'
-            color='text.base'
-            {...buttonProps}
-          >
-            {buttonContent}
-          </MenuButton>
-          <MenuList
-            minWidth='fit-content'
-            maxHeight='200px'
-            overflowY='auto'
-            zIndex={modalChildZIndex}
-          >
-            <MenuOptions
-              accountIdsByNumberAndType={accountIdsByNumberAndType}
-              asset={asset}
-              autoSelectHighestBalance={autoSelectHighestBalance}
-              disabled={disabled}
-              listProps={listProps}
-              selectedAccountId={selectedAccountId}
-              onClick={handleClick}
-            />
-          </MenuList>
-        </Menu>
+        {copyValue !== undefined ? (
+          <InlineCopyButton value={copyValue}>{menu}</InlineCopyButton>
+        ) : (
+          menu
+        )}
       </Box>
     )
   },

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -63,7 +63,6 @@ type MenuOptionsProps = {
   accountIdsByNumberAndType: AccountIdsByNumberAndType
   asset: Asset
   autoSelectHighestBalance: boolean | undefined
-  disabled: boolean | undefined
   listProps: MenuItemOptionProps | undefined
   selectedAccountId: AccountId | undefined
   onClick: (accountId: AccountId) => void
@@ -75,7 +74,6 @@ const MenuOptions = ({
   accountIdsByNumberAndType,
   asset,
   autoSelectHighestBalance,
-  disabled,
   listProps,
   selectedAccountId,
   onClick,
@@ -154,7 +152,6 @@ const MenuOptions = ({
                 symbol={asset?.symbol ?? ''}
                 isChecked={selectedAccountId === iterAccountId}
                 onOptionClick={onClick}
-                isDisabled={disabled}
                 {...listProps}
               />
             ))}
@@ -371,7 +368,6 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
               accountIdsByNumberAndType={accountIdsByNumberAndType}
               asset={asset}
               autoSelectHighestBalance={autoSelectHighestBalance}
-              disabled={disabled}
               listProps={listProps}
               selectedAccountId={selectedAccountId}
               onClick={handleClick}

--- a/src/components/AccountDropdown/AccountDropdown.tsx
+++ b/src/components/AccountDropdown/AccountDropdown.tsx
@@ -281,6 +281,34 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
       }, initial)
     }, [accountIds, accountMetadata])
 
+    const buttonContent = useMemo(
+      () => (
+        <Flex
+          direction='row'
+          alignItems='center'
+          gap={1}
+          justifyContent='space-between'
+          flexWrap='wrap'
+        >
+          {label ? (
+            label
+          ) : (
+            <>
+              <RawText fontWeight='medium'>
+                {translate('accounts.accountNumber', { accountNumber })}
+              </RawText>
+              {showLabel && (
+                <Text fontWeight='medium' color='text.subtle'>
+                  {accountLabel}
+                </Text>
+              )}
+            </>
+          )}
+        </Flex>
+      ),
+      [accountLabel, accountNumber, label, showLabel, translate],
+    )
+
     /**
      * do NOT remove these checks, this is not a visual thing, this is a safety check!
      *
@@ -292,31 +320,6 @@ export const AccountDropdown: FC<AccountDropdownProps> = memo(
     if (!isValidAccountNumber(accountNumber)) return null
     if (!Object.keys(accountIdsByNumberAndType).length) return null
     if (!accountLabel) return null
-
-    const buttonContent = (
-      <Flex
-        direction='row'
-        alignItems='center'
-        gap={1}
-        justifyContent='space-between'
-        flexWrap='wrap'
-      >
-        {label ? (
-          label
-        ) : (
-          <>
-            <RawText fontWeight='medium'>
-              {translate('accounts.accountNumber', { accountNumber })}
-            </RawText>
-            {showLabel && (
-              <Text fontWeight='medium' color='text.subtle'>
-                {accountLabel}
-              </Text>
-            )}
-          </>
-        )}
-      </Flex>
-    )
 
     // Nothing to pick from (single account, or selection explicitly disabled): render the label as
     // plain, selectable text rather than a disabled button, so users can still copy their balance

--- a/src/components/InlineCopyButton.tsx
+++ b/src/components/InlineCopyButton.tsx
@@ -1,5 +1,5 @@
 import { CheckIcon, CopyIcon } from '@chakra-ui/icons'
-import type { FlexProps } from '@chakra-ui/react'
+import type { FlexProps, IconButtonProps } from '@chakra-ui/react'
 import { Flex, IconButton, Tooltip } from '@chakra-ui/react'
 import type { MouseEvent, PropsWithChildren } from 'react'
 import React, { useCallback, useMemo } from 'react'
@@ -11,6 +11,8 @@ type InlineCopyButtonProps = {
   value: string
   isDisabled?: boolean
   flexProps?: FlexProps
+  // Render the button as another element, e.g. a span when nested inside a button
+  as?: IconButtonProps['as']
 } & PropsWithChildren
 
 const copyIcon = <CopyIcon />
@@ -21,6 +23,7 @@ export const InlineCopyButton: React.FC<InlineCopyButtonProps> = ({
   children,
   isDisabled,
   flexProps,
+  as,
 }) => {
   const translate = useTranslate()
   const { isCopied, isCopying, copyToClipboard } = useCopyToClipboard({ timeout: 2000 })
@@ -42,8 +45,9 @@ export const InlineCopyButton: React.FC<InlineCopyButtonProps> = ({
       fontSize: 'sm',
       'aria-label': 'Copy value',
       onClick: handleCopyClick,
+      as,
     }),
-    [handleCopyClick, isCopied],
+    [as, handleCopyClick, isCopied],
   )
 
   // Hide the copy button if it is disabled

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -388,6 +388,12 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
       [assetSymbol, balance, fiatBalance, isFiat, translate, accountDropdownBalanceColor],
     )
 
+    // Raw balance for the copy button, so it can be pasted straight into the amount field
+    const balanceCopyValue = useMemo(
+      () => (isFiat ? bnOrZero(fiatBalance).toFixed(2) : bnOrZero(balance).toFixed()),
+      [balance, fiatBalance, isFiat],
+    )
+
     const handleOnMaxClick = useMemo(() => () => onMaxClick(Boolean(isFiat)), [isFiat, onMaxClick])
 
     const containerStyle = useMemo(
@@ -427,6 +433,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                 boxProps={boxProps}
                 showLabel={false}
                 label={accountDropdownLabel}
+                copyValue={balanceCopyValue}
               />
             )}
           </Display.Desktop>
@@ -524,6 +531,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                     boxProps={boxProps}
                     showLabel={false}
                     label={accountDropdownLabel}
+                    copyValue={balanceCopyValue}
                   />
                 )}
 
@@ -538,6 +546,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                     boxProps={boxProps}
                     showLabel={false}
                     label={accountDropdownLabel}
+                    copyValue={balanceCopyValue}
                   />
                 )}
               </Display.Mobile>
@@ -559,6 +568,7 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                     boxProps={boxProps}
                     showLabel={false}
                     label={accountDropdownLabel}
+                    copyValue={balanceCopyValue}
                   />
                 )}
               </Display.Desktop>

--- a/src/components/MultiHopTrade/components/TradeAmountInput.tsx
+++ b/src/components/MultiHopTrade/components/TradeAmountInput.tsx
@@ -388,12 +388,6 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
       [assetSymbol, balance, fiatBalance, isFiat, translate, accountDropdownBalanceColor],
     )
 
-    // Raw balance for the copy button, so it can be pasted straight into the amount field
-    const balanceCopyValue = useMemo(
-      () => (isFiat ? bnOrZero(fiatBalance).toFixed(2) : bnOrZero(balance).toFixed()),
-      [balance, fiatBalance, isFiat],
-    )
-
     const handleOnMaxClick = useMemo(() => () => onMaxClick(Boolean(isFiat)), [isFiat, onMaxClick])
 
     const containerStyle = useMemo(
@@ -433,7 +427,6 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                 boxProps={boxProps}
                 showLabel={false}
                 label={accountDropdownLabel}
-                copyValue={balanceCopyValue}
               />
             )}
           </Display.Desktop>
@@ -531,7 +524,6 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                     boxProps={boxProps}
                     showLabel={false}
                     label={accountDropdownLabel}
-                    copyValue={balanceCopyValue}
                   />
                 )}
 
@@ -546,7 +538,6 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                     boxProps={boxProps}
                     showLabel={false}
                     label={accountDropdownLabel}
-                    copyValue={balanceCopyValue}
                   />
                 )}
               </Display.Mobile>
@@ -568,7 +559,6 @@ export const TradeAmountInput: React.FC<TradeAmountInputProps> = memo(
                     boxProps={boxProps}
                     showLabel={false}
                     label={accountDropdownLabel}
-                    copyValue={balanceCopyValue}
                   />
                 )}
               </Display.Desktop>

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -271,7 +271,10 @@ export const selectPortfolioAccountIdsByAssetIdFilter = createCachedSelector(
     const { chainId } = fromAssetId(assetId)
     return accountIds.filter(accountId => fromAccountId(accountId).chainId === chainId)
   },
-)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
+)(
+  (_state: ReduxState, filter: { assetId?: AssetId } | null): string =>
+    filter?.assetId ?? 'assetId',
+)
 export const selectPortfolioAccountIdsByAssetId = createDeepEqualOutputSelector(
   selectPortfolioAccounts,
   (accounts): Record<AssetId, AccountId[]> => {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -271,10 +271,11 @@ export const selectPortfolioAccountIdsByAssetIdFilter = createCachedSelector(
     const { chainId } = fromAssetId(assetId)
     return accountIds.filter(accountId => fromAccountId(accountId).chainId === chainId)
   },
-)(
-  (_state: ReduxState, filter: { assetId?: AssetId } | null): string =>
+)({
+  keySelector: (_state: ReduxState, filter: { assetId?: AssetId } | null): string =>
     filter?.assetId ?? 'assetId',
-)
+  selectorCreator: createDeepEqualOutputSelector,
+})
 export const selectPortfolioAccountIdsByAssetId = createDeepEqualOutputSelector(
   selectPortfolioAccounts,
   (accounts): Record<AssetId, AccountId[]> => {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -258,7 +258,9 @@ export const selectFirstAccountIdByChainId = createCachedSelector(
  * e.g. we may be swapping into a new EVM account that does not necessarily contain FOX
  * but can contain it
  */
-export const selectPortfolioAccountIdsByAssetIdFilter = createDeepEqualOutputSelector(
+// Cached per assetId so that multiple consumers with different assets (e.g. both sides of the trade
+// input) don't thrash a single-entry cache and get a fresh array on every store update
+export const selectPortfolioAccountIdsByAssetIdFilter = createCachedSelector(
   selectEnabledWalletAccountIds,
   selectAssetIdParamFromFilter,
   selectWalletId,
@@ -269,7 +271,7 @@ export const selectPortfolioAccountIdsByAssetIdFilter = createDeepEqualOutputSel
     const { chainId } = fromAssetId(assetId)
     return accountIds.filter(accountId => fromAccountId(accountId).chainId === chainId)
   },
-)
+)((_s: ReduxState, filter) => filter?.assetId ?? 'assetId')
 export const selectPortfolioAccountIdsByAssetId = createDeepEqualOutputSelector(
   selectPortfolioAccounts,
   (accounts): Record<AssetId, AccountId[]> => {

--- a/src/state/slices/portfolioSlice/selectors.ts
+++ b/src/state/slices/portfolioSlice/selectors.ts
@@ -258,8 +258,9 @@ export const selectFirstAccountIdByChainId = createCachedSelector(
  * e.g. we may be swapping into a new EVM account that does not necessarily contain FOX
  * but can contain it
  */
-// Cached per assetId so that multiple consumers with different assets (e.g. both sides of the trade
-// input) don't thrash a single-entry cache and get a fresh array on every store update
+// Keyed by assetId so consumers with different assets (e.g. both sides of the trade input) don't
+// thrash a single-entry cache, and deep-equal per key so an unrelated account change doesn't hand
+// every consumer a new array
 export const selectPortfolioAccountIdsByAssetIdFilter = createCachedSelector(
   selectEnabledWalletAccountIds,
   selectAssetIdParamFromFilter,


### PR DESCRIPTION
## Description

The sell-side balance in the trade input is the label of the account dropdown's `MenuButton`. With a single account the dropdown renders as a disabled button, so the balance is dimmed to 40% opacity and can't be selected or copied. This is the "grayed/dimmed, unable to select and copy" feedback from Discord.

When there's nothing to pick from (single account, or `disabled` passed), `AccountDropdown` now renders the label as a plain, selectable element instead of a disabled button.

Multi-account assets (e.g. BTC with its script types) keep the real dropdown, and browsers don't start a drag-selection inside a `<button>`. For that case each account row inside the dropdown now has an `InlineCopyButton` next to its balance, the same control we use for addresses. It copies the raw balance so it can be pasted straight into the amount field, without selecting the row or closing the menu. Menu items are buttons, so `InlineCopyButton` gains an `as` prop and the in-menu control renders as a span to avoid nesting buttons.

While testing the dropdown, hovering the rows made the whole menu flicker. Cause: `selectPortfolioAccountIdsByAssetIdFilter` had a single-entry deep-equal cache, and with both sides of the trade input consuming it for different assets, the cache thrashed and every store subscription check returned a fresh array. Both `AccountDropdown`s re-rendered on a ~500ms cadence, and with a menu open each re-render re-rendered the whole Chakra `Menu` and re-registered its items. Switched it to `createCachedSelector` keyed by `assetId`, matching the other filter selectors in that file. Measured zero dropdown re-renders over 14s of hovering afterwards, versus a pair every ~500ms before.

## Issue (if applicable)

N/A, from Discord feedback.

## Risk

Low. UI change in `AccountDropdown` plus a selector memoisation change, no transaction logic touched. `selectPortfolioAccountIdsByAssetIdFilter` has 11 consumers; output is unchanged, only the caching strategy differs. Every place that renders `AccountDropdown` with a single account or `disabled` now shows the label undimmed with no chevron, rather than a dimmed disabled button.

## Testing

### Engineering

- Connect a wallet with a single ETH account and open Trade. The "Balance:" label on the sell side is no longer dimmed and can be highlighted and copied.
- Select BTC as the sell asset and open the account dropdown. Each row has a copy icon next to its balance. Clicking it copies the raw amount, keeps the menu open, and doesn't change the selected account. Selecting a row still works.
- With the BTC dropdown open, hovering across the rows no longer flickers.
- Tested locally in Chromium. `tsc`, eslint and the portfolio slice tests pass.

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Connect a wallet, go to Trade, and drag the mouse across the "Balance: X ETH" text on the sell side. It should highlight and copy. For BTC, open the account dropdown, click the copy icon next to a row's balance, and paste into the amount field. Picking an account should still work.

## Screenshots (if applicable)

Before, single account, balance dimmed and not selectable:

![before](https://raw.githubusercontent.com/0xApotheosis/web/screenshots/selectable-trade-balance/01-before-single-account-dimmed.png)

After:

![after](https://raw.githubusercontent.com/0xApotheosis/web/screenshots/selectable-trade-balance/02-after-single-account.png)

After, balance drag-selected:

![after drag select](https://raw.githubusercontent.com/0xApotheosis/web/screenshots/selectable-trade-balance/03-after-drag-select.png)

Multi-account BTC, copy buttons inside the account dropdown:

![BTC account dropdown with copy buttons](https://raw.githubusercontent.com/0xApotheosis/web/screenshots/selectable-trade-balance/04-multi-account-btc.png)

Multi-account ETH, alongside the existing address copy buttons:

![ETH account dropdown with copy buttons](https://raw.githubusercontent.com/0xApotheosis/web/screenshots/selectable-trade-balance/05-multi-account-eth.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0153PrdUwXJ85dFawLUjM8nM


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added inline copy controls for cryptocurrency balances in account options.
  * Account dropdowns now display a non-interactive button when only one account is available or selection is disabled.
* **Style**
  * Updated account menu hover and active states with transparent backgrounds.
  * Improved consistency of shared account button content and menu indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->