### PR TITLE
feat(swapper): expose external payment support for Chainflip and NEAR Intents

### DIFF
--- a/packages/swapper/package.json
+++ b/packages/swapper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shapeshiftoss/swapper",
-  "version": "20.0.0",
+  "version": "20.1.0",
   "repository": "https://github.com/shapeshift/web",
   "license": "MIT",
   "type": "module",

--- a/packages/swapper/src/swappers/ChainflipSwapper/ChainflipSwapper.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/ChainflipSwapper.ts
@@ -6,6 +6,7 @@ import {
 } from '../../utils'
 
 export const chainflipSwapper: Swapper = {
+  supportsExternalPayment: true,
   executeEvmTransaction,
   executeSolanaTransaction,
   executeTronTransaction,

--- a/packages/swapper/src/swappers/ChainflipSwapper/checkTradeStatus.test.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/checkTradeStatus.test.ts
@@ -1,0 +1,64 @@
+import { Ok } from '@sniptt/monads'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CheckTradeStatusInput } from '../../types'
+import { chainflipApi } from './endpoints'
+import { chainflipService } from './utils/chainflipService'
+
+vi.mock('./utils/chainflipService', () => ({
+  chainflipService: { get: vi.fn() },
+}))
+
+const makeInput = (): CheckTradeStatusInput =>
+  ({
+    config: { VITE_CHAINFLIP_API_URL: 'https://broker', VITE_CHAINFLIP_API_KEY: 'key' },
+    swap: { metadata: { swapperMetadata: { name: 'chainflip', swapId: 1234 } } },
+  }) as unknown as CheckTradeStatusInput
+
+const mockStatus = (status: Record<string, unknown>) =>
+  vi.mocked(chainflipService.get).mockResolvedValue(Ok({ data: { status } }) as never)
+
+describe('chainflip checkTradeStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports the deposit tx hash while the swap is still pending', async () => {
+    mockStatus({
+      state: 'swapping',
+      swapId: '1234',
+      deposit: { transactionReference: '0xdeposit' },
+    })
+
+    const result = await chainflipApi.checkTradeStatus(makeInput())
+
+    expect(result.sellTxHash).toBe('0xdeposit')
+    expect(result.buyTxHash).toBeUndefined()
+  })
+
+  it('reports the deposit tx hash alongside a completed egress', async () => {
+    mockStatus({
+      state: 'completed',
+      swapId: '1234',
+      deposit: { transactionReference: '0xdeposit' },
+      swapEgress: { transactionReference: '0xegress' },
+    })
+
+    const result = await chainflipApi.checkTradeStatus(makeInput())
+
+    expect(result.sellTxHash).toBe('0xdeposit')
+    expect(result.buyTxHash).toBe('0xegress')
+  })
+
+  it('has no deposit tx hash before the deposit is witnessed', async () => {
+    mockStatus({ state: 'waiting', swapId: '1234' })
+
+    expect((await chainflipApi.checkTradeStatus(makeInput())).sellTxHash).toBeUndefined()
+  })
+
+  it('treats a null transaction reference as no deposit yet', async () => {
+    mockStatus({ state: 'receiving', swapId: '1234', deposit: { transactionReference: null } })
+
+    expect((await chainflipApi.checkTradeStatus(makeInput())).sellTxHash).toBeUndefined()
+  })
+})

--- a/packages/swapper/src/swappers/ChainflipSwapper/checkTradeStatus.test.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/checkTradeStatus.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CheckTradeStatusInput } from '../../types'
 import { chainflipApi } from './endpoints'
