### PR TITLE
fix(rfox): disable un-staking on arbitrum ahead of the migration

### DIFF
--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -3040,7 +3040,7 @@
     "foxBurnAmount": "FOX Burn Amount (This Epoch)",
     "pendingDistribution": "Pending Distribution",
     "selectRuneAddress": "Select a RUNE address",
-    "unstakeDisabledMigrationTooltip": "Un-staking is temporarily disabled ahead of the rFOX migration to Ethereum. Your cooldown is fixed when you un-stake, so un-staking now would lock your FOX for the full %{cooldownPeriod}. The cooldown is removed on October 1 \u2014 un-stake then to claim straight away.",
+    "unstakeDisabledMigrationTooltip": "Un-staking is disabled until October 1, when the cooldown period is removed.",
     "lpSunsetWarningTitle": "Program Ended",
     "lpSunsetWarningDescription": "The Arbitrum WETH/FOX Rewards program has been sunset. Please un-stake and claim your balance at your earliest convenience."
   },

--- a/src/assets/translations/en/main.json
+++ b/src/assets/translations/en/main.json
@@ -3040,6 +3040,7 @@
     "foxBurnAmount": "FOX Burn Amount (This Epoch)",
     "pendingDistribution": "Pending Distribution",
     "selectRuneAddress": "Select a RUNE address",
+    "unstakeDisabledMigrationTooltip": "Un-staking is temporarily disabled ahead of the rFOX migration to Ethereum. Your cooldown is fixed when you un-stake, so un-staking now would lock your FOX for the full %{cooldownPeriod}. The cooldown is removed on October 1 \u2014 un-stake then to claim straight away.",
     "lpSunsetWarningTitle": "Program Ended",
     "lpSunsetWarningDescription": "The Arbitrum WETH/FOX Rewards program has been sunset. Please un-stake and claim your balance at your earliest convenience."
   },

