### PR TITLE
feat(swap-widget): validate addresses on every selectable chain

### DIFF
--- a/packages/swap-widget/src/utils/__tests__/addressValidation.test.ts
+++ b/packages/swap-widget/src/utils/__tests__/addressValidation.test.ts
@@ -10,6 +10,9 @@ import {
   isValidBitcoinCashAddress,
   isValidDogecoinAddress,
   isValidLitecoinAddress,
+  isValidStarknetAddress,
+  isValidTonAddress,
+  isValidZcashAddress,
   validateAddress,
 } from '../addressValidation'
 
@@ -363,5 +366,200 @@ describe('getAddressFormatHint', () => {
   })
   it('returns Solana hint for Solana', () => {
     expect(getAddressFormatHint(solChainId)).toBe('Enter Solana address')
+  })
+})
+
+const multiByteBase58CheckAddr = (versionBytes: number[], hash: Uint8Array = HASH160): string => {
+  const payload = new Uint8Array(versionBytes.length + hash.length)
+  payload.set(versionBytes, 0)
+  payload.set(hash, versionBytes.length)
+  return bs58check.encode(payload)
+}
+
+const tronChainId = toChainId({
+  chainNamespace: CHAIN_NAMESPACE.Tron,
+  chainReference: CHAIN_REFERENCE.TronMainnet,
+})
+const suiChainId = toChainId({
+  chainNamespace: CHAIN_NAMESPACE.Sui,
+  chainReference: CHAIN_REFERENCE.SuiMainnet,
+})
+const nearChainId = toChainId({
+  chainNamespace: CHAIN_NAMESPACE.Near,
+  chainReference: CHAIN_REFERENCE.NearMainnet,
+})
+const starknetChainId = toChainId({
+  chainNamespace: CHAIN_NAMESPACE.Starknet,
+  chainReference: CHAIN_REFERENCE.StarknetMainnet,
+})
+const zcashChainId = toChainId({
+  chainNamespace: CHAIN_NAMESPACE.Utxo,
+  chainReference: CHAIN_REFERENCE.ZcashMainnet,
+})
+
+describe('validateAddress - deposit flow chains', () => {
+  it('accepts a tron address', () => {
+    expect(validateAddress(multiByteBase58CheckAddr([0x41]), tronChainId).valid).toBe(true)
+  })
+
+  it('rejects a tron address with a bad checksum', () => {
+    const address = multiByteBase58CheckAddr([0x41])
+    const corrupted = `${address.slice(0, -1)}${address.endsWith('a') ? 'b' : 'a'}`
+    expect(validateAddress(corrupted, tronChainId).valid).toBe(false)
+  })
+
+  it('rejects a bitcoin address on tron', () => {
+    expect(validateAddress(base58CheckAddr(0x00), tronChainId).valid).toBe(false)
+  })
+
+  it('rejects an evm address on tron', () => {
+    expect(validateAddress('0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045', tronChainId).valid).toBe(
+      false,
+    )
+  })
+
+  it('accepts a sui address', () => {
+    expect(validateAddress(`0x${'a'.repeat(64)}`, suiChainId).valid).toBe(true)
+  })
+
+  it('rejects a short sui address', () => {
+    expect(validateAddress(`0x${'a'.repeat(40)}`, suiChainId).valid).toBe(false)
+  })
+
+  it('accepts a named near account', () => {
+    expect(validateAddress('shapeshift.near', nearChainId).valid).toBe(true)
+  })
+
+  it('accepts an implicit near account', () => {
+    expect(validateAddress('f'.repeat(64), nearChainId).valid).toBe(true)
+  })
+
+  it('rejects a near account with invalid characters', () => {
+    expect(validateAddress('Shape Shift.near', nearChainId).valid).toBe(false)
+  })
+
+  it('accepts a starknet address', () => {
+    expect(validateAddress(`0x${'1'.repeat(63)}`, starknetChainId).valid).toBe(true)
+  })
+
+  it('rejects an over-long starknet address', () => {
+    expect(validateAddress(`0x${'1'.repeat(65)}`, starknetChainId).valid).toBe(false)
+  })
+
+  it('accepts transparent zcash addresses', () => {
+    expect(validateAddress(multiByteBase58CheckAddr([0x1c, 0xb8]), zcashChainId).valid).toBe(true)
+    expect(validateAddress(multiByteBase58CheckAddr([0x1c, 0xbd]), zcashChainId).valid).toBe(true)
+  })
+
+  it('rejects a bitcoin address on zcash', () => {
+    expect(validateAddress(base58CheckAddr(0x00), zcashChainId).valid).toBe(false)
+  })
+})
+
+describe('getAddressFormatHint - deposit flow chains', () => {
+  it('hints the tron format', () => {
+    expect(getAddressFormatHint(tronChainId)).toBe('T...')
+  })
+
+  it('hints the near format', () => {
+    expect(getAddressFormatHint(nearChainId)).toBe('name.near or 64 hex chars')
+  })
+
+  it('hints hex formats for sui and starknet', () => {
+    expect(getAddressFormatHint(suiChainId)).toBe('0x...')
+    expect(getAddressFormatHint(starknetChainId)).toBe('0x...')
+  })
+
+  it('hints the zcash format', () => {
+    expect(getAddressFormatHint(zcashChainId)).toBe('t1... or t3...')
+  })
+})
+
+describe('base58check payload length', () => {
+  // A correct version byte is not enough - the payload has to be a hash160
+  const withPayload = (version: number[], byteCount: number) =>
+    bs58check.encode(new Uint8Array([...version, ...Array(byteCount).fill(1)]))
+
+  it('rejects a bitcoin address whose payload is not 20 bytes', () => {
+    expect(isValidBitcoinAddress(withPayload([0x00], 15))).toBe(false)
+    expect(isValidBitcoinAddress(withPayload([0x00], 40))).toBe(false)
+  })
+
+  it('rejects a zcash address whose payload is not 20 bytes', () => {
+    expect(isValidZcashAddress(withPayload([0x1c, 0xb8], 5))).toBe(false)
+  })
+})
+
+describe('witness program length', () => {
+  it('accepts the v0 programs BIP141 defines', () => {
+    expect(isValidBitcoinAddress(bech32Addr('bc', 0, HASH160))).toBe(true)
+    expect(isValidBitcoinAddress(bech32Addr('bc', 0, HASH256))).toBe(true)
+  })
+
+  it('rejects a v0 program that is neither a key nor a script hash', () => {
+    expect(isValidBitcoinAddress(bech32Addr('bc', 0, new Uint8Array(21).fill(0x11)))).toBe(false)
+  })
+
+  it('rejects a program outside the 2-40 byte range', () => {
+    expect(isValidBitcoinAddress(bech32Addr('bc', 1, new Uint8Array(1), bech32m))).toBe(false)
+  })
+
+  it('still accepts taproot', () => {
+    expect(isValidBitcoinAddress(bech32Addr('bc', 1, HASH256, bech32m))).toBe(true)
+  })
+})
+
+describe('isValidStarknetAddress', () => {
+  // The contract address bound, which is lower than the stark field prime
+  const BOUND = 2n ** 251n - 256n
+
+  it('accepts a value below the contract address bound', () => {
+    expect(isValidStarknetAddress('0x04a1b2c3')).toBe(true)
+    expect(isValidStarknetAddress(`0x${(BOUND - 1n).toString(16)}`)).toBe(true)
+  })
+
+  it('rejects the zero address', () => {
+    expect(isValidStarknetAddress('0x0')).toBe(false)
+  })
+
+  it('rejects a value at or above the contract address bound', () => {
+    expect(isValidStarknetAddress(`0x${BOUND.toString(16)}`)).toBe(false)
+    expect(isValidStarknetAddress(`0x${'f'.repeat(64)}`)).toBe(false)
+  })
+
+  // Between the contract address bound and the prime, which the looser check would have accepted
+  it('rejects a felt the stark prime alone would allow', () => {
+    expect(isValidStarknetAddress(`0x${(2n ** 251n).toString(16)}`)).toBe(false)
+  })
+})
+
+describe('isValidTonAddress', () => {
+  const BOUNCEABLE = 'EQBCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQmXi'
+  const NON_BOUNCEABLE = 'UQBCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQjgn'
+  const TESTNET = 'kQBCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQt5o'
+  const BAD_CRC = 'EQBCQkJCQkACQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQmXi'
+
+  it('accepts bounceable and non-bounceable mainnet addresses', () => {
+    expect(isValidTonAddress(BOUNCEABLE)).toBe(true)
+    expect(isValidTonAddress(NON_BOUNCEABLE)).toBe(true)
+  })
+
+  it('accepts the raw workchain form', () => {
+    expect(isValidTonAddress(`0:${'42'.repeat(32)}`)).toBe(true)
+    expect(isValidTonAddress(`-1:${'42'.repeat(32)}`)).toBe(true)
+  })
+
+  it('rejects a testnet address', () => {
+    expect(isValidTonAddress(TESTNET)).toBe(false)
+  })
+
+  it('rejects a corrupted address the checksum catches', () => {
+    expect(isValidTonAddress(BAD_CRC)).toBe(false)
+  })
+
+  it('rejects addresses of the wrong shape', () => {
+    expect(isValidTonAddress('')).toBe(false)
+    expect(isValidTonAddress('EQBCQkJC')).toBe(false)
+    expect(isValidTonAddress('0x1234')).toBe(false)
   })
 })

