### PR TITLE
chore: update rfox ipfs hash

### DIFF
--- a/src/pages/RFOX/constants.ts
+++ b/src/pages/RFOX/constants.ts
@@ -11,7 +11,7 @@ export const unstakeEvent = getAbiItem({ abi: RFOX_ABI, name: 'Unstake' })
 
 export const IPFS_GATEWAY = 'https://gateway.pinata.cloud/ipfs'
 
-export const CURRENT_EPOCH_IPFS_HASH = 'bafkreihv7ilxdosw5rqky22fj5psfjhnwcqnmiurhydddetjpxrjmf32ti'
+export const CURRENT_EPOCH_IPFS_HASH = 'bafkreib3ftdt4rhq4fapplsyesyzyorayvnc3a4csdmmbzbaim6tb3gndi'
 export const STUB_RUNE_ADDRESS = 'thor1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqn8p0r8'
 export const RFOX_V3_UPGRADE_EPOCH = 18
 


### PR DESCRIPTION
## Description

Updates `CURRENT_EPOCH_IPFS_HASH` to the epoch 26 metadata hash (`bafkreib3ftdt4rhq4fapplsyesyzyorayvnc3a4csdmmbzbaim6tb3gndi`).

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low risk — constant bump only. Affects RFOX epoch history/rewards display only; no transaction logic touched.

## Testing

### Engineering

- Verified the new hash resolves via the Pinata gateway and contains epoch 26 metadata (epochStartTimestamp 2026-09-01, epochEndTimestamp 2026-09-30) with `ipfsHashByEpoch` history intact through epoch 25.
- Load RFOX and confirm current epoch details render correctly.

### Operations

- Navigate to RFOX and confirm the current epoch (26) and rewards history display correctly.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW35mc6vnZHXgTStTksuFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the current epoch’s content reference to the latest IPFS identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->