--- a/src/pages/Fox/components/RFOXSection.tsx
+++ b/src/pages/Fox/components/RFOXSection.tsx
@@ -341,10 +341,12 @@ export const RFOXSection = () => {
   // The cooldown is fixed per request when un-staking, so anyone un-staking before it is zeroed on
   // the migration date is held to the full period regardless. Lifts itself once the cooldown is
   // zeroed on chain, so this needs no follow up deploy on the day.
+  // Stays disabled unless the cooldown is confirmed to be zero, so an unresolved or failed read
+  // holds the guard rather than dropping it
   const isUnstakeDisabled = useMemo(
     () =>
       stakingAssetId === foxOnArbitrumOneAssetId &&
-      Boolean(cooldownPeriodQuery.data?.cooldownPeriodSeconds),
+      cooldownPeriodQuery.data?.cooldownPeriodSeconds !== 0,
     [cooldownPeriodQuery.data?.cooldownPeriodSeconds, stakingAssetId],
   )
 

--- a/src/pages/Fox/components/RFOXSection.tsx
+++ b/src/pages/Fox/components/RFOXSection.tsx
@@ -348,14 +348,6 @@ export const RFOXSection = () => {
     [cooldownPeriodQuery.data?.cooldownPeriodSeconds, stakingAssetId],
   )
 
-  const unstakeDisabledTooltip = useMemo(
-    () =>
-      translate('RFOX.unstakeDisabledMigrationTooltip', {
-        cooldownPeriod: cooldownPeriodQuery.data?.cooldownPeriod,
-      }),
-    [cooldownPeriodQuery.data?.cooldownPeriod, translate],
-  )
-
   const actionsButtons = useMemo(() => {
     return (
       <Flex flexWrap='wrap' gap={2}>
@@ -374,7 +366,7 @@ export const RFOXSection = () => {
             sizing lives on the wrapper to keep this button growing with its siblings */}
         <Box flex='1 1 auto' sx={tooltipWrapperSx}>
           <Tooltip
-            label={unstakeDisabledTooltip}
+            label={translate('RFOX.unstakeDisabledMigrationTooltip')}
             isDisabled={!isUnstakeDisabled}
             shouldWrapChildren
           >
@@ -409,7 +401,6 @@ export const RFOXSection = () => {
     stakingAssetId,
     hasClaimableRequests,
     isUnstakeDisabled,
-    unstakeDisabledTooltip,
   ])
 
   if (!(stakingAsset && usdcAsset)) return null

--- a/src/pages/Fox/components/RFOXSection.tsx
+++ b/src/pages/Fox/components/RFOXSection.tsx
@@ -338,11 +338,6 @@ export const RFOXSection = () => {
 
   const cooldownPeriodQuery = useCooldownPeriodQuery(stakingAssetId)
 
-  // The cooldown is fixed per request when un-staking, so anyone un-staking before it is zeroed on
-  // the migration date is held to the full period regardless. Lifts itself once the cooldown is
-  // zeroed on chain, so this needs no follow up deploy on the day.
-  // Stays disabled unless the cooldown is confirmed to be zero, so an unresolved or failed read
-  // holds the guard rather than dropping it
   const isUnstakeDisabled = useMemo(
     () =>
       stakingAssetId === foxOnArbitrumOneAssetId &&
@@ -364,8 +359,6 @@ export const RFOXSection = () => {
             {translate('defi.stake')}
           </Button>
         )}
-        {/* Tooltip wraps its child in a span to catch hover on a disabled button, so the flex
-            sizing lives on the wrapper to keep this button growing with its siblings */}
         <Box flex='1 1 auto' sx={tooltipWrapperSx}>
           <Tooltip
             label={translate('RFOX.unstakeDisabledMigrationTooltip')}

--- a/src/pages/Fox/components/RFOXSection.tsx
+++ b/src/pages/Fox/components/RFOXSection.tsx
@@ -15,6 +15,7 @@ import {
   Stack,
   Tag,
   Text as CText,
+  Tooltip,
   usePrevious,
 } from '@chakra-ui/react'
 import {
@@ -45,6 +46,7 @@ import { Stats } from '@/pages/RFOX/components/Overview/Stats'
 import { StakeModal } from '@/pages/RFOX/components/StakeModal'
 import { UnstakeModal } from '@/pages/RFOX/components/UnstakeModal'
 import { selectStakingBalance } from '@/pages/RFOX/helpers'
+import { useCooldownPeriodQuery } from '@/pages/RFOX/hooks/useCooldownPeriodQuery'
 import { useCurrentApyQuery } from '@/pages/RFOX/hooks/useCurrentApyQuery'
 import { useCurrentEpochMetadataQuery } from '@/pages/RFOX/hooks/useCurrentEpochMetadataQuery'
 import { useCurrentEpochRewardsQuery } from '@/pages/RFOX/hooks/useCurrentEpochRewardsQuery'
@@ -62,6 +64,8 @@ import {
   selectMarketDataByAssetIdUserCurrency,
 } from '@/state/slices/selectors'
 import { useAppDispatch, useAppSelector } from '@/state/store'
+
+const tooltipWrapperSx = { '& > span': { display: 'block', width: '100%' } }
 
 const tbArrowUp = <TbArrowUp />
 const tbArrowDown = <TbArrowDown />
@@ -332,6 +336,26 @@ export const RFOXSection = () => {
     setIsClaimModalOpen(false)
   }, [])
 
+  const cooldownPeriodQuery = useCooldownPeriodQuery(stakingAssetId)
+
+  // The cooldown is fixed per request when un-staking, so anyone un-staking before it is zeroed on
+  // the migration date is held to the full period regardless. Lifts itself once the cooldown is
+  // zeroed on chain, so this needs no follow up deploy on the day.
+  const isUnstakeDisabled = useMemo(
+    () =>
+      stakingAssetId === foxOnArbitrumOneAssetId &&
+      Boolean(cooldownPeriodQuery.data?.cooldownPeriodSeconds),
+    [cooldownPeriodQuery.data?.cooldownPeriodSeconds, stakingAssetId],
+  )
+
+  const unstakeDisabledTooltip = useMemo(
+    () =>
+      translate('RFOX.unstakeDisabledMigrationTooltip', {
+        cooldownPeriod: cooldownPeriodQuery.data?.cooldownPeriod,
+      }),
+    [cooldownPeriodQuery.data?.cooldownPeriod, translate],
+  )
+
   const actionsButtons = useMemo(() => {
     return (
       <Flex flexWrap='wrap' gap={2}>
@@ -346,15 +370,26 @@ export const RFOXSection = () => {
             {translate('defi.stake')}
           </Button>
         )}
-        <Button
-          data-testid='rfox-unstake-button'
-          onClick={handleUnstakeClick}
-          colorScheme='gray'
-          flex='1 1 auto'
-          leftIcon={tbArrowDown}
-        >
-          {translate('defi.unstake')}
-        </Button>
+        {/* Tooltip wraps its child in a span to catch hover on a disabled button, so the flex
+            sizing lives on the wrapper to keep this button growing with its siblings */}
+        <Box flex='1 1 auto' sx={tooltipWrapperSx}>
+          <Tooltip
+            label={unstakeDisabledTooltip}
+            isDisabled={!isUnstakeDisabled}
+            shouldWrapChildren
+          >
+            <Button
+              data-testid='rfox-unstake-button'
+              onClick={handleUnstakeClick}
+              colorScheme='gray'
+              width='full'
+              leftIcon={tbArrowDown}
+              isDisabled={isUnstakeDisabled}
+            >
+              {translate('defi.unstake')}
+            </Button>
+          </Tooltip>
+        </Box>
         <Button
           data-testid='rfox-claim-button'
           onClick={handleClaimClick}
@@ -373,6 +408,8 @@ export const RFOXSection = () => {
     translate,
     stakingAssetId,
     hasClaimableRequests,
+    isUnstakeDisabled,
+    unstakeDisabledTooltip,
   ])
 
   if (!(stakingAsset && usdcAsset)) return null

--- a/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
+++ b/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
@@ -15,8 +15,15 @@ export const useCooldownPeriodQuery = (stakingAssetId: AssetId) => {
     chainId: arbitrum.id,
     query: {
       // Ops set this on chain, so it cannot be treated as immutable - notably it is zeroed at the
-      // rFOX migration, which the UI keys un-staking off
+      // rFOX migration, which the UI keys un-staking off.
       staleTime: 60 * 1000, // 1 minute in milliseconds
+      // refetchOnMount and refetchOnWindowFocus are both disabled app wide, so without its own
+      // triggers a stale value would persist until a full page reload.
+      refetchOnMount: true,
+      // Only poll while a cooldown is actually set. The transition worth catching is it being
+      // zeroed at the migration, so polling stops for good once that is read back rather than
+      // running forever for an event that has already happened.
+      refetchInterval: query => (query.state.data === 0n ? false : 60 * 1000),
       select: data => {
         const cooldownPeriod = formatSecondsToDuration(Number(data))
         return {

--- a/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
+++ b/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
@@ -14,7 +14,9 @@ export const useCooldownPeriodQuery = (stakingAssetId: AssetId) => {
     functionName: 'cooldownPeriod',
     chainId: arbitrum.id,
     query: {
-      staleTime: Infinity,
+      // Ops set this on chain, so it cannot be treated as immutable - notably it is zeroed at the
+      // rFOX migration, which the UI keys un-staking off
+      staleTime: 60 * 1000, // 1 minute in milliseconds
       select: data => {
         const cooldownPeriod = formatSecondsToDuration(Number(data))
         return {

--- a/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
+++ b/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
@@ -20,6 +20,9 @@ export const useCooldownPeriodQuery = (stakingAssetId: AssetId) => {
       // refetchOnMount and refetchOnWindowFocus are both disabled app wide, so without its own
       // triggers a stale value would persist until a full page reload.
       refetchOnMount: true,
+      // Independent of the above - the poll is paused while the tab is in the background, so this
+      // catches a change made while the user was away without waiting for the next tick
+      refetchOnWindowFocus: true,
       // Only poll while a cooldown is actually set. The transition worth catching is it being
       // zeroed at the migration, so polling stops for good once that is read back rather than
       // running forever for an event that has already happened.

--- a/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
+++ b/src/pages/RFOX/hooks/useCooldownPeriodQuery.ts
@@ -14,19 +14,9 @@ export const useCooldownPeriodQuery = (stakingAssetId: AssetId) => {
     functionName: 'cooldownPeriod',
     chainId: arbitrum.id,
     query: {
-      // Ops set this on chain, so it cannot be treated as immutable - notably it is zeroed at the
-      // rFOX migration, which the UI keys un-staking off.
-      staleTime: 60 * 1000, // 1 minute in milliseconds
-      // refetchOnMount and refetchOnWindowFocus are both disabled app wide, so without its own
-      // triggers a stale value would persist until a full page reload.
+      staleTime: 60 * 1000,
       refetchOnMount: true,
-      // Independent of the above - the poll is paused while the tab is in the background, so this
-      // catches a change made while the user was away without waiting for the next tick
       refetchOnWindowFocus: true,
-      // Only poll while a cooldown is actually set. The transition worth catching is it being
-      // zeroed at the migration, so polling stops for good once that is read back rather than
-      // running forever for an event that has already happened.
-      refetchInterval: query => (query.state.data === 0n ? false : 60 * 1000),
       select: data => {
         const cooldownPeriod = formatSecondsToDuration(Number(data))
         return {


### PR DESCRIPTION
## Description

Disables un-staking on the rFOX Arbitrum position ahead of the migration to Ethereum, with a tooltip explaining why and when to un-stake instead.

The cooldown is fixed per unstaking request at un-stake time — `unstake()` stores `cooldownExpiry: block.timestamp + cooldownPeriod`, and `setCooldownPeriod` never touches existing requests. So a user who un-stakes today is held to the full 28 days even after the cooldown is set to 0 on October 1, leaving them strictly worse off than a user who waits.

The guard is gated on the cooldown read from the contract rather than on a date:

```ts
isUnstakeDisabled = stakingAssetId === foxOnArbitrumOneAssetId
                 && Boolean(cooldownPeriodQuery.data?.cooldownPeriodSeconds)
```

so it lifts itself as soon as the cooldown is zeroed on chain, with no follow-up deploy needed on the day.

Claim is deliberately untouched — anyone already in cooldown still needs to claim when it expires. The FOX/ETH LP program is unaffected, as its cooldown is already 0 on chain so the condition is false there.

## Issue (if applicable)

closes #

## Risk

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Low risk — no transaction logic changed. Disables one button and adds a tooltip; no contract interactions were added, removed or modified. Worst case is the button staying disabled longer than intended, which is recoverable by un-pausing nothing and simply zeroing the cooldown as planned.

Note the button markup was restructured slightly: `Tooltip`'s `shouldWrapChildren` (needed for hover on a disabled button) injects a `span` that would otherwise become the flex child, so `flex='1 1 auto'` moved to a wrapping `Box` with the span forced to full width. Worth a visual check that the three action buttons still size evenly.

## Testing

### Engineering

- On the rFOX Arbitrum FOX position, confirm Unstake is disabled and hovering shows the tooltip.
- Confirm Stake and Claim are unaffected, and that Claim still works for an unstaking request past its cooldown.
- Confirm the three action buttons still size evenly in the row.
- To verify the auto-lift, point at a contract with `cooldownPeriod` of 0 (the FOX/ETH LP contract already is) and confirm Unstake is enabled with no tooltip.

### Operations

- Navigate to the FOX Ecosystem page, rFOX section.
- Confirm the Unstake button is greyed out and hovering explains that un-staking is disabled until October 1.
- Confirm Stake and Claim still behave as before.

## Screenshots (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TW35mc6vnZHXgTStTksuFc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a tooltip explaining that RFOX unstaking is unavailable until October 1 while the cooldown period is removed.

* **Bug Fixes**
  * Disabled RFOX unstaking on Arbitrum One while the cooldown is active, unavailable, loading, or cannot be confirmed as zero.
  * Updated cooldown information periodically so unstaking availability reflects on-chain changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->