--- a/packages/swap-widget/src/utils/__tests__/validatorCoverage.test.ts
+++ b/packages/swap-widget/src/utils/__tests__/validatorCoverage.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  COSMOS_CHAIN_IDS,
+  EVM_CHAIN_IDS,
+  OTHER_CHAIN_IDS,
+  REDIRECT_ONLY_CHAIN_IDS,
+  UTXO_CHAIN_IDS,
+} from '../../types'
+import { getAddressFormatHint, validateAddress } from '../addressValidation'
+
+// Every selectable chain must be able to say what a valid address looks like
+describe('validator coverage', () => {
+  const allChainIds = [
+    ...Object.values(EVM_CHAIN_IDS),
+    ...Object.values(UTXO_CHAIN_IDS),
+    ...Object.values(COSMOS_CHAIN_IDS),
+    ...Object.values(OTHER_CHAIN_IDS),
+    ...Object.values(REDIRECT_ONLY_CHAIN_IDS),
+  ]
+
+  it.each(allChainIds)('%s has a validator', chainId => {
+    const { error } = validateAddress('definitely-not-an-address', chainId)
+    expect(error).not.toBe('Unsupported chain type')
+    expect(error).not.toBe('Unsupported UTXO chain')
+    expect(error).not.toBe('Unsupported CosmosSdk chain')
+  })
+
+  it.each(allChainIds)('%s has a format hint', chainId => {
+    expect(getAddressFormatHint(chainId)).not.toBe('Enter address')
+  })
+})