+import type { ChainFlipStatus } from './types'
 import { chainflipService } from './utils/chainflipService'
 
 vi.mock('./utils/chainflipService', () => ({
@@ -15,7 +16,7 @@ const makeInput = (): CheckTradeStatusInput =>
     swap: { metadata: { swapperMetadata: { name: 'chainflip', swapId: 1234 } } },
   }) as unknown as CheckTradeStatusInput
 
-const mockStatus = (status: Record<string, unknown>) =>
+const mockStatus = (status: ChainFlipStatus['status']) =>
   vi.mocked(chainflipService.get).mockResolvedValue(Ok({ data: { status } }) as never)
 
 describe('chainflip checkTradeStatus', () => {

--- a/packages/swapper/src/swappers/ChainflipSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/endpoints.ts
@@ -67,6 +67,7 @@ export const chainflipApi: SwapperApi = {
     const { data: statusResponse } = maybeStatusResponse.unwrap()
 
     const buyTxHash = statusResponse.status.swapEgress?.transactionReference
+    const sellTxHash = statusResponse.status.deposit?.transactionReference ?? undefined
     const swapperTxId = statusResponse.status.swapId
     const swapperTxLink = swapperTxId ? `https://scan.chainflip.io/swaps/${swapperTxId}` : undefined
 
@@ -74,6 +75,7 @@ export const chainflipApi: SwapperApi = {
     if (!buyTxHash) {
       return {
         buyTxHash: undefined,
+        sellTxHash,
         status: TxStatus.Pending,
         swapperTxId,
         swapperTxLink,
@@ -85,6 +87,7 @@ export const chainflipApi: SwapperApi = {
     // Chainflip waits for 3 confirmations to assume complete (vs. 1 for us), which is turbo long.
     return {
       buyTxHash,
+      sellTxHash,
       status: TxStatus.Confirmed,
       swapperTxId,
       swapperTxLink,

--- a/packages/swapper/src/swappers/ChainflipSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/endpoints.ts
@@ -66,7 +66,7 @@ export const chainflipApi: SwapperApi = {
 
     const { data: statusResponse } = maybeStatusResponse.unwrap()
 
-    const buyTxHash = statusResponse.status.swapEgress?.transactionReference
+    const buyTxHash = statusResponse.status.swapEgress?.transactionReference ?? undefined
     const sellTxHash = statusResponse.status.deposit?.transactionReference ?? undefined
     const swapperTxId = statusResponse.status.swapId
     const swapperTxLink = swapperTxId ? `https://scan.chainflip.io/swaps/${swapperTxId}` : undefined
@@ -74,7 +74,7 @@ export const chainflipApi: SwapperApi = {
     // Assume no outbound Tx is a pending Tx
     if (!buyTxHash) {
       return {
-        buyTxHash: undefined,
+        buyTxHash,
         sellTxHash,
         status: TxStatus.Pending,
         swapperTxId,

--- a/packages/swapper/src/swappers/ChainflipSwapper/types.ts
+++ b/packages/swapper/src/swappers/ChainflipSwapper/types.ts
@@ -33,6 +33,7 @@ export type ChainFlipStatus = {
   status: {
     state: 'waiting' | 'receiving' | 'swapping' | 'sending' | 'sent' | 'completed' | 'failed'
     swapId?: string
+    deposit?: { transactionReference?: string | null }
     swap?: ChainflipBaasStatusSwap
     swapEgress?: ChainflipBaasStatusEgress
   }

--- a/packages/swapper/src/swappers/NearIntentsSwapper/NearIntentsSwapper.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/NearIntentsSwapper.ts
@@ -10,6 +10,7 @@ import {
 } from '../../utils'
 
 export const nearIntentsSwapper: Swapper = {
+  supportsExternalPayment: true,
   executeEvmTransaction,
   executeSolanaTransaction,
   executeStarknetTransaction,

--- a/packages/swapper/src/swappers/NearIntentsSwapper/checkTradeStatus.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/checkTradeStatus.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CheckTradeStatusInput } from '../../types'
+import { nearIntentsApi } from './endpoints'
+import { OneClickService } from './utils/oneClickService'
+
+vi.mock('./utils/oneClickService', () => ({
+  initializeOneClickService: vi.fn(),
+  OneClickService: { getExecutionStatus: vi.fn() },
+}))
+
+const makeInput = (): CheckTradeStatusInput =>
+  ({
+    config: { VITE_NEAR_INTENTS_API_KEY: 'key' },
+    swap: {
+      metadata: { swapperMetadata: { name: 'nearIntents', depositAddress: '0xdepositaddress' } },
+    },
+  }) as unknown as CheckTradeStatusInput
+
+const mockExecutionStatus = (response: Record<string, unknown>) =>
+  vi.mocked(OneClickService.getExecutionStatus).mockResolvedValue(response as never)
+
+describe('near intents checkTradeStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('reports the origin chain deposit tx hash', async () => {
+    mockExecutionStatus({
+      status: 'PROCESSING',
+      swapDetails: { originChainTxHashes: [{ hash: '0xdeposit' }], destinationChainTxHashes: [] },
+    })
+
+    const result = await nearIntentsApi.checkTradeStatus(makeInput())
+
+    expect(result.sellTxHash).toBe('0xdeposit')
+    expect(result.buyTxHash).toBeUndefined()
+  })
+
+  it('reports both sides once the swap settles', async () => {
+    mockExecutionStatus({
+      status: 'SUCCESS',
+      swapDetails: {
+        originChainTxHashes: [{ hash: '0xdeposit' }],
+        destinationChainTxHashes: [{ hash: '0xsettlement' }],
+      },
+    })
+
+    const result = await nearIntentsApi.checkTradeStatus(makeInput())
+
+    expect(result.sellTxHash).toBe('0xdeposit')
+    expect(result.buyTxHash).toBe('0xsettlement')
+  })
+
+  it('has no deposit tx hash before the deposit lands', async () => {
+    mockExecutionStatus({
+      status: 'PENDING_DEPOSIT',
+      swapDetails: { originChainTxHashes: [], destinationChainTxHashes: [] },
+    })
+
+    expect((await nearIntentsApi.checkTradeStatus(makeInput())).sellTxHash).toBeUndefined()
+  })
+})

--- a/packages/swapper/src/swappers/NearIntentsSwapper/checkTradeStatus.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/checkTradeStatus.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { CheckTradeStatusInput } from '../../types'
 import { nearIntentsApi } from './endpoints'
+import type { GetExecutionStatusResponse } from './types'
 import { OneClickService } from './utils/oneClickService'
 
 vi.mock('./utils/oneClickService', () => ({
@@ -17,7 +18,15 @@ const makeInput = (): CheckTradeStatusInput =>
     },
   }) as unknown as CheckTradeStatusInput
 
-const mockExecutionStatus = (response: Record<string, unknown>) =>
+type ExecutionStatus = {
+  status: `${GetExecutionStatusResponse['status']}`
+  swapDetails: Pick<
+    GetExecutionStatusResponse['swapDetails'],
+    'originChainTxHashes' | 'destinationChainTxHashes'
+  >
+}
+
+const mockExecutionStatus = (response: ExecutionStatus) =>
   vi.mocked(OneClickService.getExecutionStatus).mockResolvedValue(response as never)
 
 describe('near intents checkTradeStatus', () => {
@@ -28,7 +37,10 @@ describe('near intents checkTradeStatus', () => {
   it('reports the origin chain deposit tx hash', async () => {
     mockExecutionStatus({
       status: 'PROCESSING',
-      swapDetails: { originChainTxHashes: [{ hash: '0xdeposit' }], destinationChainTxHashes: [] },
+      swapDetails: {
+        originChainTxHashes: [{ hash: '0xdeposit', explorerUrl: '' }],
+        destinationChainTxHashes: [],
+      },
     })
 
     const result = await nearIntentsApi.checkTradeStatus(makeInput())
@@ -41,8 +53,8 @@ describe('near intents checkTradeStatus', () => {
     mockExecutionStatus({
       status: 'SUCCESS',
       swapDetails: {
-        originChainTxHashes: [{ hash: '0xdeposit' }],
-        destinationChainTxHashes: [{ hash: '0xsettlement' }],
+        originChainTxHashes: [{ hash: '0xdeposit', explorerUrl: '' }],
+        destinationChainTxHashes: [{ hash: '0xsettlement', explorerUrl: '' }],
       },
     })
 

--- a/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
@@ -2,5 +2,7 @@ export const ONE_CLICK_BASE_URL = 'https://1click.chaindefuser.com'
 
 export const DEFAULT_SLIPPAGE_BPS = 50
 
-export const DEFAULT_QUOTE_DEADLINE_MS = 30 * 60 * 1000
-export const BTC_QUOTE_DEADLINE_MS = 60 * 60 * 1000
+// The refund cutoff we request - 1Click prices a quote the same at any length
+export const DEFAULT_QUOTE_DEADLINE_MS = 60 * 60 * 1000
+// Credited on the second confirmation, and 40-minute block gaps happen
+export const UTXO_QUOTE_DEADLINE_MS = 4 * 60 * 60 * 1000

--- a/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/constants.ts
@@ -2,7 +2,6 @@ export const ONE_CLICK_BASE_URL = 'https://1click.chaindefuser.com'
 
 export const DEFAULT_SLIPPAGE_BPS = 50
 
-// The refund cutoff we request - 1Click prices a quote the same at any length
+// 1Click refunds a deposit it cannot settle by the requested deadline, and prices a quote the same at any length
 export const DEFAULT_QUOTE_DEADLINE_MS = 60 * 60 * 1000
-// Credited on the second confirmation, and 40-minute block gaps happen
 export const UTXO_QUOTE_DEADLINE_MS = 4 * 60 * 60 * 1000

--- a/packages/swapper/src/swappers/NearIntentsSwapper/endpoints.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/endpoints.ts
@@ -240,8 +240,8 @@ export const nearIntentsApi: SwapperApi = {
       const txStatus = mapNearIntentsStatus(statusResponse.status)
       const message = getNearIntentsStatusMessage(statusResponse.status)
 
-      // Extract buyTxHash from destination chain transactions
       const buyTxHash = statusResponse.swapDetails?.destinationChainTxHashes?.[0]?.hash
+      const sellTxHash = statusResponse.swapDetails?.originChainTxHashes?.[0]?.hash
 
       // amountOut is only meaningful destination-denominated on terminal success - in-flight and
       // refund states may carry settlement-internal or refund values
@@ -251,6 +251,7 @@ export const nearIntentsApi: SwapperApi = {
       return {
         status: txStatus,
         buyTxHash,
+        sellTxHash,
         swapperTxLink: `https://explorer.near-intents.org/transactions/${depositAddress}`,
         message,
         actualBuyAmountCryptoBaseUnit,

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { btcChainId, fromAssetId, solanaChainId } from '@shapeshiftoss/caip'
+import { CHAIN_NAMESPACE, fromAssetId, fromChainId, solanaChainId } from '@shapeshiftoss/caip'
 import type { Asset } from '@shapeshiftoss/types'
 import { TxStatus } from '@shapeshiftoss/unchained-client'
 import { bnOrZero, DAO_TREASURY_NEAR, isToken } from '@shapeshiftoss/utils'
@@ -10,9 +10,9 @@ import type { SwapErrorRight, TradeAmount } from '../../../types'
 import { TradeQuoteError } from '../../../types'
 import { createTradeAmountTooSmallErr, makeSwapErrorRight } from '../../../utils'
 import {
-  BTC_QUOTE_DEADLINE_MS,
   DEFAULT_QUOTE_DEADLINE_MS,
   DEFAULT_SLIPPAGE_BPS,
+  UTXO_QUOTE_DEADLINE_MS,
 } from '../constants'
 import type { GetExecutionStatusResponse, QuoteResponse, TokenResponse } from '../types'
 import { chainIdToNearIntentsChain, QuoteRequest } from '../types'
@@ -178,7 +178,10 @@ export const resolveNearIntentsAssets = async ({
   }
 }
 
-// BTC deposits confirm slowly, so BTC pairs get a longer deadline
+const isUtxoChainId = (chainId: string): boolean =>
+  fromChainId(chainId).chainNamespace === CHAIN_NAMESPACE.Utxo
+
+// Utxo legs confirm slowly, so those pairs get a longer deadline
 export const getNearIntentsQuoteDeadline = ({
   sellAsset,
   buyAsset,
@@ -187,8 +190,8 @@ export const getNearIntentsQuoteDeadline = ({
   buyAsset: Asset
 }): string => {
   const deadlineMs =
-    sellAsset.chainId === btcChainId || buyAsset.chainId === btcChainId
-      ? BTC_QUOTE_DEADLINE_MS
+    isUtxoChainId(sellAsset.chainId) || isUtxoChainId(buyAsset.chainId)
+      ? UTXO_QUOTE_DEADLINE_MS
       : DEFAULT_QUOTE_DEADLINE_MS
 
   return new Date(Date.now() + deadlineMs).toISOString()

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/helpers.ts
@@ -181,13 +181,12 @@ export const resolveNearIntentsAssets = async ({
 const isUtxoChainId = (chainId: string): boolean =>
   fromChainId(chainId).chainNamespace === CHAIN_NAMESPACE.Utxo
 
-// Utxo legs confirm slowly, so those pairs get a longer deadline
 export const getNearIntentsQuoteDeadline = ({
   sellAsset,
   buyAsset,
 }: {
-  sellAsset: Asset
-  buyAsset: Asset
+  sellAsset: Pick<Asset, 'chainId'>
+  buyAsset: Pick<Asset, 'chainId'>
 }): string => {
   const deadlineMs =
     isUtxoChainId(sellAsset.chainId) || isUtxoChainId(buyAsset.chainId)

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/quoteDeadline.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/quoteDeadline.test.ts
@@ -1,0 +1,37 @@
+import { btcChainId, dogeChainId, ethChainId, solanaChainId } from '@shapeshiftoss/caip'
+import type { Asset } from '@shapeshiftoss/types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DEFAULT_QUOTE_DEADLINE_MS, UTXO_QUOTE_DEADLINE_MS } from '../constants'
+import { getNearIntentsQuoteDeadline } from './helpers'
+
+const asset = (chainId: string): Asset => ({ chainId }) as Asset
+
+describe('getNearIntentsQuoteDeadline', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-09-10T22:00:00.000Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('gives a utxo sell leg the long deadline', () => {
+    expect(Date.parse(getNearIntentsQuoteDeadline({ sellAsset: asset(btcChainId), buyAsset: asset(ethChainId) }))).toBe(
+      Date.now() + UTXO_QUOTE_DEADLINE_MS,
+    )
+  })
+
+  it('gives a utxo buy leg the long deadline, on any utxo chain', () => {
+    expect(Date.parse(getNearIntentsQuoteDeadline({ sellAsset: asset(ethChainId), buyAsset: asset(dogeChainId) }))).toBe(
+      Date.now() + UTXO_QUOTE_DEADLINE_MS,
+    )
+  })
+
+  it('gives everything else the default deadline', () => {
+    expect(
+      Date.parse(getNearIntentsQuoteDeadline({ sellAsset: asset(ethChainId), buyAsset: asset(solanaChainId) })),
+    ).toBe(Date.now() + DEFAULT_QUOTE_DEADLINE_MS)
+  })
+})

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/quoteDeadline.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/quoteDeadline.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_QUOTE_DEADLINE_MS, UTXO_QUOTE_DEADLINE_MS } from '../constants'
 import { getNearIntentsQuoteDeadline } from './helpers'
 
-const asset = (chainId: string): Asset => ({ chainId }) as Asset
+const asset = (chainId: string): Pick<Asset, 'chainId'> => ({ chainId })
 
 describe('getNearIntentsQuoteDeadline', () => {
   beforeEach(() => {

--- a/packages/swapper/src/swappers/NearIntentsSwapper/utils/quoteDeadline.test.ts
+++ b/packages/swapper/src/swappers/NearIntentsSwapper/utils/quoteDeadline.test.ts
@@ -18,20 +18,29 @@ describe('getNearIntentsQuoteDeadline', () => {
   })
 
   it('gives a utxo sell leg the long deadline', () => {
-    expect(Date.parse(getNearIntentsQuoteDeadline({ sellAsset: asset(btcChainId), buyAsset: asset(ethChainId) }))).toBe(
-      Date.now() + UTXO_QUOTE_DEADLINE_MS,
-    )
+    expect(
+      Date.parse(
+        getNearIntentsQuoteDeadline({ sellAsset: asset(btcChainId), buyAsset: asset(ethChainId) }),
+      ),
+    ).toBe(Date.now() + UTXO_QUOTE_DEADLINE_MS)
   })
 
   it('gives a utxo buy leg the long deadline, on any utxo chain', () => {
-    expect(Date.parse(getNearIntentsQuoteDeadline({ sellAsset: asset(ethChainId), buyAsset: asset(dogeChainId) }))).toBe(
-      Date.now() + UTXO_QUOTE_DEADLINE_MS,
-    )
+    expect(
+      Date.parse(
+        getNearIntentsQuoteDeadline({ sellAsset: asset(ethChainId), buyAsset: asset(dogeChainId) }),
+      ),
+    ).toBe(Date.now() + UTXO_QUOTE_DEADLINE_MS)
   })
 
   it('gives everything else the default deadline', () => {
     expect(
-      Date.parse(getNearIntentsQuoteDeadline({ sellAsset: asset(ethChainId), buyAsset: asset(solanaChainId) })),
+      Date.parse(
+        getNearIntentsQuoteDeadline({
+          sellAsset: asset(ethChainId),
+          buyAsset: asset(solanaChainId),
+        }),
+      ),
     ).toBe(Date.now() + DEFAULT_QUOTE_DEADLINE_MS)
   })
 })

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -765,6 +765,8 @@ export type CheckTradeStatusInput = {
 export type TradeStatus = {
   status: TxStatus
   buyTxHash: string | undefined
+  // Set by externally paid swappers, whose client may never see the deposit it reports
+  sellTxHash?: string | undefined
   // The swapper/protocol's own identifier for the swap (relayer tx hash, native swap id, order uid)
   swapperTxId?: string | undefined
   // Fully-formed link to the swapper/protocol's own tracker page for the swap
@@ -782,6 +784,8 @@ export type TradeRateResult = Result<TradeRate[], SwapErrorRight>
 export type EvmMessageToSign = CowMessageToSign
 
 export type Swapper = {
+  supportsExternalPayment?: boolean
+
   executeEvmTransaction?: (
     txToSign: SignTx<EvmChainId>,
     callbacks: EvmTransactionExecutionProps,

--- a/packages/swapper/src/types.ts
+++ b/packages/swapper/src/types.ts
@@ -765,7 +765,7 @@ export type CheckTradeStatusInput = {
 export type TradeStatus = {
   status: TxStatus
   buyTxHash: string | undefined
-  // Set by externally paid swappers, whose client may never see the deposit it reports
+  // The funding tx as the provider reports it - an externally paid swap's client may never have seen it
   sellTxHash?: string | undefined
   // The swapper/protocol's own identifier for the swap (relayer tx hash, native swap id, order uid)
   swapperTxId?: string | undefined

--- a/packages/swapper/src/utils/helpers.test.ts
+++ b/packages/swapper/src/utils/helpers.test.ts
@@ -4,7 +4,10 @@ import { KnownChainIds } from '@shapeshiftoss/types'
 import { treasuryChainIds } from '@shapeshiftoss/utils'
 import { describe, expect, it } from 'vitest'
 
-import { getTreasuryAddressFromChainId, normalizeEpochToMs } from './helpers'
+import { swappers } from '../constants'
+import type { TradeQuoteStep } from '../types'
+import { SwapperName } from '../types'
+import { getDepositAddress, getTreasuryAddressFromChainId, normalizeEpochToMs } from './helpers'
 
 describe('getTreasuryAddressFromChainId', () => {
   // Affiliate and fee recipient addresses for every swapper flow through here, so pin the values
@@ -59,5 +62,53 @@ describe('normalizeEpochToMs', () => {
 
   it('converts nanoseconds to ms', () => {
     expect(normalizeEpochToMs(epochMs * 1e6)).toBe(epochMs)
+  })
+})
+
+const makeStep = (overrides: Partial<TradeQuoteStep>): TradeQuoteStep => overrides as TradeQuoteStep
+
+describe('getDepositAddress', () => {
+  it('reads the chainflip deposit address', () => {
+    const step = makeStep({ chainflipSpecific: { depositAddress: 'bc1qdeposit' } })
+    expect(getDepositAddress(step, SwapperName.Chainflip)).toBe('bc1qdeposit')
+  })
+
+  it('returns undefined when chainflip has no deposit address', () => {
+    expect(getDepositAddress(makeStep({}), SwapperName.Chainflip)).toBeUndefined()
+  })
+
+  it('reads the near intents deposit address', () => {
+    const step = makeStep({
+      swapperMetadata: { name: 'nearIntents', depositAddress: '0xdeposit' },
+    })
+    expect(getDepositAddress(step, SwapperName.NearIntents)).toBe('0xdeposit')
+  })
+
+  it('rejects a memo-bound near intents deposit address', () => {
+    const step = makeStep({
+      swapperMetadata: { name: 'nearIntents', depositAddress: 'EQdeposit', depositMemo: '12345' },
+    })
+    expect(getDepositAddress(step, SwapperName.NearIntents)).toBeUndefined()
+  })
+
+  it('rejects an empty near intents deposit address', () => {
+    const step = makeStep({ swapperMetadata: { name: 'nearIntents', depositAddress: '' } })
+    expect(getDepositAddress(step, SwapperName.NearIntents)).toBeUndefined()
+  })
+
+  it('returns undefined for swappers that do not use deposit addresses', () => {
+    const step = makeStep({ chainflipSpecific: { depositAddress: 'bc1qdeposit' } })
+    expect(getDepositAddress(step, SwapperName.Relay)).toBeUndefined()
+  })
+})
+
+describe('supportsExternalPayment', () => {
+  it('is flagged on exactly the externally paid swappers', () => {
+    const flagged = Object.entries(swappers)
+      .filter(([, swapper]) => swapper?.supportsExternalPayment)
+      .map(([name]) => name)
+      .sort()
+
+    expect(flagged).toEqual([SwapperName.Chainflip, SwapperName.NearIntents].sort())
   })
 })

--- a/packages/swapper/src/utils/helpers.test.ts
+++ b/packages/swapper/src/utils/helpers.test.ts
@@ -5,8 +5,8 @@ import { treasuryChainIds } from '@shapeshiftoss/utils'
 import { describe, expect, it } from 'vitest'
 
 import { swappers } from '../constants'
-import type { TradeQuoteStep } from '../types'
 import { SwapperName } from '../types'
+import type { DepositAddressStep } from './helpers'
 import { getDepositAddress, getTreasuryAddressFromChainId, normalizeEpochToMs } from './helpers'
 
 describe('getTreasuryAddressFromChainId', () => {
@@ -65,7 +65,7 @@ describe('normalizeEpochToMs', () => {
   })
 })
 
-const makeStep = (overrides: Partial<TradeQuoteStep>): TradeQuoteStep => overrides as TradeQuoteStep
+const makeStep = (step: DepositAddressStep): DepositAddressStep => step
 
 describe('getDepositAddress', () => {
   it('reads the chainflip deposit address', () => {

--- a/packages/swapper/src/utils/helpers.ts
+++ b/packages/swapper/src/utils/helpers.ts
@@ -34,7 +34,8 @@ import {
   isTreasuryChainId,
 } from '@shapeshiftoss/utils'
 
-import type { TradeAmount } from '../types'
+import type { TradeAmount, TradeQuoteStep, TradeRateStep } from '../types'
+import { SwapperName } from '../types'
 
 // Deadline for providers without their own expiry - short enough to keep priced amounts honest
 export const FALLBACK_QUOTE_DEADLINE_MS = 60_000
@@ -112,4 +113,24 @@ export const getTreasuryAddressFromChainId = (chainId: ChainId): string => {
   if (!treasuryAddress)
     throw new Error(`[getTreasuryAddressFromChainId] - Unsupported chainId: ${chainId}`)
   return treasuryAddress
+}
+
+export const getDepositAddress = (
+  step: TradeQuoteStep | TradeRateStep,
+  swapperName: SwapperName,
+): string | undefined => {
+  switch (swapperName) {
+    case SwapperName.Chainflip:
+      return step.chainflipSpecific?.depositAddress || undefined
+    case SwapperName.NearIntents: {
+      if (step.swapperMetadata?.name !== 'nearIntents') return
+
+      const { depositAddress, depositMemo } = step.swapperMetadata
+      if (depositMemo) return
+
+      return depositAddress || undefined
+    }
+    default:
+      return
+  }
 }

--- a/packages/swapper/src/utils/helpers.ts
+++ b/packages/swapper/src/utils/helpers.ts
@@ -34,7 +34,7 @@ import {
   isTreasuryChainId,
 } from '@shapeshiftoss/utils'
 
-import type { TradeAmount, TradeQuoteStep, TradeRateStep } from '../types'
+import type { TradeAmount, TradeStepCommon } from '../types'
 import { SwapperName } from '../types'
 
 // Deadline for providers without their own expiry - short enough to keep priced amounts honest
@@ -115,8 +115,10 @@ export const getTreasuryAddressFromChainId = (chainId: ChainId): string => {
   return treasuryAddress
 }
 
+export type DepositAddressStep = Pick<TradeStepCommon, 'chainflipSpecific' | 'swapperMetadata'>
+
 export const getDepositAddress = (
-  step: TradeQuoteStep | TradeRateStep,
+  step: DepositAddressStep,
   swapperName: SwapperName,
 ): string | undefined => {
   switch (swapperName) {


### PR DESCRIPTION
## Description

The `packages/swapper` half of #12594, broken out so it can release ahead of the widget, API and swap-service work that depends on it.

Chainflip and NEAR Intents both settle a plain transfer to a provider-issued deposit address, so the paying transaction can be built and signed outside our app. This PR:

- Adds `Swapper.supportsExternalPayment`, set on Chainflip and NEAR Intents.
- Adds `getDepositAddress(step, swapperName)`, returning the address a quote can be paid to. Memo-bound routes (TON via NEAR Intents) return `undefined`, since a memo-less send there is unrecoverable.
- Adds `TradeStatus.sellTxHash`, filled by both swappers' `checkTradeStatus` from the provider's own report of the deposit (Chainflip `deposit.transactionReference`, NEAR `originChainTxHashes[0]`), so a client that never saw the transaction can still track it.
- Lengthens NEAR Intents' requested quote deadline to one hour, or four when either leg is a UTXO chain. 1Click prices a quote identically at any deadline length (dry-quoted from 30 minutes to 12 hours) and credits a UTXO deposit only on its second confirmation; the previous one-hour BTC window lost to ordinary block variance in testing.
- Bumps the package to 20.1.0. Every addition is optional or new.

Consumers: swap-service reads `sellTxHash` to track deposit-address swaps registered before any hash exists (microservices `feat/external-payment-deposit-detection`), and the widget and API in #12594 read the flag and the address.

## Issue (if applicable)

closes #

## Risk

> High Risk PRs Require 2 approvals

Low. No transaction is built or modified. New fields are optional and unread by the web app today. The one behaviour change is the NEAR Intents request deadline, which only affects how long a NEAR quote stays executable before 1Click refunds a late deposit; longer is strictly safer for the user and the quoted price is unchanged.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

NEAR Intents quotes (deadline), Chainflip and NEAR Intents status polling (an extra field).

## Testing

### Engineering

- `pnpm vitest run packages/swapper/src/swappers/ChainflipSwapper packages/swapper/src/swappers/NearIntentsSwapper packages/swapper/src/utils` — 143 passed.
- `getDepositAddress`: Chainflip, NEAR with and without a memo, and non-deposit swappers are covered in `utils/helpers.test.ts`.
- `checkTradeStatus` sell hash extraction for both swappers has its own test file per swapper.
- Live: ETH → ZEC, BTC → ETH and ZEC → ETH swaps through NEAR Intents on the #12594 branch, which carries this exact diff, with the sell hash reported for the EVM and BTC deposits. A shielded Zcash deposit is reported with no origin hash by NEAR, which swap-service handles separately.

### Operations

- [x] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

Nothing user-facing in the web app changes until #12594 lands.

## Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqEXAyUKM3NMSscNtGbkCj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for externally paid swaps through Chainflip and Near Intents.
  - Deposit addresses are now available for supported swap providers.
  - Swap status can display originating and destination transaction hashes.

- **Improvements**
  - Extended quote validity to 60 minutes generally and up to 4 hours for UTXO-based assets.
  - Improved transaction-status reporting across pending, processing, and completed swaps.
  - Improved handling of deposit and settlement transaction references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->