### PR TITLE
fix(release): sort semver tags before picking the latest

### DIFF
--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -27,5 +27,5 @@ export const getSemverTags = async (): Promise<string[]> => {
   const validTags: string[] = allTags
     .filter(t => semver.valid(t))
     .filter(t => semver.satisfies(t, WEB_VERSION_RANGES))
-  return validTags
+  return validTags.sort(semver.compare)
 }


### PR DESCRIPTION
## Description

`pnpm release` aborted on the `v1.1043.0` release with:

```
Release state: needs_tag
Current: v1.1022.0 -> Next: v1.1023.0
Tagging v1.1023.0...
GitError: fatal: tag 'v1.1023.0' already exists
```

`v1.1022.0` was cut back in May — the real latest tag is `v1.1042.0`.

### Root cause

`getSemverTags()` trusted the ordering returned by simple-git's `tags()` and took `slice(-1)[0]`. simple-git's tag comparator is inconsistent for this repo's tag list:

```js
function singleSorted(a, b) {
  const aIsNum = Number.isNaN(a);   // a is already a number here, so this is
  const bIsNum = Number.isNaN(b);   // always false
  if (aIsNum !== bIsNum) return aIsNum ? 1 : -1;
  return aIsNum ? sorted(a, b) : 0; // -> always returns 0
}
```

That branch is taken whenever either tag has no `.` in it, and this repo has **424 dotless legacy tags** (`031020master`, `20190114`, `160320stable`, …). An inconsistent comparator means `Array.prototype.sort` returns an arbitrary order, so the last element is not the maximum.

### Why it only broke now

The bug has been latent since the comparator's inputs are the whole tag list — adding or removing a single tag reshuffles the merge order and can flip the result. Isolating each tag added since `v1.1042.0` was cut on 2026-08-26:

| tag list | `getLatestSemverTag()` returns |
| --- | --- |
| today, full | `v1.1022.0` :x: |
| minus `hdwallet-keepkey-v1.62.42` | `v1.1042.0` :white_check_mark: |
| minus `swap-widget-v0.9.0` | `v1.1017.0` :x: |
| minus `keepkey-pairing-attempt-1` | `v1.1017.0` :x: |
| repo as of 2026-08-26 | `v1.1041.0` :white_check_mark: (correct at the time) |

`hdwallet-keepkey-v1.62.42` is the trigger. It was pushed by `publish-packages.yml` a few hours before the release run, after the `1.62.41 -> 1.62.42` bump from #12604 landed on `main`. simple-git's `toNumber` strips leading non-digits per dot-segment, so `hdwallet-keepkey-v1.62.42` reads as `1.62.42` and sorts into the middle of the web `v1.x` tags.

Note the ordering is arbitrary, not "newest package tag wins" — dropping either of the other two new tags also produces a wrong answer.

### Fix

Sort the already-filtered list with `semver.compare` instead of relying on simple-git's order. Non-semver and non-web tags are filtered out first, so package publish tags can no longer influence the result at all — this decouples the release script from whatever `publish-packages.yml` tags next.

## Issue (if applicable)

closes #

## Risk

Low. One line in a local CLI dev script (`scripts/release.ts` and `scripts/writeBuildMetadata.ts` are the only consumers). No app or runtime code, no on-chain surface.

Worth noting the pre-fix blast radius, since it explains more than the failed release: `writeBuildMetadata.ts` uses the same helper, so builds have been stamping whatever version this returned.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

None.

## Testing

### Engineering

Against the live tag list, before the fix:

```
getLatestSemverTag: v1.1022.0
```

After:

```
latest=v1.1042.0  next(minor)=v1.1043.0  next(patch)=v1.1042.1
```

`v1.1043.0` matches the title of the already-merged release PR #12624, and `origin/main` is one commit past `v1.1042.0`, so `needs_tag` is the correct state and the re-run tags the right version.

To verify yourself:

```ts
import { getLatestSemverTag } from './scripts/utils'
getLatestSemverTag().then(console.log)
```

Sanity check that the sort is now total and monotonic:

```ts
import semver from 'semver'
import { getSemverTags } from './scripts/utils'
getSemverTags().then(tags =>
  console.log(tags.every((t, i) => i === 0 || semver.gt(t, tags[i - 1]))),
) // true
```

Note this fix has to land on `main` before it takes effect for the next release — the run that hit the bug is unblocked by the local change, but `main` won't carry it until this merges through `develop`.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Dev tooling only, no user-facing impact.

## Screenshots (if applicable)

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LTuE7p1KzhuFL4hdxdRJjE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version tags are now sorted according to semantic version ordering, ensuring releases appear in the correct sequence wherever version tags are displayed or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->