--- a/packages/swap-widget/src/utils/addressValidation.ts
+++ b/packages/swap-widget/src/utils/addressValidation.ts
@@ -20,10 +20,12 @@ const VERSION_BYTES = {
   dogecoinP2SH: 0x16,
 } as const
 
+const HASH160_LENGTH = 20
+
 const isValidBase58Check = (address: string, allowedVersionBytes: number[]): boolean => {
   try {
     const decoded = bs58check.decode(address)
-    return allowedVersionBytes.includes(decoded[0])
+    return decoded.length === 1 + HASH160_LENGTH && allowedVersionBytes.includes(decoded[0])
   } catch {
     return false
   }
@@ -58,6 +60,12 @@ const isValidSegwit = (address: string, expectedHrp: string): boolean => {
       const witnessVersion = words[0]
       if (witnessVersion === 0 && codec !== bech32) continue
       if (witnessVersion >= 1 && codec !== bech32m) continue
+
+      // BIP141: any witness program is 2-40 bytes, and v0 is a 20-byte key or a 32-byte script
+      const program = codec.fromWords(words.slice(1))
+      if (program.length < 2 || program.length > 40) continue
+      if (witnessVersion === 0 && program.length !== 20 && program.length !== 32) continue
+
       return true
     } catch {
       // try next codec
@@ -84,6 +92,88 @@ export const isValidLitecoinAddress = (address: string): boolean =>
 export const isValidDogecoinAddress = (address: string): boolean =>
   isValidBase58Check(address, [VERSION_BYTES.dogecoinP2PKH, VERSION_BYTES.dogecoinP2SH])
 
+// Zcash transparent addresses use a two-byte version prefix, unlike the single-byte utxo chains
+const ZCASH_VERSION_BYTES = {
+  transparentP2PKH: [0x1c, 0xb8],
+  transparentP2SH: [0x1c, 0xbd],
+} as const
+
+export const isValidZcashAddress = (address: string): boolean => {
+  try {
+    const decoded = bs58check.decode(address)
+    if (decoded.length !== 2 + HASH160_LENGTH) return false
+
+    return Object.values(ZCASH_VERSION_BYTES).some(
+      ([first, second]) => decoded[0] === first && decoded[1] === second,
+    )
+  } catch {
+    return false
+  }
+}
+
+export const isValidTronAddress = (address: string): boolean => {
+  if (!address.startsWith('T')) return false
+  try {
+    const decoded = bs58check.decode(address)
+    return decoded.length === 1 + HASH160_LENGTH && decoded[0] === 0x41
+  } catch {
+    return false
+  }
+}
+
+// TON user-friendly addresses are 36 base64url bytes: tag, workchain, 32-byte hash, then a crc16
+const crc16Xmodem = (data: Uint8Array): number => {
+  let crc = 0
+  for (const byte of data) {
+    crc ^= byte << 8
+    for (let bit = 0; bit < 8; bit++) {
+      crc = crc & 0x8000 ? ((crc << 1) ^ 0x1021) & 0xffff : (crc << 1) & 0xffff
+    }
+  }
+  return crc
+}
+
+const TON_TAG_BOUNCEABLE = 0x11
+const TON_TAG_NON_BOUNCEABLE = 0x51
+
+export const isValidTonAddress = (address: string): boolean => {
+  // Raw form, workchain 0 (basechain) or -1 (masterchain)
+  if (/^(0|-1):[0-9a-fA-F]{64}$/.test(address)) return true
+
+  if (!/^[A-Za-z0-9_-]{48}$/.test(address)) return false
+
+  try {
+    const base64 = address.replace(/-/g, '+').replace(/_/g, '/')
+    const bytes = Uint8Array.from(atob(base64), character => character.charCodeAt(0))
+    if (bytes.length !== 36) return false
+
+    // The testnet bit is deliberately not masked off - a testnet address is not a valid destination
+    if (bytes[0] !== TON_TAG_BOUNCEABLE && bytes[0] !== TON_TAG_NON_BOUNCEABLE) return false
+
+    return crc16Xmodem(bytes.subarray(0, 34)) === ((bytes[34] << 8) | bytes[35])
+  } catch {
+    return false
+  }
+}
+
+export const isValidSuiAddress = (address: string): boolean => /^0x[0-9a-fA-F]{64}$/.test(address)
+
+// Contract addresses are bounded well below the felt maximum
+const STARKNET_ADDRESS_BOUND = 2n ** 251n - 256n
+
+export const isValidStarknetAddress = (address: string): boolean => {
+  if (!/^0x[0-9a-fA-F]{1,64}$/.test(address)) return false
+
+  const value = BigInt(address)
+  return value > 0n && value < STARKNET_ADDRESS_BOUND
+}
+
+// Either an implicit account (a 64-char hex public key) or a named one
+export const isValidNearAddress = (address: string): boolean => {
+  if (/^[0-9a-f]{64}$/.test(address)) return true
+  return /^(?=.{2,64}$)[a-z0-9]+([-_.][a-z0-9]+)*$/.test(address)
+}
+
 const UTXO_VALIDATORS: Record<
   string,
   { check: (a: string) => boolean; label: string; hint: string }
@@ -107,6 +197,11 @@ const UTXO_VALIDATORS: Record<
     check: isValidDogecoinAddress,
     label: 'Dogecoin',
     hint: 'D...',
+  },
+  [CHAIN_REFERENCE.ZcashMainnet]: {
+    check: isValidZcashAddress,
+    label: 'Zcash',
+    hint: 't1... or t3...',
   },
 }
 
