### PR TITLE
fix(swapper): send a btc refund address for BOB Gateway btc sells

### DIFF
--- a/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeQuote.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeQuote.ts
@@ -20,15 +20,21 @@ export const getBobGatewayTradeQuote = async (
   if (maybeAddresses.isErr()) return Err(maybeAddresses.unwrapErr())
   const { sendAddress, receiveAddress } = maybeAddresses.unwrap()
 
+  const isEvmSell = isEvmChainId(sellAsset.chainId)
+
   // omit the sender for utxo sells so order creation does not enforce a per-address confirmed
   // funds check (deposits are matched via op_return, not the sending address)
-  const sender = isEvmChainId(sellAsset.chainId) ? sendAddress : undefined
+  const sender = isEvmSell ? sendAddress : undefined
+
+  // utxo deposits are refunded on the sell chain, so refunds go to the sending address
+  const refundAddress = isEvmSell ? undefined : sendAddress
 
   const maybeContext = await getBobGatewayTradeContext({
     input,
     deps,
     sender,
     recipient: receiveAddress,
+    refundAddress,
   })
 
   if (maybeContext.isErr()) return Err(maybeContext.unwrapErr())

--- a/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeRate.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/swapperApi/getTradeRate.ts
@@ -14,11 +14,20 @@ export const getBobGatewayTradeRate = async (
 ): Promise<Result<TradeRate[], SwapErrorRight>> => {
   const { accountNumber, sellAsset, buyAsset, receiveAddress } = input
 
-  const recipient = receiveAddress ?? dummyAddressForChainId(buyAsset.chainId)
-  const sender =
-    sellAsset.chainId === btcChainId ? undefined : dummyAddressForChainId(sellAsset.chainId)
+  const isBtcSell = sellAsset.chainId === btcChainId
 
-  const maybeContext = await getBobGatewayTradeContext({ input, deps, sender, recipient })
+  const recipient = receiveAddress ?? dummyAddressForChainId(buyAsset.chainId)
+  const sender = isBtcSell ? undefined : dummyAddressForChainId(sellAsset.chainId)
+  // utxo deposits are refunded on the sell chain, so the refund address must be a btc address
+  const refundAddress = isBtcSell ? dummyAddressForChainId(sellAsset.chainId) : undefined
+
+  const maybeContext = await getBobGatewayTradeContext({
+    input,
+    deps,
+    sender,
+    recipient,
+    refundAddress,
+  })
 
   if (maybeContext.isErr()) return Err(maybeContext.unwrapErr())
   const { tradeCommon, stepCommon, protocolFees, stepDataArgs } = maybeContext.unwrap()

--- a/packages/swapper/src/swappers/BobGatewaySwapper/utils/getBobGatewayTradeContext.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/utils/getBobGatewayTradeContext.ts
@@ -33,11 +33,13 @@ export const getBobGatewayTradeContext = async ({
   deps,
   sender,
   recipient,
+  refundAddress,
 }: {
   input: BobGatewayTradeQuoteInput | BobGatewayTradeRateInput
   deps: SwapperDeps
   sender: string | undefined
   recipient: string
+  refundAddress: string | undefined
 }): Promise<Result<BobGatewayTradeContext, SwapErrorRight>> => {
   const {
     sellAsset,
@@ -60,6 +62,7 @@ export const getBobGatewayTradeContext = async ({
     buyChainName,
     sender,
     recipient,
+    refundAddress,
     amount: sellAmountIncludingProtocolFeesCryptoBaseUnit,
     affiliateBps,
     slippageTolerancePercentageDecimal,

--- a/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/BobGatewaySwapper/utils/helpers.ts
@@ -83,6 +83,7 @@ export const getBobGatewayQuote = async ({
   buyChainName,
   sender,
   recipient,
+  refundAddress,
   amount,
   affiliateBps,
   slippageTolerancePercentageDecimal,
@@ -94,6 +95,7 @@ export const getBobGatewayQuote = async ({
   buyChainName: BobGatewayChainName
   sender: string | undefined
   recipient: string
+  refundAddress: string | undefined
   amount: string
   affiliateBps: string
   slippageTolerancePercentageDecimal: string | undefined
@@ -114,7 +116,7 @@ export const getBobGatewayQuote = async ({
       amount,
       maxSlippage: Number(slippage),
       ownerAddress: sellChainName === 'bitcoin' ? recipient : (sender as string),
-      refundAddress: sellChainName === 'bitcoin' ? recipient : undefined,
+      refundAddress,
       affiliates: getBobGatewayAffiliates(affiliateBps),
     })
 


### PR DESCRIPTION
## Description

Fixes a regression from #12610 that breaks **every** BOB Gateway BTC sell — rates and quotes both — currently live on `release`.

That PR added `refundAddress` to the quote request, sourced from `recipient`:

```ts
ownerAddress: sellChainName === 'bitcoin' ? recipient : (sender as string),
refundAddress: sellChainName === 'bitcoin' ? recipient : undefined,
```

Those two params take different address types. On a BTC sell `recipient` is the **EVM** receive address, but per [BOB's API reference](https://docs.gobob.xyz/api-reference/v3/get_quote_v3) `refundAddress` is an "Optional refund **bitcoin** address to be used in a bitcoin onramp request. Must be valid on Bitcoin mainnet." BOB tries to parse the `0x…` value as a Bitcoin address and rejects the whole request:

```json
{ "code": "INVALID_REQUEST", "error": "base58 error" }
```

BOB's own documented example keeps them distinct, with `refundAddress` mirroring the BTC `sender`:

```
srcChain=bitcoin&dstChain=bob&sender=bc1qyhc…&recipient=0xf39F…
  &ownerAddress=0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
  &refundAddress=bc1qyhc4uslh46axl553pq3mjclrt7dcgmlzxv0ktx
```

This threads `refundAddress` through explicitly instead of deriving it from `recipient` inside `getBobGatewayQuote`:

- `utils/helpers.ts` — `getBobGatewayQuote` takes `refundAddress` and passes it straight through.
- `utils/getBobGatewayTradeContext.ts` — accepts and forwards it.
- `swapperApi/getTradeQuote.ts` — the BTC sending address (`sendAddress`), reusing the same `isEvmSell` branch the existing `sender` omission uses, so `sender` stays unset for UTXO sells.
- `swapperApi/getTradeRate.ts` — `DUMMY_BTC_ADDRESS`, keeping the rate request shape identical to the quote's.

Worth confirming with @slavastartsev: setting `refundAddress` is not a no-op — it is committed into `signedQuoteData` (see Testing), so it changes refund behaviour versus omitting it. [The refunds doc](https://docs.gobob.xyz/gateway/refunds) says BTC-to-X refunds default to USDT on Ethereum via `ownerAddress`, which is what happened before #12610; supplying a BTC `refundAddress` presumably opts into a native BTC refund instead. Assuming that was the intent, sending the user's BTC address is correct — but a confirmation of the semantics would be good.

## Issue (if applicable)

N/A — regression from #12610.

## Risk

Low. Restores BTC-sell quote requests that currently fail outright. No change to transaction construction, wallet signing, or contract interactions — only which address is sent in one query param. Non-BTC sells are unchanged (`refundAddress` stays `undefined`, exactly as before).

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

BOB Gateway BTC → EVM (onramp) rates and quotes, and the refund destination for those orders. Nothing else.

## Testing

### Engineering

`pnpm run type-check` is clean for `packages/swapper`. Lint not run. No existing tests reference `getBobGatewayQuote` or `getBobGatewayTradeContext`.

Verified against the live API — same request, only `refundAddress` varied:

| `refundAddress` | response |
| --- | --- |
| *(omitted)* | reaches quoting |
| `0xA44C…1535` (EVM — what's on `release` today) | `INVALID_REQUEST` / `base58 error` |
| `bc1qfk7…hwyg` (bech32) | full onramp quote |
| `1A1zP1…DivfNa` (base58) | full onramp quote |

A real BTC→ETH quote off this branch returns `"sender": null`, confirming the deliberate UTXO `sender` omission still holds, and the refund address is ASCII-embedded in the signed quote alongside the EVM recipient:

```
…2a 3078413434433238364241383342623737316364303130374232633144663637383433354264313533 35  → "0xA44C286BA83Bb771cd0107B2c1Df678435Bd1535"
…012a 62633171666b376e766d6371326436766a753630756d63366436783973753463723535717367687779 67  → "bc1qfk7nvmcq2d6vju60umc6d6x9su4cr55qsghwyg"
```

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Get a BTC → ETH quote via BOB Gateway. On `develop` no rate is returned at all; on this branch the trade quotes and confirms normally. Also spot-check an EVM → BTC quote (e.g. ETH → BTC) still works, to confirm the non-BTC-sell path is untouched.

## Screenshots (if applicable)

BTC → ETH via BOB Gateway quoting normally on this branch (screenshot to be attached).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTuE7p1KzhuFL4hdxdRJjE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved swap quote handling for Bitcoin and other UTXO-based sell assets.
  * Refund addresses are now correctly assigned for UTXO-based sells, while EVM sell transactions continue using the sender address appropriately.
  * Updated trade quotes and rates to pass the correct refund address to the gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->