@@ -148,6 +243,16 @@ export const validateAddress = (
         return invalid('Solana')
       }
     }
+    case CHAIN_NAMESPACE.Tron:
+      return isValidTronAddress(address) ? { valid: true } : invalid('Tron')
+    case CHAIN_NAMESPACE.Sui:
+      return isValidSuiAddress(address) ? { valid: true } : invalid('Sui')
+    case CHAIN_NAMESPACE.Ton:
+      return isValidTonAddress(address) ? { valid: true } : invalid('TON')
+    case CHAIN_NAMESPACE.Near:
+      return isValidNearAddress(address) ? { valid: true } : invalid('NEAR')
+    case CHAIN_NAMESPACE.Starknet:
+      return isValidStarknetAddress(address) ? { valid: true } : invalid('Starknet')
     default:
       return { valid: false, error: 'Unsupported chain type' }
   }
@@ -167,6 +272,15 @@ export const getAddressFormatHint = (chainId: ChainId): string => {
     }
     case CHAIN_NAMESPACE.Solana:
       return 'Enter Solana address'
+    case CHAIN_NAMESPACE.Tron:
+      return 'T...'
+    case CHAIN_NAMESPACE.Ton:
+      return 'UQ... or EQ...'
+    case CHAIN_NAMESPACE.Sui:
+    case CHAIN_NAMESPACE.Starknet:
+      return '0x...'
+    case CHAIN_NAMESPACE.Near:
+      return 'name.near or 64 hex chars'
     default:
       return 'Enter address'
   }


### PR DESCRIPTION
## Description

Broken out of #12594. The widget could only validate EVM, Bitcoin-family, Cosmos and Solana addresses, so any other chain in the selector had no way to tell the user what a valid destination looks like.

- New validators: Zcash transparent (`t1`/`t3`, two-byte version), Tron (base58check, `0x41`), TON (raw form, and user-friendly form with crc16 checked and the testnet bit deliberately not masked), Sui, Starknet (bounded below the felt maximum) and NEAR (implicit or named accounts).
- Tightened existing ones: base58check payloads must be exactly version byte plus hash160, and segwit witness programs must be 2–40 bytes, with v0 at exactly 20 or 32.
- Format hints for each new chain.
- `validatorCoverage.test.ts` walks every chain in the selector's lists and fails if one lacks a validator or a hint.

## Issue (if applicable)

closes #

## Risk

> High Risk PRs Require 2 approvals

Low. Pure functions with tests; the only consumer today is the receive address row, which becomes usable for the new chains as a destination. A wrong validator would reject a valid address at input time, not send funds anywhere.

> What protocols, transaction types, wallets or contract interactions might be affected by this PR?

Receive address entry in the widget for the listed chains.

## Testing

### Engineering

- `pnpm vitest run packages/swap-widget/src/utils/__tests__/addressValidation.test.ts packages/swap-widget/src/utils/__tests__/validatorCoverage.test.ts`

### Operations

- [ ] :checkered_flag: My feature is behind a flag and doesn't require operations testing (yet)

In the widget demo, pick ZEC as the buy asset and enter a `t1…` address (accepted) and a `u1…` unified address (rejected with a Zcash-specific message).

## Screenshots (if applicable)

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LqEXAyUKM3NMSscNtGbkCj


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded wallet address validation to support Zcash, Tron, TON, Sui, NEAR, and Starknet.
  * Added format guidance for the newly supported address types.
  * Improved validation for Base58Check addresses, including multi-byte prefixes and payload lengths.
  * Added TON format, checksum, and network validation.

* **Tests**
  * Expanded coverage across supported chains, address formats, and validation constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->